### PR TITLE
docs: sync Phel main guidance

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,7 +8,7 @@ src/
 ├── commands/play.phel               ; outer orchestration (game-loop, run-levels)
 └── modules/
     ├── core/                        ; pure, deterministic, no IO
-    │   ├── state.phel               ; world + player records, gain-life, max-lives
+    │   ├── state.phel               ; world + player maps, gain-life, max-lives
     │   ├── map.phel                 ; grid generators, cell constants, wall? / door?
     │   ├── engine.phel              ; raycaster (cast-ray, cast-frame)
     │   ├── physics.phel             ; player rotation + translation + counter decay

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -191,33 +191,32 @@ Two caveats:
 Outside `render.phel` (and the math-only `php/sqrt`, `php/atan2`,
 `php/intval`, etc. used everywhere for raw arithmetic), prefer
 Phel-native data: maps, vectors, keywords. Game world, player,
-enemy records, level configs, scores, and the `:moves` counter
+enemy maps, level configs, scores, and the `:moves` counter
 table are all Phel-native.
 
 `tests/modules/core/engine-test.phel` exercises the cast-frame loop
 with literal grids if you want to benchmark.
 
-### Use `php/+` (not `+`) inside hot loops
+### Choose raw `php/*` ops deliberately in hot loops
 
 Phel's `phel.core/+`, `-`, `*`, `<`, `>=`, `=`, ... wrap the PHP
 operators with a `NumericOperations` dispatch for `BigInt` / `Ratio`
 polymorphism. Each call: two `numeric-object?` checks, a branch, a
-method invocation. Per-cell or per-ray that adds up.
+method invocation. Per-cell or per-ray that adds up when the
+compiler cannot prove the call is primitive.
 
-The compiler's `ParamTypeInferrer` only observes `php/*` operators
-today, so `(php/+ a 1)` infers `^int a` and the analyser tags the
-PHP signature; `(+ a 1)` doesn't. Until phel-lang/phel-lang#2078 +
-#2079 land (auto-inference from phel.core wrappers + native emit
-on typed args), the rule is:
+Latest Phel `main` can now auto-tag float params used with
+`phel.core` arithmetic / ordering wrappers and native-emit two-arg
+`+`, `-`, `*`, `<`, `<=`, `>`, `>=`, and `=` when both operands are
+statically primitive. Int-literal uses can stay ambiguous to preserve
+`BigInt` / `Ratio` semantics, and unspecialised calls still take the
+runtime path. This project keeps raw `php/*` ops where the hot loop
+needs that fast path explicitly:
 
 - **Hot loops (cast-ray, compute-wall-shades, per-cell paint)**:
   `php/+`, `php/<`, `php/===`, etc. Direct ops, no dispatch.
 - **Everything else** (frame-stats, setup, glue): `+`, `<`, `=`.
   Reads idiomatically; the dispatch overhead is invisible.
-
-When the two phel-lang PRs land, this rule flips: idiomatic ops
-will inline to native PHP on tagged params. Until then, this is
-the perf-fast path.
 
 ## Adding a new overlay (worked example)
 

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -4,7 +4,10 @@
 
 ## Direct PHP ops in the hot loop
 
-Phel's `+`, `<`, `aget` are polymorphic; they dispatch through the Phel runtime. Fine for app code, heavy per-cell.
+Unspecialised Phel `+`, `<`, and collection reads dispatch through the Phel
+runtime. Fine for app code, heavy per-cell. Latest Phel `main` can native-emit
+some typed primitive `phel.core` arithmetic and comparisons, but these hot loops
+keep the raw PHP path explicit.
 
 Renderer + raycaster use `php/+`, `php/<`, `php/aget`. Compile to `$a + $b`, `$a < $b`, `$arr[$k]` directly. No dispatch, no method call. ~5× speedup on the hot loop.
 

--- a/docs/state.md
+++ b/docs/state.md
@@ -99,12 +99,15 @@ Float-seconds countdowns on the world, decayed by `decay-timers` in `core/combat
 
 `:fx` is a vector of blood splatters with their own `:ttl` ticked by `decay-fx`.
 
-## Why the world is a flat map, not records
+## Why the world is a flat map, not a record
 
-Phel has no built-in record type with the ergonomics of Clojure's `defrecord`. Plain maps win on:
+Phel has `defrecord`, backed by its map-like `defstruct`. This world still stays
+a plain map because it is a broad state aggregate assembled in stages:
 
 - one-liner construction
 - assoc / update without ceremony
 - direct serialization for tests (`(is (= expected (tick-world ...)))`)
 
-Cost: no compile-time validation that a key exists. Mitigated by documenting the keyset here and centralising key reads in `frame-stats` (so a typo is loud).
+Cost: call sites do not get `defstruct`'s fixed key shape. Mitigated by
+documenting the keyset here and centralising key reads in `frame-stats` (so a
+typo is loud).


### PR DESCRIPTION
## 📚 Description

Sync the Phel-specific docs notes with current Phel `main`. `phel-doom` tracks
`phel-lang/phel-lang` as `dev-main`, so its docs should not describe landed
record and arithmetic-specialisation work as missing.

## 🔖 Changes

- replace the stale `defrecord` rationale in the world-state docs with the
  actual reason the world remains a broad plain map
- rename adjacent "records" prose to maps where the docs describe current
  `phel-doom` state values
- update hot-loop guidance now that typed primitive `phel.core` arithmetic and
  comparisons can be specialised on latest Phel `main`
- keep the explicit `php/*` fast-path guidance for hot loops where
  `phel-doom` deliberately wants raw PHP operators

Potential follow-up for a later iteration: benchmark a small plain-map versus
`defrecord`/`defstruct` comparison for stable game-state shapes before turning
the world-state rationale into stronger performance guidance.
