### PR TITLE
fix(render): pause credits right border stays white

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 
 ## [Unreleased]
 
+### Fixed
+
+- Pause menu credits row: right border now renders white like the other rows (was gray because the dim attribute leaked through the SGR reset). Closes #8.
+
 ## [0.1.0] - 2026-05-22
 
 ### Added

--- a/src/modules/io/render.phel
+++ b/src/modules/io/render.phel
@@ -478,8 +478,12 @@
              blnk
              (str "├" bar "┤")
              blnk
-             (str "│\e[2;97m" (pause-pad "  phel-doom by Chemaclass" w) "\e[40;97m│")
-             (str "│\e[2;97m" (pause-pad "  written in Phel Lang"   w) "\e[40;97m│")
+             ;; Dim text (\e[2) leaks through pause-pad's \e[40;97m
+             ;; because BG/FG SGR does not reset the intensity attribute.
+             ;; Explicit \e[22 (normal intensity) before the right border
+             ;; keeps the `│` bright white like every other row.
+             (str "│\e[2;97m" (pause-pad "  phel-doom by Chemaclass" w) "\e[22;40;97m│")
+             (str "│\e[2;97m" (pause-pad "  written in Phel Lang"   w) "\e[22;40;97m│")
              blnk
              (str "└" bar "┘")]))]
     (let [col0 (php/max 1 (php/- (php/+ (php/intdiv vw 2) 1)


### PR DESCRIPTION
## Summary

- Right border of the two credits rows in the pause menu rendered gray instead of white.
- Cause: `\e[2;97m` (dim) leaks past `pause-pad`'s `\e[40;97m` reapply because SGR BG/FG does not reset the intensity attribute. The trailing `│` inherits the dim state.
- Fix: emit `\e[22m` (normal intensity) together with the BG/FG reapply before the right border on both credits rows.

Closes #8

## Test plan

- [ ] `composer ci` green
- [ ] `composer play` → press `p`, confirm right border of `phel-doom by Chemaclass` and `written in Phel Lang` rows is bright white, matching every other row