### PR TITLE
fix(enemy): tighten rear-warn radius from 10 to 5 units

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 
 ## [Unreleased]
 
+### Changed
+
+- "Enemy behind you" warning radius tightened from 10 to 5 world-units so the cue fires only when something is genuinely close behind. Closes #6.
+
 ### Fixed
 
 - Pause menu credits row: right border now renders white like the other rows (was gray because the dim attribute leaked through the SGR reset). Closes #8.

--- a/src/modules/core/enemy.phel
+++ b/src/modules/core/enemy.phel
@@ -239,7 +239,7 @@
 (def rear-warn-max-dist
   "World-units beyond which a rear enemy is too far to register on
    the breathing-behind-you cue."
-  10.0)
+  5.0)
 
 (defn rear-attacker?
   "True when at least one alive enemy sits in the rear arc AND within

--- a/tests/modules/core/enemy-test.phel
+++ b/tests/modules/core/enemy-test.phel
@@ -184,8 +184,17 @@
   (is (= false (rear-attacker? [{:x 8.0 :y 5.0 :alive true}] 5.0 5.0 0.0))))
 
 (deftest test-rear-attacker-false-when-behind-but-too-far
-  ;; 30 units west — well past the 10-unit audible range.
+  ;; 30 units west — well past the 5-unit audible range.
   (is (= false (rear-attacker? [{:x -25.0 :y 5.0 :alive true}] 5.0 5.0 0.0))))
+
+(deftest test-rear-attacker-false-just-past-warn-radius
+  ;; 7 units west — behind the player but past the 5-unit threshold.
+  ;; Pins the tightened radius from issue #6.
+  (is (= false (rear-attacker? [{:x -2.0 :y 5.0 :alive true}] 5.0 5.0 0.0))))
+
+(deftest test-rear-attacker-true-just-inside-warn-radius
+  ;; 4 units west — behind the player, inside the 5-unit threshold.
+  (is (= true (rear-attacker? [{:x 1.0 :y 5.0 :alive true}] 5.0 5.0 0.0))))
 
 (deftest test-rear-attacker-false-when-dead
   (is (= false (rear-attacker? [{:x 2.0 :y 5.0 :alive false}] 5.0 5.0 0.0))))


### PR DESCRIPTION
## Summary

- The "‹ behind ›" cue was firing too aggressively — enemies 10 units out (still well outside combat range) lit it up.
- Lower `rear-warn-max-dist` to 5.0 so the warning only triggers when something is genuinely close behind.
- Adds two boundary tests pinning the new threshold (just-inside true, just-outside false).

Closes #6

## Test plan

- [ ] `composer ci` green
- [ ] `composer play` → back away from an enemy, confirm warning only blinks when it is close behind (~5 cells), not 10