### PR TITLE
feat(render): F3 toggles per-frame perf debug overlay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 
 ## [Unreleased]
 
+### Added
+
+- F3 toggles a per-frame perf overlay (frame-ms, cast-ms, render-ms, bytes emitted, avg RLE run-length, PHP memory). Off by default and fully gated, so the off path pays zero overhead. The canonical way to validate future cast/render optimisations. Closes #9.
+
 ### Changed
 
 - "Enemy behind you" warning radius tightened from 10 to 5 world-units so the cue fires only when something is genuinely close behind. Closes #6.

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ make play
 | `m`            | Toggle minimap               |
 | `n`            | Toggle sound                 |
 | `p`            | Pause                        |
+| `F3`           | Toggle perf debug overlay    |
 | `q`            | Quit                         |
 
 Walk into a door to advance. Walk over a heart to refill a life.

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -112,3 +112,15 @@ Phel emits `float $t_then, float $t_now`. No implicit cast, no deprecation, no l
 | 180×40 | ~5 ms |
 
 Game-loop overhead (`stty size`, `microtime`, `usleep`) adds ~2ms. Effective frame rate caps around 165 fps at 180×40.
+
+### Reading these live: the F3 debug overlay
+
+Press **F3** in-game to toggle a per-frame perf row that paints above the standard HUD footer. It surfaces (last-frame snapshot):
+
+- `frame` — total frame time in ms (same source as the existing fps counter).
+- `cast` / `render` — split of the frame budget between `cast-frame` and everything else `render!` does. Should add up to `frame` within timing jitter.
+- `bytes` — `strlen` of the emitted ANSI frame string. Tracks the hypothesis behind the differential-rendering investigation (issue #3).
+- `rle` — average bytes per `\e[` SGR prefix in the frame, a proxy for how effectively run-length encoding is collapsing same-colour runs (higher = better).
+- `mem` — current / peak PHP memory (`memory_get_usage(true)`).
+
+The overlay is **off by default and pays zero per-frame cost when off** — the instrumentation is fully gated behind the `:debug?` flag on the world, so production runs never call `microtime`, `strlen`, `substr_count`, or `memory_get_usage`. This is the canonical way to validate any future cast/render optimisation (issues #2, #3, #4): toggle F3, read the numbers before and after.

--- a/src/commands/play.phel
+++ b/src/commands/play.phel
@@ -2,7 +2,7 @@
   (:require phel.cli :as cli)
   (:require phel.string :as str)
   (:require phel-doom.modules.core.state    :refer [advance-game-time gain-life max-lives
-                                                    toggle-map toggle-pause toggle-sound])
+                                                    toggle-debug toggle-map toggle-pause toggle-sound])
   (:require phel-doom.modules.core.map      :refer [door?])
   (:require phel-doom.modules.glue.controls :refer [refresh-from-keys key-states rising-edges
                                                     initial-key-snapshot])
@@ -13,6 +13,7 @@
   (:require phel-doom.modules.core.level    :refer [build-world num-levels])
   (:require phel-doom.modules.io.scores   :refer [update-scores!])
   (:require phel-doom.modules.io.render   :refer [render! clear-screen
+                                                  read-perf-snapshot
                                                   render-start-menu
                                                   render-death-screen render-victory-screen])
   (:require phel-doom.modules.io.input    :refer [init-input! restore! drain-keys]))
@@ -65,13 +66,15 @@
   (update-in world [:player :angle] (fn [a] (php/+ a php/M_PI))))
 
 (defn- handle-toggles
-  "Apply rising-edge toggle keys (pause / minimap / sound / about-face)
-   for this frame."
+  "Apply rising-edge toggle keys (pause / minimap / sound / debug /
+   about-face) for this frame. Debug edge stays outside the paused
+   short-circuit so F3 still flips the overlay while paused."
   [world edges]
   (let [after-pause (if (:toggle-pause edges) (toggle-pause world) world)
         after-map   (if (:toggle-map edges) (toggle-map after-pause) after-pause)
-        after-sound (if (:toggle-sound edges) (toggle-sound after-map) after-map)]
-    (if (:about-face edges) (about-face after-sound) after-sound)))
+        after-sound (if (:toggle-sound edges) (toggle-sound after-map) after-map)
+        after-debug (if (:toggle-debug edges) (toggle-debug after-sound) after-sound)]
+    (if (:about-face edges) (about-face after-debug) after-debug)))
 
 (defn- tick-enemies
   "Step every alive enemy one dt-scaled frame toward the player, using
@@ -191,6 +194,8 @@
    :blood-drops (:blood-drops world)
    :door-face-active-secs (:door-face-active-secs world)
    :game-time   (or (:game-time world) 0.0)
+   :debug?      (:debug? world)
+   :perf-stats  (when (:debug? world) (read-perf-snapshot))
    :rear-warning? (rear-attacker? (:enemies world)
                                   (:x (:player world))
                                   (:y (:player world))

--- a/src/modules/core/state.phel
+++ b/src/modules/core/state.phel
@@ -24,6 +24,7 @@
    :player    player
    :show-map  true
    :paused    false
+   :debug?    false
    :sound-on  true
    :enemies   []
    :hearts    []
@@ -101,6 +102,15 @@
   {:export true}
   [world]
   (update world :sound-on not))
+
+(defn toggle-debug
+  "Flip the :debug? flag that controls the perf overlay (F3). When on,
+   the renderer paints an extra HUD row with frame timing, byte count,
+   RLE effectiveness, and PHP memory; when off, none of the
+   instrumentation runs so the off-state pays zero overhead."
+  {:export true}
+  [world]
+  (update world :debug? not))
 
 (defn move-player
   "Translate the player by (dx, dy) — no collision check here."

--- a/src/modules/glue/controls.phel
+++ b/src/modules/glue/controls.phel
@@ -212,7 +212,13 @@
 
 (def initial-key-snapshot
   "First-frame snapshot — nothing held yet."
-  {:m false :sp false :p false :n false :e false})
+  {:m false :sp false :p false :n false :e false :f3 false})
+
+(defn- f3-pressed? [keys]
+  ;; F3 across terminals: xterm/macOS Terminal/iTerm2 send `\eOR`;
+  ;; Linux console + a few others send `\e[13~`. Cover both.
+  (or (str/contains? keys "\eOR")
+      (str/contains? keys "\e[13~")))
 
 (defn key-states
   "Which of the tracked one-shot keys appear in `keys` this frame."
@@ -222,7 +228,8 @@
    :sp (str/contains? keys " ")
    :p  (str/contains? keys "p")
    :n  (str/contains? keys "n")
-   :e  (str/contains? keys "e")})
+   :e  (str/contains? keys "e")
+   :f3 (f3-pressed? keys)})
 
 (defn rising-edges
   "Build the edges map tick consumes — truthy only for keys that just
@@ -233,4 +240,5 @@
    :toggle-map   (and (:m now)  (not (:m prev)))
    :toggle-pause (and (:p now)  (not (:p prev)))
    :toggle-sound (and (:n now)  (not (:n prev)))
+   :toggle-debug (and (:f3 now) (not (:f3 prev)))
    :about-face   (and (:e now)  (not (:e prev)))})

--- a/src/modules/io/render.phel
+++ b/src/modules/io/render.phel
@@ -122,7 +122,39 @@
   "Yellow ◆ on the bright-blue BG for the pulse frame."
   "\e[48;5;33;38;5;226;1m◆")
 (def char-aspect 2.0)
-(def hud-rows 1)
+(def base-hud-rows 1)
+
+(defn- hud-rows-for
+  "Number of HUD rows to reserve at the bottom of the viewport. The
+   debug overlay (F3) adds a second row above the standard footer; off
+   by default so the 3D viewport keeps its full vertical real estate."
+  [stats]
+  (if (get stats :debug?) 2 base-hud-rows))
+
+(def perf-snapshot
+  "Side-channel for the F3 perf overlay. `render!` writes the latest
+   cast-ms / render-ms / bytes / avg-rle / PHP-mem snapshot into this
+   atom every frame the overlay is on; `frame-stats` reads it on the
+   following frame so the debug row paints last-frame numbers. nil
+   while the overlay is off — gates the paint-debug-row helper out."
+  (atom nil))
+
+(defn read-perf-snapshot
+  "Public accessor for the latest perf snapshot written by render!.
+   Called by play.frame-stats so the debug HUD has data to paint on
+   the next frame. Returns nil while the overlay has never been on."
+  {:export true}
+  []
+  @perf-snapshot)
+
+(defn- record-cast-ms!
+  "Helper used by `frame->string` when :debug? is on. Stashes the
+   measured cast-phase time so `render!` can subtract it from total
+   frame time to get the render-phase slice. Skips the swap when the
+   atom is unset so the off path stays branch-free."
+  [^float ms]
+  (swap! perf-snapshot
+         (fn [snap] (if (nil? snap) {:cast-ms ms} (assoc snap :cast-ms ms)))))
 
 (def shade-table
   "Pre-baked ANSI strings for the 24 grayscale palette entries (codes
@@ -386,6 +418,44 @@
         (recur (php/+ row 1))))
     rows))
 
+(defn- fmt-ms
+  "Render an ms reading to one decimal so the debug row stays compact
+   even when timings stretch past 10ms. Falls back to `--` when the
+   metric is not available yet (e.g. first frame)."
+  [v]
+  (if (nil? v) "--" (php/number_format v 1)))
+
+(defn- fmt-bytes
+  "Human-readable byte count: under 10k stays plain, otherwise `k`/`M`
+   suffix with one decimal so the row fits in a single line."
+  [n]
+  (cond (nil? n)          "--"
+        (php/< n 10000)   (str n)
+        (php/< n 1000000) (str (php/number_format (php// n 1000.0) 1) "k")
+        :else             (str (php/number_format (php// n 1000000.0) 2) "M")))
+
+(defn- hud-debug-line
+  "Single-line perf overlay. Reads the snapshot `frame-stats` already
+   pulled from the side-channel atom — no instrumentation work runs
+   here, so the row repaints cheaply once the cost has been paid by
+   the previous frame's render!. Off when :debug? is false."
+  [stats]
+  (let [snap         (or (get stats :perf-stats) {})
+        frame-ms     (or (get stats :frame-ms) 0)
+        cast-ms      (get snap :cast-ms)
+        render-ms    (get snap :render-ms)
+        bytes        (get snap :bytes)
+        avg-rle      (get snap :avg-rle)
+        php-mem      (get snap :php-mem)
+        php-mem-peak (get snap :php-mem-peak)]
+    (str "\e[0m\e[1;36m[DEBUG]\e[0m"
+         "  \e[1mframe\e[0m " frame-ms "ms"
+         "  \e[1mcast\e[0m "  (fmt-ms cast-ms) "ms"
+         "  \e[1mrender\e[0m " (fmt-ms render-ms) "ms"
+         "  \e[1mbytes\e[0m " (fmt-bytes bytes)
+         "  \e[1mrle\e[0m "  (if (nil? avg-rle) "--" (php/number_format avg-rle 1))
+         "  \e[1mmem\e[0m "  (fmt-bytes php-mem) "/" (fmt-bytes php-mem-peak))))
+
 (defn- hud-line [world stats]
   (let [{:keys [x y angle]} (:player world)]
     (str "\e[0m\e[1mpos\e[0m ("
@@ -504,10 +574,12 @@
 
 (defn- layout
   "Viewport fills the whole terminal. The minimap is an overlay in the
-   top-right corner that the M key shows or hides."
-  [cols rows mw]
+   top-right corner that the M key shows or hides. The HUD row count
+   grows by one when the F3 debug overlay is on so the perf row can
+   sit above the standard footer without clipping the 3D view."
+  [cols rows mw stats]
   {:vw      cols
-   :vh      (- rows hud-rows)
+   :vh      (- rows (hud-rows-for stats))
    :map-col (php/max 1 (+ (- cols mw) 1))
    :map-row 1})
 
@@ -1099,7 +1171,7 @@
   {:export true}
   [world stats cols rows]
   (let [{:keys [vw vh map-col map-row]}
-        (layout cols rows (count (first (:grid world))))
+        (layout cols rows (count (first (:grid world))) stats)
         bloody?                            (php/> (or (get stats :iframes) 0.0) 0.0)
         ;; Walls + sky + floor are ALL pure grayscale: enemy colours
         ;; pop against neutral stonework, and far walls fade toward
@@ -1156,8 +1228,17 @@
                                              (or (get stats :enemy-body-glyph-alt)
                                                  body-glyph-base))
         body-glyph-fg                      (get stats :enemy-body-glyph-fg)
+        ;; Cast phase. When the F3 overlay is on, sample microtime
+        ;; around the call so render! can split cast-ms from total
+        ;; frame-ms. The branch is the only debug-gated cost in the
+        ;; off path — a single `(get stats :debug?)` check per frame.
+        debug?                             (get stats :debug?)
+        t-cast-start                       (if debug? (php/microtime true) 0.0)
         {:keys [dists hits sides hxs hys]}
         (cast-frame world vw)
+        _                                  (when debug?
+                                             (record-cast-ms!
+                                              (php/* (php/- (php/microtime true) t-cast-start) 1000.0)))
         ;; Half-block edge cells need the sky/floor colour CODE for
         ;; the current palette so the composer can write
         ;; "\e[48;5;WALL;38;5;SKYm▀" and let ▀'s upper half show sky.
@@ -1373,6 +1454,9 @@
                                           (buf-push parts (php/str_repeat " " (php/- run 1)))
                                           (recur (php/+ col 1) c 1))))))
                (buf-push parts "\e[0m\n"))
+      (when (get stats :debug?)
+        (buf-push parts (hud-debug-line stats))
+        (buf-push parts "\n"))
       (buf-push parts (hud-line world stats))
       (dotimes [i visible-mh]
                (buf-push parts (str "\e[" (php/+ map-row i) ";" map-col "H" (buf-get mrows i))))
@@ -1447,6 +1531,28 @@
     (buf-push parts "\e[0m")
     (php/implode "" parts)))
 
+(defn- update-perf-snapshot!
+  "Compute the perf snapshot from the just-emitted `frame-str` and the
+   `total-ms` it took, then merge it into `perf-snapshot` (cast-ms was
+   already stashed by frame->string). Render-ms is whatever's left
+   after subtracting cast — the same accounting the manual sanity
+   check in issue #9 uses (`cast + render ≈ frame`)."
+  [^string frame-str ^float total-ms]
+  (let [bytes     (php/strlen frame-str)
+        sgr-count (php/max 1 (php/substr_count frame-str "\e["))
+        avg-rle   (php// bytes sgr-count)
+        cast-ms   (or (get @perf-snapshot :cast-ms) 0.0)
+        render-ms (php/max 0.0 (php/- total-ms cast-ms))]
+    (swap! perf-snapshot
+           (fn [snap]
+             (assoc (or snap {})
+                    :cast-ms      cast-ms
+                    :render-ms    render-ms
+                    :bytes        bytes
+                    :avg-rle      avg-rle
+                    :php-mem      (php/memory_get_usage true)
+                    :php-mem-peak (php/memory_get_peak_usage true))))))
+
 (defn render!
   "Move cursor home and overwrite the previous frame in place. Avoids
    the full-screen clear that would otherwise flicker each frame.
@@ -1454,19 +1560,29 @@
    impact jolt that lands before the red i-frame wash. Screen-shake:
    the first ~0.25s of the i-frame window offsets the cursor-home
    anchor by ±1 col so the next frame paints one cell off, reading
-   as a snap-shake on damage."
+   as a snap-shake on damage. When :debug? is set, also samples
+   microtime around `frame->string` and updates `perf-snapshot` so the
+   next frame's HUD can paint the F3 overlay; the work is gated so
+   the off path pays nothing beyond a single key read."
   {:export true}
   [world stats cols rows]
   (let [iframes (or (get stats :iframes) 0.0)
         shake?  (php/> iframes 0.75)
         t       (or (get stats :game-time) 0.0)
+        debug?  (get stats :debug?)
         shake-x (if shake?
                   (php/+ 1 (mod (php/intval (php/* t 50.0)) 3))
                   1)]
     (print (str "\e[1;" shake-x "H"))
     (if (php/> (or (get stats :flash-secs) 0.0) 0.0)
       (print (white-flash-frame cols rows))
-      (print (frame->string world stats cols rows))))
+      (if debug?
+        (let [t-start  (php/microtime true)
+              frame    (frame->string world stats cols rows)
+              total-ms (php/* (php/- (php/microtime true) t-start) 1000.0)]
+          (print frame)
+          (update-perf-snapshot! frame total-ms))
+        (print (frame->string world stats cols rows)))))
   (php/flush))
 
 ;; ---------------------------------------------------------------------

--- a/tests/commands/play-test.phel
+++ b/tests/commands/play-test.phel
@@ -78,3 +78,11 @@
                   :game-time 1.5)
         w1 (tick-world w0 "" 10.0 no-edges)]
     (is (= 1.5 (:game-time w1)))))
+
+(deftest test-tick-world-toggle-debug-edge-flips-debug-flag
+  ;; F3 rising edge flips :debug? — off by default, on after one
+  ;; press. Pause does not gate this so the overlay can be toggled
+  ;; while the game is paused.
+  (let [w  (new-world open-grid (new-player 5.0 5.0 0.0))
+        w' (tick-world w "" 0.016 (assoc no-edges :toggle-debug true))]
+    (is (= true (:debug? w')))))

--- a/tests/modules/core/state-test.phel
+++ b/tests/modules/core/state-test.phel
@@ -1,7 +1,7 @@
 (ns phel-doom-tests.modules.core.state-test
   (:require phel.test :refer [deftest is])
   (:require phel-doom.modules.core.state :refer [new-player new-world move-player turn-player
-                                                 toggle-map toggle-pause with-enemies
+                                                 toggle-map toggle-pause toggle-debug with-enemies
                                                  advance-game-time gain-life max-lives]))
 
 (def grid [[1 1 1] [1 0 1] [1 1 1]])
@@ -69,3 +69,11 @@
   (let [w  (new-world grid (new-player 1.0 1.0 0.0))
         w' (advance-game-time (advance-game-time w 0.25) 0.1)]
     (is (= 0.35 (:game-time w')))))
+
+(deftest test-debug-flag-default-off
+  (is (= false (:debug? (new-world grid (new-player 1.0 1.0 0.0))))))
+
+(deftest test-toggle-debug-flips
+  (let [w (new-world grid (new-player 1.0 1.0 0.0))]
+    (is (= true  (:debug? (toggle-debug w))))
+    (is (= false (:debug? (toggle-debug (toggle-debug w)))))))

--- a/tests/modules/glue/controls-test.phel
+++ b/tests/modules/glue/controls-test.phel
@@ -63,4 +63,23 @@
   (is (= false (:m  initial-key-snapshot)))
   (is (= false (:p  initial-key-snapshot)))
   (is (= false (:n  initial-key-snapshot)))
-  (is (= false (:e  initial-key-snapshot))))
+  (is (= false (:e  initial-key-snapshot)))
+  (is (= false (:f3 initial-key-snapshot))))
+
+(deftest test-key-states-detects-f3-xterm-sequence
+  ;; Most terminals (xterm, macOS Terminal, iTerm2) send `\eOR` for F3.
+  (is (= true (:f3 (key-states "\eOR")))))
+
+(deftest test-key-states-detects-f3-linux-sequence
+  ;; Linux console + a handful of others use the CSI `~` form.
+  (is (= true (:f3 (key-states "\e[13~")))))
+
+(deftest test-rising-edges-toggle-debug-fires-on-fresh-f3
+  (let [edges (rising-edges {:sp false :m false :p false :n false :e false :f3 true}
+                            {:sp false :m false :p false :n false :e false :f3 false})]
+    (is (= true (:toggle-debug edges)))))
+
+(deftest test-rising-edges-toggle-debug-does-not-refire-while-held
+  (let [edges (rising-edges {:sp false :m false :p false :n false :e false :f3 true}
+                            {:sp false :m false :p false :n false :e false :f3 true})]
+    (is (= false (:toggle-debug edges)))))


### PR DESCRIPTION
## Summary

- Adds an off-by-default debug HUD bound to **F3**. When on, paints a second HUD row with `frame` ms, `cast`/`render` ms split, `bytes` emitted, `rle` (avg bytes per SGR prefix), and `mem` (current/peak PHP memory).
- All instrumentation is gated by `:debug?`. The off path adds one `get`-then-branch per frame; no `microtime`, `strlen`, `substr_count`, or memory syscalls run unless the overlay is on.
- `cast-ms` is sampled inside `frame->string` and stashed via a side-channel atom; `render!` measures the whole frame and derives `render-ms = total − cast`. The next frame's `frame-stats` reads the snapshot, so the HUD paint is free.
- Layout adjusts: `hud-rows-for` returns 2 with `:debug?` so the perf row sits above the standard footer without clipping the 3D viewport.
- Tests cover the toggle contract (controls edge, state flip, tick-world plumbing). `docs/performance.md` gains a "Reading these live" section so future cast/render optimisations (issues #2, #3, #4) have a single canonical knob to validate against.

Closes #9

## Test plan

- [ ] `composer ci` green
- [ ] `composer play` → press **F3**, confirm: second HUD row appears, all 6 fields populate after one frame, `cast + render ≈ frame` within jitter, repeat F3 hides the row again
- [ ] Press `p` to pause, then **F3**: overlay still toggles while paused
- [ ] With debug off, resize terminal: viewport reclaims the second row (no leftover artefacts)