### PR TITLE
docs(perf): close #3 — differential rendering not worth shipping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 
 - DDA raycaster replaces the fixed-step march in `cast-ray` / `cast-ray-hit`. ~20-24% faster cast phase across all viewports (`80×24` 0.81 → 0.65 ms, `120×30` 1.26 → 0.99 ms, `180×40` 2.04 → 1.55 ms). As a side-effect `cast-frame` now also surfaces `:hxs` / `:hys` (hit-cell coords) so the renderer's brick-texture hash gets real inputs. Closes #2.
 
+### Investigated, not shipping
+
+- **Differential rendering** (issue #3) — evaluated, closed without merge. Bench shows ~60 % bytes saved in still-but-animating scenes and 100 % saved on pause, but a 2 % regression once the player moves or turns. Active gameplay = net loss; complexity cost not justified. Full numbers + rationale in `docs/performance.md` *Evaluated and shelved*.
+
 ### Changed
 
 - "Enemy behind you" warning radius tightened from 10 to 5 world-units so the cue fires only when something is genuinely close behind. Closes #6.

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -103,8 +103,26 @@ Phel emits `float $t_then, float $t_now`. No implicit cast, no deprecation, no l
 
 ## What's NOT optimised (yet)
 
-- **Differential rendering**. Every frame painted in full. Could diff against previous and emit only changed cells. Huge win on static scenes, meaningful complexity cost.
 - **Sprite occlusion via z-buffer**. We re-test wall distance per cell when painting an enemy. A per-column min-z buffer would early-exit. Marginal at 5ms total budget.
+
+## Evaluated and shelved
+
+### Differential rendering (issue #3 — closed without merge)
+
+Per-row diff against the previous frame, emitting only changed rows. Same `default-grid`, two-frame diff, bytes-emitted measured (lower = better):
+
+| Scenario | Viewport | Full repaint | Row-diff | Δ |
+|---|---|---|---|---|
+| Paused (dt = 0) | 180×40 | 15693 B | 0 B | **-100 %** |
+| Still player, world ticks (HUD + pulses only) | 180×40 | 15693 B | 6121 B | **-61 %** |
+| Moving forward | 180×40 | 15583 B | 15864 B | **+2 %** |
+| Turning | 180×40 | 15616 B | 15897 B | **+2 %** |
+
+The static-scene wins are real but rare — once the player moves OR turns, every row's wall column changes and the diff cost (cursor-positioning overhead + the per-row string compare) makes it net *more* expensive than a single cursor-home full repaint. With the existing run-length encoding already keeping frames under ~16 KB at 180×40 and the cast+render budget under 5 ms, the saved bytes don't move the needle in the case that actually matters (active gameplay).
+
+Add to that: invalidation logic for resize, scene reset, alt-screen re-entry, pause-menu overlay, minimap toggle, transient effects — every one of those would need a forced full-repaint flag, and getting any of them wrong leaves stale cells on screen.
+
+Verdict: **complexity cost > realistic win**. Issue closed without merging.
 
 ## Measured numbers
 


### PR DESCRIPTION
## Summary

Prototyped a per-row diff against the previous frame and measured bytes emitted at 80×24, 120×30, 180×40 on `default-grid`:

| Scenario | Viewport | Full repaint | Row-diff | Δ |
|---|---|---|---|---|
| Paused (dt = 0) | 180×40 | 15693 B | 0 B | **-100 %** |
| Still player, world ticks | 180×40 | 15693 B | 6121 B | **-61 %** |
| Moving forward | 180×40 | 15583 B | 15864 B | **+2 %** |
| Turning | 180×40 | 15616 B | 15897 B | **+2 %** |

Wins land only when the player is literally not moving. In active gameplay every row's wall column changes; cursor-positioning + per-row compare overhead make the diff path *more* expensive than today's cursor-home full repaint.

With cast+render already under 5 ms and frames already ~16 KB at 180×40 (thanks to RLE), the saved bytes don't move the needle in the case that matters. Add the invalidation matrix (resize, scene reset, pause menu, minimap toggle, alt-screen re-entry, transient overlays) and the complexity cost dwarfs the realistic savings.

Per the issue's own acceptance ("Close without merge if measurements do not justify"), shelving. Doc note + numbers added under `docs/performance.md` *Evaluated and shelved*.

Closes #3

## Test plan

- [ ] `composer ci` green (docs-only changes)