### PR TITLE
feat(level,render): ammo-box pickups in 3D and minimap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 ### Added
 
 - Finite ammo reserve (phase 2 of issue #5). Fresh runs start with `:ammo-reserve 30` (three mags) and cap at `max-reserve 50`. Reload draws `min(mag-size - mag, reserve)` rounds; reload is a no-op when the reserve is empty so spamming R stays harmless. HUD ammo cell now reads `ammo N/10 [R]` with both segments coloured (amber under one-mag's worth, red on empty).
+- Ammo-box pickups. Every level spawns two `▣` boxes at random open cells; stepping on one adds `ammo-per-box 10` to the reserve (capped at `max-reserve`). Boxes pulse warm-brown → yellow in the 3D view at 7 rad/s (distinct from heart/armor pulses) and show as a yellow `A` on the minimap.
 
 ## [0.2.0] - 2026-05-22
 

--- a/docs/level-system.md
+++ b/docs/level-system.md
@@ -47,6 +47,8 @@ Level N config (1-indexed). Clamps out-of-range to nearest valid.
             (assoc with-foes
                    :level level-num :lives lives
                    :hearts      (maybe-spawn-heart grid lives px py)
+                   :armors      (maybe-spawn-armor grid)
+                   :ammo-boxes  (spawn-ammo-boxes grid)
                    :chase-speed (:chase cfg)
                    ;; enemy visual stamps...
                    :level-name  (:name cfg)
@@ -60,7 +62,9 @@ Sequence:
 3. Player spawn at a random open cell.
 4. `:enemies` monsters at least `enemy-min-spawn-dist = 3.0` from player.
 5. Heart pickup in a random open cell if `lives < max-lives`; otherwise none.
-6. Stamp level metadata (chase speed, monster colours, glyphs, name) + 1.5s intro splash timer.
+6. Armor pickup roughly every other level (50% chance, one cell).
+7. Two ammo-boxes at random open cells (always — reserve is finite, so the player must restock).
+8. Stamp level metadata (chase speed, monster colours, glyphs, name) + 1.5s intro splash timer.
 
 Result feeds into `game-loop`.
 

--- a/docs/state.md
+++ b/docs/state.md
@@ -17,6 +17,9 @@ Pure data shapes that every other module operates on. `src/modules/core/state.ph
  :sound-on   <bool>     ; N toggle
  :enemies    <vector of enemy maps>
  :hearts     <vector of {:x :y}>
+ :armors     <vector of {:x :y}>
+ :ammo-boxes <vector of {:x :y}>
+ :armor      <int, hits absorbed before lives drop>
  :kills      <int>
  :lives      <int, 0..max-lives>
  :iframes    <float seconds>  ; post-hit invulnerability

--- a/src/commands/play.phel
+++ b/src/commands/play.phel
@@ -7,7 +7,7 @@
   (:require phel-doom.modules.glue.controls :refer [refresh-from-keys key-states rising-edges
                                                     initial-key-snapshot])
   (:require phel-doom.modules.core.physics  :refer [apply-physics tick-heartbeat tick-flicker tick-blood-drops tick-door-face])
-  (:require phel-doom.modules.core.combat   :refer [damage-step reload tick-shooting])
+  (:require phel-doom.modules.core.combat   :refer [ammo-per-box damage-step max-reserve reload tick-shooting])
   (:require phel-doom.modules.core.enemy    :refer [advance tick-scare rear-attacker?])
   (:require phel-doom.modules.io.sound    :refer [play-sfx! mute-for!])
   (:require phel-doom.modules.core.level    :refer [build-world num-levels])
@@ -125,6 +125,28 @@
         (when (:sound-on world) (play-sfx! :door))
         (update shielded :armor (fn [a] (php/+ (or a 0) 1)))))))
 
+(defn- ammo-boxes-not-at [boxes px py]
+  (apply vector
+         (filter (fn [b]
+                   (not (and (php/=== (php/intval (:x b)) px)
+                             (php/=== (php/intval (:y b)) py))))
+                 (or boxes []))))
+
+(defn- pickup-ammos
+  "Step-on triggers an ammo-box pickup: bumps :ammo-reserve by
+   `ammo-per-box`, capped at `max-reserve`. Box is removed from the
+   world so the player can't farm a single cell."
+  [world]
+  (let [kept (ammo-boxes-not-at (:ammo-boxes world)
+                                (php/intval (:x (:player world)))
+                                (php/intval (:y (:player world))))]
+    (if (= (count kept) (count (or (:ammo-boxes world) [])))
+      world
+      (let [refilled (assoc world :ammo-boxes kept)]
+        (when (:sound-on world) (play-sfx! :door))
+        (update refilled :ammo-reserve
+                (fn [r] (php/min max-reserve (php/+ (or r 0) ammo-per-box))))))))
+
 (defn- on-door?
   "True when the player's current cell is a door (auto-advances level)."
   [world]
@@ -152,7 +174,8 @@
             w2  (apply-physics w1 dt)
             w3  (pickup-hearts w2)
             w4  (pickup-armors w3)
-            w5  (tick-enemies  w4 dt)
+            w4b (pickup-ammos  w4)
+            w5  (tick-enemies  w4b dt)
             w5b (if (:reload edges) (reload w5) w5)
             w6  (tick-shooting w5b (:fire edges))
             w7  (damage-step   w6 dt)

--- a/src/modules/core/combat.phel
+++ b/src/modules/core/combat.phel
@@ -62,6 +62,11 @@
    beyond this so the player can't stockpile infinitely."
   50)
 
+(def ammo-per-box
+  "Rounds each ammo-box pickup adds to `:ammo-reserve`. One full mag
+   per box keeps the math obvious for the player."
+  10)
+
 (def reload-cooldown-seconds
   "Brief lockout after a reload so the player can't trigger-mash R to
    bypass the empty-mag block when timing a shot. Short enough that

--- a/src/modules/core/level.phel
+++ b/src/modules/core/level.phel
@@ -110,6 +110,22 @@
       [{:x ax :y ay}])
     []))
 
+(defn- spawn-ammo-boxes
+  "Every level seeds two ammo boxes at random open cells. Ammo reserve
+   is finite (see combat/max-reserve) so a steady refill keeps the
+   player firing as monster counts ramp. Loops up to a few times so
+   the second box doesn't accidentally land on the first (random-spawn
+   is unconditioned across calls, and a collision would silently halve
+   the reward — both boxes consumed by a single step)."
+  [grid]
+  (let [[ax ay] (random-spawn grid)]
+    (loop [attempt 0]
+      (let [[bx by] (random-spawn grid)]
+        (cond
+          (or (php/!== ax bx) (php/!== ay by)) [{:x ax :y ay} {:x bx :y by}]
+          (php/>= attempt 4)                   [{:x ax :y ay}]
+          :else                                (recur (php/+ attempt 1)))))))
+
 (defn build-world
   "Construct a brand-new world for `level-num` carrying `lives` over
    from the previous level. Walls, enemies, the single door, the
@@ -132,6 +148,7 @@
                    :lives       lives
                    :hearts      (maybe-spawn-heart grid lives px py)
                    :armors      (maybe-spawn-armor grid)
+                   :ammo-boxes  (spawn-ammo-boxes grid)
                    :chase-speed (:chase cfg)
                    :enemy-head-code     (:head-code cfg)
                    :enemy-body-code     (:body-code cfg)

--- a/src/modules/core/state.phel
+++ b/src/modules/core/state.phel
@@ -29,6 +29,7 @@
    :enemies   []
    :hearts    []
    :armors    []
+   :ammo-boxes []
    :armor     0
    :kills     0
    :streak    0

--- a/src/modules/io/render.phel
+++ b/src/modules/io/render.phel
@@ -54,6 +54,7 @@
 ;; on some iTerm2 themes) shows through and washes the overlay out.
 (def enemy-marker "\e[40;91;1mE\e[0m")
 (def heart-marker "\e[40;91;1m♥\e[0m")
+(def ammo-marker  "\e[40;93;1mA\e[0m")
 (def door-shade
   "Door body cell drawn when a ray hit a door. Frame glyph `▌` (left
    half block) on a dark steel BG with bright orange FG, so a column
@@ -121,6 +122,26 @@
 (def armor-glyph-bright
   "Yellow ◆ on the bright-blue BG for the pulse frame."
   "\e[48;5;33;38;5;226;1m◆")
+
+(def ammo-shade
+  "Ammo-box idle BG: warm brown so it reads as a wooden crate from a
+   distance, distinct from the cooler armor blue and warmer heart red."
+  "\e[48;5;94m ")
+
+(def ammo-shade-bright
+  "Ammo-box pulse BG: saturated yellow so it grabs the eye when the
+   player is low on rounds."
+  "\e[48;5;220m ")
+
+(def ammo-glyph
+  "White ▣ on the brown BG: stylised round-pack with a centre dot."
+  "\e[48;5;94;38;5;231;1m▣")
+
+(def ammo-glyph-bright
+  "Black ▣ on the yellow pulse BG so the icon flips contrast in tempo
+   with the shade swap."
+  "\e[48;5;220;38;5;52;1m▣")
+
 (def char-aspect 2.0)
 (def base-hud-rows 1)
 
@@ -381,6 +402,21 @@
         (recur (next hs))))
     acc))
 
+(defn- ammo-cells
+  "Build a PHP array keyed by `row*gw+col` whose truthy entries mark
+   cells currently holding an ammo-box pickup."
+  [boxes gw]
+  (let [acc (buf-mk)]
+    (loop [bs boxes]
+      (when (php/!== bs nil)
+        (let [b (first bs)]
+          (when b
+            (buf-set acc
+                     (php/+ (php/* (php/intval (:y b)) gw) (php/intval (:x b)))
+                     true)))
+        (recur (next bs))))
+    acc))
+
 (defn- minimap-rows
   "Render the world's grid into a PHP array of ANSI-coded strings, one
    per grid row. Reads the grid via :pgrid (PHP-native nested array)
@@ -398,6 +434,7 @@
         gw                  (php/count (buf-get pgrid 0))
         emap                (enemy-cells (:enemies world) gw)
         hmap                (heart-cells (:hearts world) gw)
+        amap                (ammo-cells  (:ammo-boxes world) gw)
         rows                (buf-mk)]
     (loop [row 0]
       (when (php/< row gh)
@@ -412,6 +449,7 @@
                           (php/=== 2 (buf-get grow col))              door-glyph
                           (buf-get emap (php/+ (php/* row gw) col))   enemy-marker
                           (buf-get hmap (php/+ (php/* row gw) col))   heart-marker
+                          (buf-get amap (php/+ (php/* row gw) col))   ammo-marker
                           :else                                       minimap-floor))
               (recur (php/+ col 1))))
           (buf-set rows row (php/implode "" parts)))
@@ -1284,6 +1322,12 @@
         aggro-bright?                      (pulse t 5.0)
         armor-shade-now                    (if armor-bright? armor-shade-bright armor-shade)
         armor-glyph-now                    (if armor-bright? armor-glyph-bright armor-glyph)
+        ;; Ammo-box pulse: warm-brown crate to yellow flare at 7 rad/s
+        ;; — slower than hearts so the two pickup types read distinct
+        ;; even when both are in frame.
+        ammo-bright?                       (pulse t 7.0)
+        ammo-shade-now                     (if ammo-bright? ammo-shade-bright ammo-shade)
+        ammo-glyph-now                     (if ammo-bright? ammo-glyph-bright ammo-glyph)
         ;; Camera kick: while :fire-anim > 0 shift the wall vertical
         ;; position one row down so the horizon tilts up. Settles back
         ;; as the timer decays in combat.phel.
@@ -1431,6 +1475,9 @@
           bp-armors (paint-pickups-into  bp-hearts (or (:armors world) [])
                                          (:player world) dists edists vw vh
                                          armor-shade-now armor-glyph-now)
+          bp-ammos  (paint-pickups-into  bp-armors (or (:ammo-boxes world) [])
+                                         (:player world) dists edists vw vh
+                                         ammo-shade-now ammo-glyph-now)
           parts     (buf-mk)]
       (dotimes [row vh]
                (loop [col 0 prev nil run 0]
@@ -1449,7 +1496,7 @@
                          flr-row   (buf-get (if in-blood? blood-floor-gradient floor-gradient) row)
                          c         (if (and (php/< row visible-mh) (php/>= col mini-col0))
                                      sky-row
-                                     (or (buf-get bp-armors (php/+ (php/* row vw) col))
+                                     (or (buf-get bp-ammos (php/+ (php/* row vw) col))
                                          (cond
                                            (php/< row (buf-get tops col))             sky-row
                                            (php/>= row (buf-get bots col))            flr-row
@@ -1498,7 +1545,7 @@
             c-row       (php/+ (php/intdiv vh 2) (if firing? -1 0))
             top-col     (buf-get tops c-col)
             bot-col     (buf-get bots c-col)
-            center-cell (or (buf-get bp-armors (php/+ (php/* c-row vw) c-col))
+            center-cell (or (buf-get bp-ammos (php/+ (php/* c-row vw) c-col))
                             (cond
                               (php/< c-row top-col)             (buf-get sky-gradient c-row)
                               (php/>= c-row bot-col)            (buf-get floor-gradient c-row)


### PR DESCRIPTION
## 📚 Description

PR 2/3 of the ammo overhaul (PR1 #20 merged). Adds the world-side counterpart to the finite ammo reserve: ammo-box pickups that the player walks over to top the reserve back up.

PR3 (low-ammo HUD warning) closes out issue #5.

## 🔖 Changes

### State + level
- `:ammo-boxes []` added to `new-world`.
- `spawn-ammo-boxes` always seeds two boxes at random open cells. Collision-guarded: a uniqueness loop avoids the two boxes landing on the same cell (silent half-reward bug otherwise).
- `build-world` wires it in alongside hearts and armors.

### Combat
- New `ammo-per-box 10` constant — one full mag per box keeps the math obvious.

### Pickup helper
- `pickup-ammos` in `play.phel` mirrors `pickup-armors`: removes the box at the player's cell, plays the door sfx (placeholder), bumps `:ammo-reserve` by `ammo-per-box` capped at `max-reserve`.
- Wired between `pickup-armors` and `tick-enemies` in the world-tick chain.

### Render
- Constants: `ammo-shade` / `-bright`, `ammo-glyph` / `-bright`, `ammo-marker`.
- `ammo-cells` helper builds the minimap lookup map (mirrors `heart-cells`).
- Minimap cond row gains an ammo branch (yellow `A`).
- Big-let pulse state: `ammo-bright?` at 7 rad/s — deliberately slower than the heart pulse (6 rad/s) so the two pickup types stay distinguishable in a busy frame.
- `paint-pickups-into` chain extended with `bp-ammos`; the two `bp-armors` consumers (row composer + centre-cell pick) repointed to `bp-ammos`.

### Docs
- `state.md`: `:armors`, `:ammo-boxes`, `:armor` added to the world schema (previously omitted).
- `level-system.md`: armor + ammo entries added to the build-world sequence.

## ✅ Verification

- `composer ci` → 0 lint warnings, 333 tests pass (unchanged — pickup helpers are side-effecting and covered primarily via `/play` smoke).
- `clean-code-reviewer` agent: cap logic + chain update + IO boundaries all clean; flagged the two-box collision case (fixed in this PR before push) and the absent armor minimap marker (out of scope — tracked as potential follow-up).

Issue #5 stays open until PR3 (low-ammo warning) lands.