### PR TITLE
feat(render): top-row LOW AMMO N pulsing warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 
 - Finite ammo reserve (phase 2 of issue #5). Fresh runs start with `:ammo-reserve 30` (three mags) and cap at `max-reserve 50`. Reload draws `min(mag-size - mag, reserve)` rounds; reload is a no-op when the reserve is empty so spamming R stays harmless. HUD ammo cell now reads `ammo N/10 [R]` with both segments coloured (amber under one-mag's worth, red on empty).
 - Ammo-box pickups. Every level spawns two `▣` boxes at random open cells; stepping on one adds `ammo-per-box 10` to the reserve (capped at `max-reserve`). Boxes pulse warm-brown → yellow in the 3D view at 7 rad/s (distinct from heart/armor pulses) and show as a yellow `A` on the minimap.
+- Top-of-screen `! LOW AMMO N !` warning that pulses when total firepower (mag + reserve) drops to 3 or fewer rounds. Amber at 3, bright red at 1; suppressed at 0 because the HUD ammo cell already flashes red on full empty. Sits on screen row 1 so it stacks above the existing `‹ behind ›` rear-warning on row 2.
 
 ## [0.2.0] - 2026-05-22
 

--- a/src/modules/io/render.phel
+++ b/src/modules/io/render.phel
@@ -818,6 +818,31 @@
       (buf-push parts (str "\e[2;" col "H" label))))
   parts)
 
+(defn- paint-low-ammo
+  "Top-row pulsing 'LOW AMMO N' label when total firepower
+   (mag + reserve) drops to 3 or fewer rounds — i.e. the player is
+   3/2/1 shots away from being defenceless. Right-anchored on row 1
+   so it sits next to the centre compass without overdrawing it,
+   one row ABOVE paint-rear-warning's row-2 strip.
+
+   Row 1 layout the player sees:
+     [hearts/armor at col 1]  ... [compass at vw/2 ± 5]  ... [LOW AMMO right]
+
+   Amber at 3, bright red at 1. Suppressed at 0 because the ammo
+   HUD cell already flashes red when both mag and reserve hit zero."
+  [parts ^float t stats vw]
+  (let [total (php/+ (or (get stats :mag) 0)
+                     (or (get stats :ammo-reserve) 0))]
+    (when (and (php/> total 0) (php/<= total 3) (pulse t 4.0))
+      (let [colour (cond (php/<= total 1) "38;5;196"
+                         :else            "38;5;214")
+            label  (str "\e[40;" colour ";1m! LOW AMMO " total " !\e[0m")
+            ;; 14 visible chars in the label; right-anchor with a
+            ;; 1-cell breathing margin so it can't bleed past vw.
+            col    (php/max 1 (php/- vw 15))]
+        (buf-push parts (str "\e[1;" col "H" label))))
+    parts))
+
 (defn- paint-flicker
   "Lights-flickering overlay: paint full-width dark scanlines on every
    other row while :flicker-active-secs is positive. The eye reads the
@@ -1579,11 +1604,12 @@
             p11         (paint-kill-streak        p10 stats map-col map-row visible-mh)
             p12         (paint-compass            p11 world vw)
             p13         (paint-rear-warning       p12 t stats vw)
-            p14         (paint-hearts-hud         p13 t stats bloody?)
-            p15         (paint-pistol-hud         p14 stats vw vh floor-gradient)]
+            p14         (paint-low-ammo           p13 t stats vw)
+            p15         (paint-hearts-hud         p14 t stats bloody?)
+            p16         (paint-pistol-hud         p15 stats vw vh floor-gradient)]
         (when (get stats :paused)
-          (buf-push p15 (pause-menu-string vw vh (get stats :sound-on))))
-        (php/implode "" p15)))))
+          (buf-push p16 (pause-menu-string vw vh (get stats :sound-on))))
+        (php/implode "" p16)))))
 
 (defn clear-screen
   "ANSI clear + cursor home."


### PR DESCRIPTION
## 📚 Description

PR 3/3 of the ammo overhaul — **closes #5**. Final piece: a pulsing top-row warning when the player is 3/2/1 shots from being defenceless.

PR1 #20 added the finite reserve. PR2 #21 added world ammo-boxes. This PR adds the early-warning signal so the player knows to hunt for boxes before they're cornered with an empty gun.

## 🔖 Changes

- New `paint-low-ammo` helper. Trigger: `(:mag + :ammo-reserve) <= 3 && > 0`.
- Right-anchored on **row 1** so it stacks above `paint-rear-warning` on row 2 without colliding with the centre compass.
- Pulse 4 rad/s (rear is 3 rad/s, hearts-bloody is 8 rad/s) — distinct frequencies form a clear urgency hierarchy.
- Amber `38;5;214` at total ≤ 3; bright red `38;5;196` at total ≤ 1. Suppressed at 0 (the HUD ammo cell already flashes red — double-warning would be noise).
- Paint chain extended p15 → p16; hearts-hud + pistol-hud renumbered with preserved arg orders.

## Row 1 layout

```
[hearts/armor at col 1] ... [compass at vw/2 ± 5] ... [LOW AMMO right]
```

Docstring documents this so the next person touching HUD layout sees the constraint.

## ✅ Verification

- `composer ci` → 0 lint, 333 tests pass.
- `clean-code-reviewer`: flagged a row-1 collision with the compass (blocker, fixed before push); approved trigger logic, chain order, naming, and IO boundary.

Closes #5.