### PR TITLE
feat(combat): random loot drop on enemy kill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 **Enemies**
 
 - Per-level HP: L1 imp 1, L2 demon 2, L3 caco 3, L4 baron 4, L5 cyber 5. Body shades darker as HP drops; a yellow HP digit floats above the head 1.2s after each hit. Distinct `:wound` sfx so "I hit them" sounds different from "they hit me".
+- Kill loot drops: every kill rolls for a pickup (30% ammo box, 15% armor, 5% heart when not at max lives, 50% nothing). Drops land on the corpse cell and feed the existing `pickup-*` helpers / minimap markers.
 
 **HUD + map**
 

--- a/docs/combat.md
+++ b/docs/combat.md
@@ -46,6 +46,19 @@ A trigger pull on an empty mag with no other gate active routes through `empty-t
 
 Fresh runs start with `:ammo-reserve 30` (three full mags); the cap is `max-reserve` (50). Ammo-box pickups on the map top the reserve back up (see [`level-system.md`](level-system.md)).
 
+## Kill loot drops
+
+On every kill `on-shot-hit` rolls a uniform float and routes through `roll-loot-kind`:
+
+| Band | Drop | Notes |
+|------|------|-------|
+| `[0.00, 0.30)` | `:ammo` (`+10` reserve) | Most common — players burn rounds faster than anything else |
+| `[0.30, 0.45)` | `:armor` (absorb one hit) | Mid — useful but not as scarce as health |
+| `[0.45, 0.50)` | `:heart` (`+1` life) | Rarest, AND suppressed when `lives = max-lives` so it never wastes |
+| `[0.50, 1.00)` | nothing | ~half of kills drop nothing; keeps the floor uncluttered |
+
+The drop is pushed into the same `:hearts` / `:armors` / `:ammo-boxes` vectors that level-start pickups use, so the existing `pickup-*` helpers in `play.phel` and the minimap markers in `render.phel` need no special case for kill loot vs starting loot.
+
 ## Shooting
 
 ```phel

--- a/src/modules/core/combat.phel
+++ b/src/modules/core/combat.phel
@@ -2,6 +2,7 @@
   (:require phel-doom.modules.core.engine  :refer [cast-ray])
   (:require phel-doom.modules.core.enemy   :refer [shoot])
   (:require phel-doom.modules.core.physics :refer [try-move])
+  (:require phel-doom.modules.core.state   :refer [max-lives])
   (:require phel-doom.modules.io.sound   :refer [play-sfx!]))
 
 ;; ---------------------------------------------------------------------
@@ -266,6 +267,48 @@
             (conj (or fx [])
                   {:x (:x hit-pos) :y (:y hit-pos) :ttl fx-ttl-seconds}))))
 
+(def loot-drop-chance
+  "Probability cutoffs for a kill drop, layered on a single uniform roll
+   in [0, 1). Lower bound exclusive, upper bound inclusive of the
+   cumulative range. Ammo dominates (most common need); armor mid;
+   heart only when it would actually heal (lives < cap), so it's also
+   the rarest. The 0.50 ceiling means roughly half of kills drop
+   nothing — keeps the floor uncluttered and the drops feeling
+   earned."
+  {:ammo  0.30          ; 0.00 .. 0.30
+   :armor 0.45          ; 0.30 .. 0.45
+   :heart 0.50})        ; 0.45 .. 0.50 (gated by lives < max-lives)
+
+(defn roll-loot-kind
+  "Decide which pickup (if any) drops on the current kill. nil = no
+   drop. `roll` is a uniform float in [0, 1) supplied by the caller
+   so tests can pin the outcome."
+  {:export true}
+  [world ^float roll]
+  (cond
+    (php/< roll (:ammo  loot-drop-chance)) :ammo
+    (php/< roll (:armor loot-drop-chance)) :armor
+    (and (php/< roll (:heart loot-drop-chance))
+         (php/< (or (:lives world) 0) max-lives)) :heart
+    :else nil))
+
+(defn- push-pickup [world key hit-pos]
+  (update world key
+          (fn [xs] (conj (or xs []) {:x (:x hit-pos) :y (:y hit-pos)}))))
+
+(defn- push-kill-loot
+  "Possibly drop a pickup at the enemy's death position. Random number
+   pulled from mt_rand here so the caller stays a one-liner; tests
+   exercise the cut-points via `roll-loot-kind` directly."
+  [world hit-pos]
+  (let [roll (php// (php/mt_rand) (php/mt_getrandmax))
+        kind (roll-loot-kind world roll)]
+    (cond
+      (php/=== kind :ammo)  (push-pickup world :ammo-boxes hit-pos)
+      (php/=== kind :armor) (push-pickup world :armors     hit-pos)
+      (php/=== kind :heart) (push-pickup world :hearts     hit-pos)
+      :else                 world)))
+
 (defn- on-shot-hit
   "World update on a successful hit. enemy/shoot has already decremented
    `:lives` and (when the pool emptied) flipped `:alive false` and
@@ -276,16 +319,19 @@
    shot that drops the enemy. Streak chains while `:streak-secs` is
    still ticking from the previous kill; otherwise it restarts at 1."
   [world enemies-after hit-pos idx]
-  (let [killed? (false? (:alive (get enemies-after idx)))
-        chain?  (php/> (or (:streak-secs world) 0.0) 0.0)
-        streak' (if chain? (php/+ (or (:streak world) 0) 1) 1)
-        scored  (if killed?
-                  (assoc (update (assoc world :enemies enemies-after)
-                                 :kills (fn [k] (php/+ k 1)))
-                         :streak      streak'
-                         :streak-secs streak-window-seconds)
-                  (assoc world :enemies enemies-after))]
-    (push-blood-fx (assoc scored :fire-anim fire-anim-seconds) hit-pos)))
+  (let [killed?   (false? (:alive (get enemies-after idx)))
+        chain?    (php/> (or (:streak-secs world) 0.0) 0.0)
+        streak'   (if chain? (php/+ (or (:streak world) 0) 1) 1)
+        scored    (if killed?
+                    (assoc (update (assoc world :enemies enemies-after)
+                                   :kills (fn [k] (php/+ k 1)))
+                           :streak      streak'
+                           :streak-secs streak-window-seconds)
+                    (assoc world :enemies enemies-after))
+        ;; Kill drops a random pickup at the corpse's cell. Wounds
+        ;; don't drop — the kill is the reward trigger.
+        with-loot (if killed? (push-kill-loot scored hit-pos) scored)]
+    (push-blood-fx (assoc with-loot :fire-anim fire-anim-seconds) hit-pos)))
 
 (defn- on-shot-miss [world]
   (assoc world :fire-anim fire-anim-seconds))

--- a/tests/modules/core/combat-test.phel
+++ b/tests/modules/core/combat-test.phel
@@ -2,7 +2,7 @@
   (:require phel.test :refer [deftest is])
   (:require phel-doom.modules.core.state :refer [new-world new-player])
   (:require phel-doom.modules.core.combat
-            :refer [closest-attacker attacker-side can-fire? apply-heat empty-click-seconds knockback mag-size reload reloading? tick-shooting]))
+            :refer [closest-attacker attacker-side can-fire? apply-heat empty-click-seconds knockback mag-size reload reloading? roll-loot-kind tick-shooting]))
 
 ;; ---------------------------------------------------------------------
 ;; closest-attacker: selection rule.
@@ -243,3 +243,29 @@
   (let [w (knockback open-arena {:x 3.5 :y 3.5})]
     (is (= 3.5 (:x (:player w))))
     (is (= 3.5 (:y (:player w))))))
+
+;; ---------------------------------------------------------------------
+;; roll-loot-kind: deterministic cut-points for the kill drop roll.
+;; ammo 0.00..0.30, armor 0.30..0.45, heart 0.45..0.50 (gated by
+;; lives < max-lives), nothing 0.50..1.0.
+;; ---------------------------------------------------------------------
+
+(deftest test-roll-loot-kind-ammo-band
+  (is (= :ammo (roll-loot-kind {:lives 3} 0.0)))
+  (is (= :ammo (roll-loot-kind {:lives 3} 0.29))))
+
+(deftest test-roll-loot-kind-armor-band
+  (is (= :armor (roll-loot-kind {:lives 3} 0.30)))
+  (is (= :armor (roll-loot-kind {:lives 3} 0.44))))
+
+(deftest test-roll-loot-kind-heart-band-when-not-full
+  (is (= :heart (roll-loot-kind {:lives 3} 0.45)))
+  (is (= :heart (roll-loot-kind {:lives 4} 0.49))))
+
+(deftest test-roll-loot-kind-heart-band-suppressed-at-full-lives
+  ;; lives == max-lives (5) -> heart would be wasted, drop nothing.
+  (is (= nil (roll-loot-kind {:lives 5} 0.45))))
+
+(deftest test-roll-loot-kind-nothing-band
+  (is (= nil (roll-loot-kind {:lives 3} 0.50)))
+  (is (= nil (roll-loot-kind {:lives 3} 0.99))))


### PR DESCRIPTION
Every kill rolls for a pickup, DOOM-ish weights.

| Band | Drop | Notes |
|------|------|-------|
| 0.00..0.30 | :ammo (+10 reserve) | most common — players burn rounds fastest |
| 0.30..0.45 | :armor (absorb one hit) | mid |
| 0.45..0.50 | :heart (+1 life) | gated by lives < max-lives |
| 0.50..1.00 | nothing | ~half of kills |

Drops push into the existing :hearts/:armors/:ammo-boxes vectors so pickup helpers + minimap markers get them for free.

5 new tests pin each band edge. composer ci green (369 tests).

Closes task PR10.