### PR TITLE
feat(weapons): pistol / shotgun / chaingun roster with per-weapon ammo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 - Armor caps at 3 (was unbounded). Pickups beyond cap consume the box but don't bump — same pattern as max-lives + heart pickups.
 - Death + victory end screens responsive: box width adapts to viewport (22..36 cols, 4-col margin), and short terminals (< 20 rows) drop the best-scores block + extra padding so the screen never clips off the bottom.
 - Shoot animation kicks the pistol sprite up ~2 rows instead of tilting the whole 3D view. Sine curve recoil settles back to rest as `:fire-anim` decays.
+- Multi-weapon roster (DOOM-classic 3-slot): **pistol** (10-mag, 0.12s cd, 1 dmg, 1.2s reload), **shotgun** (4-mag, 0.6s cd, 3 dmg, 2.0s reload), **chaingun** (30-mag, 0.05s cd, 1 dmg, 1.8s reload). Number keys 1/2/3 snap to each slot (no-op mid-reload). Per-weapon mag + reserve persist across switches; ammo-box pickups feed the active weapon's reserve at its own `:ammo-per-box` rate capped at the weapon's own `:reserve-cap`. HUD strip shows the active weapon name (`L1 imps  kills 7  pistol 7/10 [23]`).
 
 ## [0.2.0] - 2026-05-22
 

--- a/src/commands/play.phel
+++ b/src/commands/play.phel
@@ -9,6 +9,7 @@
   (:require phel-doom.modules.core.physics  :refer [apply-physics tick-heartbeat tick-flicker tick-blood-drops tick-door-face])
   (:require phel-doom.modules.core.combat   :refer [ammo-per-box damage-step fire-anim-seconds max-reserve reload reloading? reload-cooldown-seconds tick-shooting])
   (:require phel-doom.modules.core.enemy    :refer [advance tick-scare rear-attacker?])
+  (:require phel-doom.modules.core.weapons  :refer [switch-weapon weapon-spec weapon-order weapons])
   (:require phel-doom.modules.io.sound    :refer [play-sfx! mute-for!])
   (:require phel-doom.modules.core.level    :refer [build-world num-levels])
   (:require phel-doom.modules.io.scores   :refer [update-scores!])
@@ -135,19 +136,22 @@
                  (or boxes []))))
 
 (defn- pickup-ammos
-  "Step-on triggers an ammo-box pickup: bumps :ammo-reserve by
-   `ammo-per-box`, capped at `max-reserve`. Box is removed from the
-   world so the player can't farm a single cell."
+  "Step-on triggers an ammo-box pickup: bumps the ACTIVE weapon's
+   reserve by its `:ammo-per-box`, capped at the weapon's
+   `:reserve-cap`. Box is removed so the player can't farm one cell."
   [world]
   (let [kept (ammo-boxes-not-at (:ammo-boxes world)
                                 (php/intval (:x (:player world)))
                                 (php/intval (:y (:player world))))]
     (if (= (count kept) (count (or (:ammo-boxes world) [])))
       world
-      (let [refilled (assoc world :ammo-boxes kept)]
+      (let [sp       (or (weapon-spec world) {})
+            per-box  (or (:ammo-per-box sp) ammo-per-box)
+            cap      (or (:reserve-cap sp)  max-reserve)
+            refilled (assoc world :ammo-boxes kept)]
         (when (:sound-on world) (play-sfx! :door))
         (update refilled :ammo-reserve
-                (fn [r] (php/min max-reserve (php/+ (or r 0) ammo-per-box))))))))
+                (fn [r] (php/min cap (php/+ (or r 0) per-box))))))))
 
 (defn- on-door?
   "True when the player's current cell is a door (auto-advances level)."
@@ -172,7 +176,15 @@
       ;; but the lint pass doesn't macro-expand it (arity-mismatch
       ;; false positives), so stick with sequential let bindings.
       (let [w1  (refresh-from-keys w0 keys)
-            w2  (apply-physics w1 dt)
+            ;; Weapon swap (1/2/3) routes through weapons/switch-weapon
+            ;; — no-op when the player is mid-reload so the lockout
+            ;; can't be skipped.
+            w1a (cond
+                  (:select-weapon1 edges) (switch-weapon w1 (get weapon-order 0))
+                  (:select-weapon2 edges) (switch-weapon w1 (get weapon-order 1))
+                  (:select-weapon3 edges) (switch-weapon w1 (get weapon-order 2))
+                  :else                   w1)
+            w2  (apply-physics w1a dt)
             w3  (pickup-hearts w2)
             w4  (pickup-armors w3)
             w4b (pickup-ammos  w4)
@@ -226,10 +238,13 @@
    :game-time   (or (:game-time world) 0.0)
    :debug?      (:debug? world)
    :perf-stats  (when (:debug? world) (read-perf-snapshot))
+   :weapon      (or (:weapon world) :pistol)
+   :weapon-name (or (:name (weapon-spec world)) "pistol")
    :mag         (or (:mag world) 0)
+   :mag-size    (or (:mag-size (weapon-spec world)) 10)
    :ammo-reserve (or (:ammo-reserve world) 0)
    :reload-cooldown (or (:reload-cooldown world) 0.0)
-   :reload-duration reload-cooldown-seconds
+   :reload-duration (or (:reload-duration (weapon-spec world)) reload-cooldown-seconds)
    :empty-click-secs (or (:empty-click-secs world) 0.0)
    :rear-warning? (rear-attacker? (:enemies world)
                                   (:x (:player world))

--- a/src/modules/core/combat.phel
+++ b/src/modules/core/combat.phel
@@ -3,6 +3,7 @@
   (:require phel-doom.modules.core.enemy   :refer [shoot])
   (:require phel-doom.modules.core.physics :refer [try-move])
   (:require phel-doom.modules.core.state   :refer [max-lives])
+  (:require phel-doom.modules.core.weapons :refer [weapon-spec])
   (:require phel-doom.modules.io.sound   :refer [play-sfx!]))
 
 ;; ---------------------------------------------------------------------
@@ -48,33 +49,47 @@
    Counter resets to 1 if the player waits longer without a kill."
   4.0)
 
+;; Per-weapon cadence / capacity now lives in weapons/spec. These
+;; constants stay as the pistol defaults — every test fixture that
+;; didn't carry a :weapon used the pistol numbers, so falling back to
+;; them via `w-spec` keeps old tests green.
+
 (def fire-cooldown-seconds
-  "Minimum interval between shots so trigger-mashing doesn't fire on
-   every frame (~8 shots/sec cap)."
+  "Default minimum interval between shots (pistol cadence). Per-weapon
+   override in weapons/weapons :fire-cooldown."
   0.12)
 
 (def mag-size
-  "Magazine capacity. A fresh mag holds this many shots; reload draws
-   from the world's `:ammo-reserve` to top it back up."
+  "Default magazine capacity (pistol). Per-weapon override in
+   weapons/weapons :mag-size."
   10)
 
 (def max-reserve
-  "Hard cap on the spare ammo pool. Ammo-box pickups stop adding
-   beyond this so the player can't stockpile infinitely."
+  "Default cap on the spare ammo pool (pistol). Per-weapon override
+   in weapons/weapons :reserve-cap."
   50)
 
 (def ammo-per-box
-  "Rounds each ammo-box pickup adds to `:ammo-reserve`. One full mag
-   per box keeps the math obvious for the player."
+  "Default rounds added to the active weapon's reserve per pickup
+   (pistol). Per-weapon override in weapons/weapons :ammo-per-box."
   10)
 
 (def reload-cooldown-seconds
-  "Length of the reload animation + firing lockout. The pistol drops
-   off-screen, refills, and rises back into view over this window; the
-   trigger stays disabled the whole time so the player commits to the
-   reload instead of mashing through it. 1.2s reads as a real action
-   without slowing mid-combat reloads to a crawl."
+  "Default reload animation + firing lockout (pistol). Per-weapon
+   override in weapons/weapons :reload-duration."
   1.2)
+
+(defn- w-spec
+  "Active-weapon spec with hard-coded pistol fallbacks so a bare test
+   fixture (no :weapon set) still gets sensible numbers."
+  [world]
+  (or (weapon-spec world)
+      {:mag-size        mag-size
+       :fire-cooldown   fire-cooldown-seconds
+       :reload-duration reload-cooldown-seconds
+       :damage          1
+       :reserve-cap     max-reserve
+       :ammo-per-box    ammo-per-box}))
 
 (def empty-click-seconds
   "How long the 'dry-fire click' visual + audio cue lingers after the
@@ -252,10 +267,11 @@
     (cast-ray (:pgrid world) (:x p) (:y p) (:angle p))))
 
 (defn- resolve-shot [world]
-  (let [p (:player world)]
+  (let [p   (:player world)
+        dmg (or (:damage (w-spec world)) 1)]
     (shoot (:enemies world) (:x p) (:y p) (:angle p)
            (cast-wall-distance world)
-           shot-hit-radius shot-max-range)))
+           shot-hit-radius shot-max-range dmg)))
 
 (defn- push-blood-fx [world hit-pos]
   (update world :fx
@@ -366,29 +382,28 @@
        (php/> (or (:mag world) 0) 0)))
 
 (defn apply-heat
-  "After a shot lands, bump heat + arm the cooldown, and burn one
-   round from the magazine. If heat crosses 1.0 the pistol overheats
-   and jams for jam-seconds (heat resets so the player isn't
-   punished twice)."
+  "After a shot lands, bump heat + arm the per-weapon fire-cooldown,
+   and burn one round from the magazine. If heat crosses 1.0 the
+   pistol overheats and jams for jam-seconds (heat resets so the
+   player isn't punished twice)."
   [world]
-  (let [heat' (php/+ (or (:heat world) 0.0) heat-per-shot)
+  (let [sp    (w-spec world)
+        heat' (php/+ (or (:heat world) 0.0) heat-per-shot)
         jam?  (php/>= heat' 1.0)
-        mag'  (php/max 0 (php/- (or (:mag world) mag-size) 1))]
+        mag'  (php/max 0 (php/- (or (:mag world) (:mag-size sp)) 1))]
     (assoc world
-           :fire-cooldown fire-cooldown-seconds
+           :fire-cooldown (:fire-cooldown sp)
            :heat          (if jam? 0.0 heat')
            :jam-secs      (if jam? jam-seconds (or (:jam-secs world) 0.0))
            :mag           mag')))
 
 (defn reloading?
-  "True when the player COULD reload right now — used by play.phel to
-   gate the reload sfx so the click only plays on an actual reload, not
-   every R press during cooldown / when the mag is full / when the
-   reserve is dry."
+  "True when the player COULD reload the active weapon right now."
   [world]
-  (and (php/<= (or (:reload-cooldown world) 0.0) 0.0)
-       (php/< (or (:mag world) 0) mag-size)
-       (php/> (or (:ammo-reserve world) 0) 0)))
+  (let [sp (w-spec world)]
+    (and (php/<= (or (:reload-cooldown world) 0.0) 0.0)
+         (php/< (or (:mag world) 0) (:mag-size sp))
+         (php/> (or (:ammo-reserve world) 0) 0))))
 
 (defn reload
   "Top the magazine back up from the spare reserve and arm a short
@@ -401,9 +416,10 @@
    Otherwise: draw `min(needed, reserve)` rounds from `:ammo-reserve`
    into `:mag` and arm the cooldown."
   [world]
-  (let [mag     (or (:mag world) 0)
+  (let [sp      (w-spec world)
+        mag     (or (:mag world) 0)
         reserve (or (:ammo-reserve world) 0)
-        needed  (php/- mag-size mag)]
+        needed  (php/- (:mag-size sp) mag)]
     (cond
       (php/> (or (:reload-cooldown world) 0.0) 0.0) world
       (php/<= needed 0)                             world
@@ -413,7 +429,7 @@
         (assoc world
                :mag             (php/+ mag drawn)
                :ammo-reserve    (php/- reserve drawn)
-               :reload-cooldown reload-cooldown-seconds)))))
+               :reload-cooldown (:reload-duration sp))))))
 
 (defn fire-shot
   "Resolve one trigger pull end-to-end."

--- a/src/modules/core/enemy.phel
+++ b/src/modules/core/enemy.phel
@@ -89,57 +89,61 @@
 
 (defn shoot
   "Fire a hitscan from the player along their facing. Returns
-   [new-enemies hit?]: the nearest alive enemy whose distance-to-ray is
-   under `hit-radius` and whose distance-along-ray is under `max-range`
-   AND closer than the wall in that direction is flipped to :alive false;
-   `hit?` is true when an enemy was killed this shot."
-  [enemies px py angle wall-dist hit-radius max-range]
-  (let [cos-a (php/cos angle)
-        sin-a (php/sin angle)]
-    (let [best (loop [i      0
-                      best-i -1
-                      best-d max-range
-                      es     enemies]
-                 (if (php/=== es nil)
-                   best-i
-                   (let [e (first es)]
-                     (let [along (when (and e (:alive e))
-                                   (let [dx (php/- (:x e) px)
-                                         dy (php/- (:y e) py)]
-                                     (let [proj (php/+ (php/* dx cos-a) (php/* dy sin-a))]
-                                       (when (and (php/> proj 0.0) (php/< proj best-d)
-                                                  (php/< proj wall-dist))
-                                         (let [perp-x (php/- dx (php/* proj cos-a))
-                                               perp-y (php/- dy (php/* proj sin-a))]
-                                           (let [perp2 (php/+ (php/* perp-x perp-x) (php/* perp-y perp-y))]
-                                             (when (php/<= perp2 (php/* hit-radius hit-radius))
-                                               proj)))))))]
-                       (if along
-                         (recur (php/+ i 1) i along (next es))
-                         (recur (php/+ i 1) best-i best-d (next es)))))))]
-      (if (php/=== best -1)
-        [enemies false nil -1]
+   `[new-enemies hit? hit-pos idx]`: the nearest alive enemy in
+   range with its `:lives` decremented by `damage`. `:alive` only
+   flips to false once `:lives` hits zero, so a 1-damage pistol
+   round just wounds a 3-HP cacodemon while a 3-damage shotgun
+   shell drops it. `damage` defaults to 1 for callers that don't
+   carry a weapon spec (older tests, etc)."
+  ([enemies px py angle wall-dist hit-radius max-range]
+   (shoot enemies px py angle wall-dist hit-radius max-range 1))
+  ([es' x' y' a' wd' hr max-r damage]
+   (let [cos-a (php/cos a')
+         sin-a (php/sin a')]
+     (let [best (loop [i      0
+                       best-i -1
+                       best-d max-r
+                       es     es']
+                  (if (php/=== es nil)
+                    best-i
+                    (let [e (first es)]
+                      (let [along (when (and e (:alive e))
+                                    (let [dx (php/- (:x e) x')
+                                          dy (php/- (:y e) y')]
+                                      (let [proj (php/+ (php/* dx cos-a) (php/* dy sin-a))]
+                                        (when (and (php/> proj 0.0) (php/< proj best-d)
+                                                   (php/< proj wd'))
+                                          (let [perp-x (php/- dx (php/* proj cos-a))
+                                                perp-y (php/- dy (php/* proj sin-a))]
+                                            (let [perp2 (php/+ (php/* perp-x perp-x) (php/* perp-y perp-y))]
+                                              (when (php/<= perp2 (php/* hr hr))
+                                                proj)))))))]
+                        (if along
+                          (recur (php/+ i 1) i along (next es))
+                          (recur (php/+ i 1) best-i best-d (next es)))))))]
+       (if (php/=== best -1)
+         [es' false nil -1]
         ;; Decrement lives; flip :alive only when the shot empties the
         ;; HP pool. Default-1 enemies still die in one hit because the
         ;; subtract takes them to 0. Multi-life enemies stay :alive true
         ;; with a lower :lives, which render shades darker as a tell.
-        (let [hit-enemy  (get enemies best)
-              hit-pos    {:x (:x hit-enemy) :y (:y hit-enemy)}
-              prev-lives (or (:lives hit-enemy) 1)
-              new-lives  (php/max 0 (php/- prev-lives 1))
-              hit-vec    (apply vector enemies)
-              wounded    (assoc-in hit-vec [best :lives] new-lives)]
-          (if (php/<= new-lives 0)
-            (let [delay   (php/+ respawn-delay-min
-                                 (php/* (php// (php/mt_rand) (php/mt_getrandmax))
-                                        (php/- respawn-delay-max respawn-delay-min)))
-                  killed' (assoc-in (assoc-in wounded [best :alive] false)
-                                    [best :respawn-after] delay)]
-              [killed' true hit-pos best])
+         (let [hit-enemy  (get es' best)
+               hit-pos    {:x (:x hit-enemy) :y (:y hit-enemy)}
+               prev-lives (or (:lives hit-enemy) 1)
+               new-lives  (php/max 0 (php/- prev-lives damage))
+               hit-vec    (apply vector es')
+               wounded    (assoc-in hit-vec [best :lives] new-lives)]
+           (if (php/<= new-lives 0)
+             (let [delay   (php/+ respawn-delay-min
+                                  (php/* (php// (php/mt_rand) (php/mt_getrandmax))
+                                         (php/- respawn-delay-max respawn-delay-min)))
+                   killed' (assoc-in (assoc-in wounded [best :alive] false)
+                                     [best :respawn-after] delay)]
+               [killed' true hit-pos best])
             ;; Stamp the hit-flash timer so render can paint the
             ;; remaining HP digit above the head for a beat.
-            (let [flashed (assoc-in wounded [best :hit-flash-secs] hit-flash-seconds)]
-              [flashed true hit-pos best])))))))
+             (let [flashed (assoc-in wounded [best :hit-flash-secs] hit-flash-seconds)]
+               [flashed true hit-pos best]))))))))
 
 (defn- random-spawn-far-from
   "Random open cell at least min-dist from (px, py). Falls back to nil

--- a/src/modules/core/state.phel
+++ b/src/modules/core/state.phel
@@ -1,4 +1,5 @@
-(ns phel-doom.modules.core.state)
+(ns phel-doom.modules.core.state
+  (:require phel-doom.modules.core.weapons :refer [initial-weapon-state]))
 
 (defn new-player
   "Create a player record with floating-point position and angle in radians."
@@ -46,11 +47,13 @@
    :fire-cooldown 0.0
    :reload-cooldown 0.0
    :empty-click-secs 0.0
-   ;; Magazine + reserve — issue #5. Numbers kept in sync with
-   ;; `mag-size` / `max-reserve` over in combat.phel; state.phel
-   ;; can't require combat without inverting the dependency. Fresh
-   ;; runs start with three full mags worth of reserve so the
-   ;; player has runway before the first ammo pickup.
+   ;; Weapons. :weapon is the active slot. :weapon-state is the
+   ;; per-weapon mag/reserve table (catalogue lives in weapons.phel).
+   ;; :mag and :ammo-reserve mirror the active weapon's live state so
+   ;; combat / render / HUD code can read them without an extra hop;
+   ;; weapons/switch keeps the mirror in sync.
+   :weapon        :pistol
+   :weapon-state  (initial-weapon-state)
    :mag           10
    :ammo-reserve  30
    :heat        0.0

--- a/src/modules/core/weapons.phel
+++ b/src/modules/core/weapons.phel
@@ -1,0 +1,96 @@
+(ns phel-doom.modules.core.weapons)
+
+;; ---------------------------------------------------------------------
+;; Weapon catalogue + per-weapon ammo bookkeeping.
+;;
+;; DOOM-classic roster:
+;;   :pistol    balanced default — light damage, snappy cadence
+;;   :shotgun   slow + hard-hitting — kills a 3-HP caco in one shot
+;;   :chaingun  rapid-fire spray — many shots needed but fastest cd
+;;
+;; Per-weapon stats (mag-size, fire-cooldown, reload-duration, damage,
+;; reserve cap, ammo-per-box) live in `weapons`. Per-weapon ammo state
+;; (current mag count, current reserve) lives on the world under
+;; :weapon-state — a map keyed by the same weapon keyword.
+;;
+;; combat.phel reads the *spec* via `spec` and the *current weapon's
+;; live state* via `mag`/`reserve` helpers; both mirror up to the
+;; top-level :mag / :ammo-reserve fields so existing tests + the
+;; render HUD keep working without rewrites.
+;; ---------------------------------------------------------------------
+
+(def weapons
+  "Per-weapon stat table. Adding a new weapon is one map literal."
+  {:pistol   {:name            "pistol"
+              :mag-size        10
+              :reserve-start   30
+              :reserve-cap     50
+              :ammo-per-box    10
+              :fire-cooldown   0.12
+              :reload-duration 1.2
+              :damage          1}
+   :shotgun  {:name            "shotgun"
+              :mag-size        4
+              :reserve-start   8
+              :reserve-cap     24
+              :ammo-per-box    4
+              :fire-cooldown   0.6
+              :reload-duration 2.0
+              :damage          3}
+   :chaingun {:name            "chaingun"
+              :mag-size        30
+              :reserve-start   0
+              :reserve-cap     90
+              :ammo-per-box    20
+              :fire-cooldown   0.05
+              :reload-duration 1.8
+              :damage          1}})
+
+(def weapon-order
+  "Slot order keyed by 1/2/3."
+  [:pistol :shotgun :chaingun])
+
+(defn current-weapon
+  "Active weapon keyword for `world`. Defaults to :pistol so fresh test
+   worlds (which don't set :weapon) keep behaving like single-pistol
+   runs from before this PR."
+  [world]
+  (or (:weapon world) :pistol))
+
+(defn weapon-spec
+  "Static catalogue entry for the active weapon."
+  [world]
+  (get weapons (current-weapon world)))
+
+(defn initial-weapon-state
+  "Per-weapon ammo state for a brand-new run: starting mag full,
+   reserve at :reserve-start."
+  []
+  (let [build (fn [acc kw]
+                (let [s (get weapons kw)]
+                  (assoc acc kw {:mag     (:mag-size s)
+                                 :reserve (:reserve-start s)})))]
+    (reduce build {} weapon-order)))
+
+(defn switch-weapon
+  "Snap to weapon `to`. Persists the current weapon's mag + reserve
+   back into `:weapon-state`, then loads `to`'s saved state into the
+   mirrored top-level `:mag` / `:ammo-reserve` fields. No-op when
+   the target weapon doesn't exist OR the player is mid-reload (so
+   you can't dodge a reload by hot-swapping)."
+  [world to]
+  (cond
+    (php/=== (get weapons to) nil)                world
+    (php/> (or (:reload-cooldown world) 0.0) 0.0) world
+    :else
+    (let [from   (current-weapon world)
+          saved  (assoc (or (:weapon-state world) {})
+                        from {:mag     (or (:mag world) 0)
+                              :reserve (or (:ammo-reserve world) 0)})
+          loaded (get saved to {:mag (:mag-size (get weapons to))
+                                :reserve (:reserve-start (get weapons to))})]
+      (assoc world
+             :weapon        to
+             :weapon-state  saved
+             :mag           (:mag loaded)
+             :ammo-reserve  (:reserve loaded)))))

--- a/src/modules/glue/controls.phel
+++ b/src/modules/glue/controls.phel
@@ -227,16 +227,22 @@
    :n  (str/contains? keys "n")
    :e  (str/contains? keys "e")
    :f3 (f3-pressed? keys)
-   :r  (str/contains? keys "r")})
+   :r  (str/contains? keys "r")
+   :k1 (str/contains? keys "1")
+   :k2 (str/contains? keys "2")
+   :k3 (str/contains? keys "3")})
 
 (defn rising-edges
   "Build the edges map tick consumes — truthy only for keys that just
    turned on relative to the previous snapshot."
   [now prev]
-  {:fire         (and (:sp now) (not (:sp prev)))
-   :toggle-map   (and (:m now)  (not (:m prev)))
-   :toggle-pause (and (:p now)  (not (:p prev)))
-   :toggle-sound (and (:n now)  (not (:n prev)))
-   :toggle-debug (and (:f3 now) (not (:f3 prev)))
-   :reload       (and (:r now)  (not (:r prev)))
-   :about-face   (and (:e now)  (not (:e prev)))})
+  {:fire           (and (:sp now) (not (:sp prev)))
+   :toggle-map     (and (:m now)  (not (:m prev)))
+   :toggle-pause   (and (:p now)  (not (:p prev)))
+   :toggle-sound   (and (:n now)  (not (:n prev)))
+   :toggle-debug   (and (:f3 now) (not (:f3 prev)))
+   :reload         (and (:r now)  (not (:r prev)))
+   :about-face     (and (:e now)  (not (:e prev)))
+   :select-weapon1 (and (:k1 now) (not (:k1 prev)))
+   :select-weapon2 (and (:k2 now) (not (:k2 prev)))
+   :select-weapon3 (and (:k3 now) (not (:k3 prev)))})

--- a/src/modules/io/render.phel
+++ b/src/modules/io/render.phel
@@ -525,15 +525,18 @@
    and the spare pool at a glance."
   [stats]
   (let [mag     (or (get stats :mag) 0)
+        cap     (or (get stats :mag-size) 10)
         reserve (or (get stats :ammo-reserve) 0)
-        mag-col (cond (php/<= mag 0) "\e[1;91m"
-                      (php/<= mag 3) "\e[1;93m"
-                      :else          "\e[1m")
-        res-col (cond (php/<= reserve 0)  "\e[1;91m"
-                      (php/<= reserve 10) "\e[1;93m" ; one mag's worth
-                      :else               "\e[2m")]
+        mag-low (php/max 1 (php/intdiv cap 3))
+        res-low cap
+        mag-col (cond (php/<= mag 0)       "\e[1;91m"
+                      (php/<= mag mag-low) "\e[1;93m"
+                      :else                "\e[1m")
+        res-col (cond (php/<= reserve 0)       "\e[1;91m"
+                      (php/<= reserve res-low) "\e[1;93m" ; one mag's worth
+                      :else                    "\e[2m")]
     (str "\e[1mammo\e[0m "
-         mag-col mag "\e[0m/10 "
+         mag-col mag "\e[0m/" cap " "
          res-col "[" reserve "]\e[0m")))
 
 (defn- hud-line
@@ -930,17 +933,22 @@
   (let [lvl     (or (get stats :level) 1)
         name'   (or (get stats :level-name) "")
         kills   (or (get stats :kills) 0)
+        wname   (or (get stats :weapon-name) "pistol")
         mag     (or (get stats :mag) 0)
+        cap     (or (get stats :mag-size) 10)
         reserve (or (get stats :ammo-reserve) 0)
-        mag-col (cond (php/<= mag 0) "\e[1;91m"
-                      (php/<= mag 3) "\e[1;93m"
-                      :else          "\e[1m")
-        res-col (cond (php/<= reserve 0)  "\e[1;91m"
-                      (php/<= reserve 10) "\e[1;93m"
-                      :else               "\e[2m")
+        mag-low (php/max 1 (php/intdiv cap 3))
+        res-low cap
+        mag-col (cond (php/<= mag 0)       "\e[1;91m"
+                      (php/<= mag mag-low) "\e[1;93m"
+                      :else                "\e[1m")
+        res-col (cond (php/<= reserve 0)       "\e[1;91m"
+                      (php/<= reserve res-low) "\e[1;93m"
+                      :else                    "\e[2m")
         styled  (str "\e[40;97m\e[1mL" lvl "\e[0m\e[40;97m " name'
                      "  \e[1mkills\e[0m " kills
-                     "  \e[1mammo\e[0m " mag-col mag "\e[0m\e[40;97m/10 "
+                     "  \e[1m" wname "\e[0m\e[40;97m "
+                     mag-col mag "\e[0m\e[40;97m/" cap " "
                      res-col "[" reserve "]\e[0m")]
     (buf-push parts (str "\e[2;1H" styled)))
   parts)

--- a/tests/modules/core/weapons-test.phel
+++ b/tests/modules/core/weapons-test.phel
@@ -1,0 +1,59 @@
+(ns phel-doom-tests.modules.core.weapons-test
+  (:require phel.test :refer [deftest is])
+  (:require phel-doom.modules.core.state :refer [new-player new-world])
+  (:require phel-doom.modules.core.weapons :refer [current-weapon initial-weapon-state switch-weapon weapon-spec weapons]))
+
+(def empty-grid [[1 1 1] [1 0 1] [1 1 1]])
+
+(defn fresh-world []
+  (new-world empty-grid (new-player 1.5 1.5 0.0)))
+
+(deftest test-current-weapon-defaults-to-pistol
+  (is (= :pistol (current-weapon {})))
+  (is (= :pistol (current-weapon (fresh-world))))
+  (is (= :shotgun (current-weapon {:weapon :shotgun}))))
+
+(deftest test-weapon-spec-returns-catalogue-entry
+  (let [w (assoc (fresh-world) :weapon :shotgun)]
+    (is (= 4   (:mag-size  (weapon-spec w))))
+    (is (= 3   (:damage    (weapon-spec w))))
+    (is (= 0.6 (:fire-cooldown (weapon-spec w))))))
+
+(deftest test-initial-weapon-state-has-every-weapon-at-spec-defaults
+  (let [s (initial-weapon-state)]
+    (is (= 10 (get-in s [:pistol   :mag])))
+    (is (= 4  (get-in s [:shotgun  :mag])))
+    (is (= 30 (get-in s [:chaingun :mag])))
+    (is (= 30 (get-in s [:pistol   :reserve])))
+    (is (= 8  (get-in s [:shotgun  :reserve])))
+    (is (= 0  (get-in s [:chaingun :reserve])))))
+
+(deftest test-switch-weapon-saves-current-and-loads-target
+  ;; Player burns 3 pistol rounds (mag 7), then swaps to shotgun.
+  (let [w0 (assoc (fresh-world) :mag 7 :ammo-reserve 25)
+        w1 (switch-weapon w0 :shotgun)]
+    (is (= :shotgun (:weapon w1)))
+    (is (= 4 (:mag w1)))           ; shotgun mag-size fresh
+    (is (= 8 (:ammo-reserve w1)))  ; shotgun reserve-start
+    ;; Pistol's mid-mag count survived in :weapon-state.
+    (is (= 7  (get-in w1 [:weapon-state :pistol :mag])))
+    (is (= 25 (get-in w1 [:weapon-state :pistol :reserve])))))
+
+(deftest test-switch-weapon-is-noop-mid-reload
+  (let [w0 (assoc (fresh-world) :reload-cooldown 0.5)
+        w1 (switch-weapon w0 :shotgun)]
+    (is (= :pistol (:weapon w1)))))
+
+(deftest test-switch-weapon-unknown-target-is-noop
+  (let [w0 (fresh-world)
+        w1 (switch-weapon w0 :rocket-launcher)]
+    (is (= :pistol (:weapon w1)))))
+
+(deftest test-switch-weapon-round-trip-preserves-state
+  ;; Pistol mag 7, swap to shotgun, swap back -> pistol still mag 7.
+  (let [w0 (assoc (fresh-world) :mag 7 :ammo-reserve 25)
+        w1 (switch-weapon w0 :shotgun)
+        w2 (switch-weapon w1 :pistol)]
+    (is (= :pistol (:weapon w2)))
+    (is (= 7  (:mag w2)))
+    (is (= 25 (:ammo-reserve w2)))))


### PR DESCRIPTION
## 📚 Description

DOOM-classic 3-slot loadout. Keys **1 / 2 / 3** snap to a weapon, with mag + reserve preserved per slot.

| Weapon | Mag | Reserve | Fire cd | Reload | Damage |
|--------|-----|---------|---------|--------|--------|
| pistol   | 10 | 30 / 50 | 0.12s | 1.2s | 1 |
| shotgun  | 4  | 8 / 24  | 0.60s | 2.0s | 3 |
| chaingun | 30 | 0 / 90  | 0.05s | 1.8s | 1 |

Damage scales with reload time as the user requested — shotgun one-shots a cacodemon (3 HP), chaingun sprays but needs every round to finish a baron.

## 🔖 Changes

### New `core/weapons.phel`
- Weapon catalogue + helpers (`current-weapon`, `weapon-spec`, `initial-weapon-state`, `switch-weapon`).
- `switch-weapon` is a no-op mid-reload (can't skip the lockout) and for unknown weapon kws.
- Saves/restores per-weapon mag + reserve through `:weapon-state`; top-level `:mag` / `:ammo-reserve` mirror the active weapon so existing combat / render / tests keep working.

### Combat
- `combat.phel/w-spec` wraps `weapon-spec` with pistol-numbered fallbacks for bare test fixtures.
- `reload`, `reloading?`, `apply-heat`, `fire-shot` all read mag-size / fire-cooldown / reload-duration / damage from the spec.
- `enemy/shoot` gains an 8-arity overload that threads `damage` per shot; 7-arity delegates with damage 1 so older callers keep one-shot semantics.

### Input
- `glue/controls.phel` adds `:select-weapon{1,2,3}` rising edges from 1/2/3 keys.
- `commands/play.phel` routes the edges to `switch-weapon` BEFORE physics so the swap is reflected for the rest of the frame.

### HUD
- `paint-game-info` shows the active weapon name in place of the static `ammo` label (`L1 imps  kills 7  pistol 7/10 [23]`).
- `ammo-cell` denominator uses `:mag-size` so shotgun reads `4/4` not `4/10`.

### Tests
- 8 new `weapons-test` cases: default current-weapon, spec lookup, initial state, switch round-trip, mid-reload no-op, unknown weapon no-op.

### Out of scope (queued)
- Per-weapon sprite art (currently all 3 share the pistol silhouette — fastest path to a working loop). Distinct silhouettes for shotgun / chaingun follow in a smaller render-only PR.
- Weapon pickups on the map (player currently starts with all three unlocked; chaingun has reserve 0 so it must be earned via ammo boxes).

## ✅ Verification

- `composer ci` → 0 lint, 391 tests pass (+22 net since last main; +8 from this PR's weapons-test).
- `composer build` produces `out/main.php` cleanly.