### PR TITLE
feat(combat,level,render): berserk sphere powerup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 - Shoot recoils the pistol sprite up 2 rows (no more screen tilt).
 - Responsive UI: minimap ≤ 1/3 vw on narrow terminals; death + victory boxes auto-size 22–36 cols and drop the best-scores block on short rows.
 - Armor caps at 3.
+- Berserk sphere pickup (rare, ~25% per level). Step on it for 20s of 2× damage on every weapon; rage state shows as a pulsing centred `BERSERK Ns` banner and a red `B` on the minimap.
 
 ## [0.2.0] - 2026-05-22
 

--- a/src/commands/play.phel
+++ b/src/commands/play.phel
@@ -7,7 +7,7 @@
   (:require phel-doom.modules.glue.controls :refer [refresh-from-keys key-states rising-edges
                                                     initial-key-snapshot])
   (:require phel-doom.modules.core.physics  :refer [apply-physics tick-heartbeat tick-flicker tick-blood-drops tick-door-face])
-  (:require phel-doom.modules.core.combat   :refer [ammo-per-box damage-step fire-anim-seconds max-reserve reload reloading? reload-cooldown-seconds tick-shooting])
+  (:require phel-doom.modules.core.combat   :refer [ammo-per-box berserk-seconds damage-step fire-anim-seconds max-reserve reload reloading? reload-cooldown-seconds tick-shooting])
   (:require phel-doom.modules.core.enemy    :refer [advance tick-scare rear-attacker?])
   (:require phel-doom.modules.core.weapons  :refer [switch-weapon weapon-spec weapon-order weapons])
   (:require phel-doom.modules.io.sound    :refer [play-sfx! mute-for!])
@@ -153,6 +153,28 @@
         (update refilled :ammo-reserve
                 (fn [r] (php/min cap (php/+ (or r 0) per-box))))))))
 
+(defn- berserks-not-at [bs px py]
+  (apply vector
+         (filter (fn [b]
+                   (not (and (php/=== (php/intval (:x b)) px)
+                             (php/=== (php/intval (:y b)) py))))
+                 (or bs []))))
+
+(defn- pickup-berserks
+  "Step-on consumes the berserk sphere + arms `:berserk-secs` for the
+   2x-damage rage window. Stacks duration: stepping on a second
+   sphere while still berserk refreshes (not adds)."
+  [world]
+  (let [kept (berserks-not-at (:berserks world)
+                              (php/intval (:x (:player world)))
+                              (php/intval (:y (:player world))))]
+    (if (= (count kept) (count (or (:berserks world) [])))
+      world
+      (do (when (:sound-on world) (play-sfx! :door))
+          (assoc world
+                 :berserks     kept
+                 :berserk-secs berserk-seconds)))))
+
 (defn- on-door?
   "True when the player's current cell is a door (auto-advances level)."
   [world]
@@ -188,7 +210,8 @@
             w3  (pickup-hearts w2)
             w4  (pickup-armors w3)
             w4b (pickup-ammos  w4)
-            w5  (tick-enemies  w4b dt)
+            w4c (pickup-berserks w4b)
+            w5  (tick-enemies  w4c dt)
             w5b (if (:reload edges)
                   (do
                     (when (and (:sound-on w5) (reloading? w5)) (play-sfx! :reload))
@@ -246,6 +269,7 @@
    :reload-cooldown (or (:reload-cooldown world) 0.0)
    :reload-duration (or (:reload-duration (weapon-spec world)) reload-cooldown-seconds)
    :empty-click-secs (or (:empty-click-secs world) 0.0)
+   :berserk-secs (or (:berserk-secs world) 0.0)
    :rear-warning? (rear-attacker? (:enemies world)
                                   (:x (:player world))
                                   (:y (:player world))

--- a/src/modules/core/combat.phel
+++ b/src/modules/core/combat.phel
@@ -98,6 +98,21 @@
    leave it pinned forever."
   0.8)
 
+(def berserk-seconds
+  "Active window of the berserk powerup. While > 0 the player's
+   weapon damage is multiplied by `berserk-damage-mul` and render
+   paints a red rage tint on the viewport."
+  20.0)
+
+(def berserk-damage-mul
+  "Damage multiplier applied to every shot while berserk-secs > 0."
+  2)
+
+(defn berserk?
+  "True while the player's berserk timer is still ticking down."
+  [world]
+  (php/> (or (:berserk-secs world) 0.0) 0.0))
+
 (def heat-per-shot
   "Heat added on each shot. Heat decays continuously; when it crosses
    1.0 the pistol jams. 0.30 = ~4 shots cold-mashed before jam, ~6
@@ -156,6 +171,7 @@
         cooldown'    (php/max 0.0 (php/- (or (:fire-cooldown world) 0.0) dt))
         reload-cd'   (php/max 0.0 (php/- (or (:reload-cooldown world) 0.0) dt))
         click-secs'  (php/max 0.0 (php/- (or (:empty-click-secs world) 0.0) dt))
+        berserk'     (php/max 0.0 (php/- (or (:berserk-secs world) 0.0) dt))
         heat'        (php/max 0.0 (php/- (or (:heat world) 0.0) (php/* heat-cool-rate dt)))
         jam-secs'    (php/max 0.0 (php/- (or (:jam-secs world) 0.0) dt))]
     (assoc world
@@ -167,6 +183,7 @@
            :fire-cooldown   cooldown'
            :reload-cooldown reload-cd'
            :empty-click-secs click-secs'
+           :berserk-secs    berserk'
            :heat            heat'
            :jam-secs        jam-secs'
            ;; Window expired: streak counter goes back to 0 so the HUD
@@ -267,8 +284,9 @@
     (cast-ray (:pgrid world) (:x p) (:y p) (:angle p))))
 
 (defn- resolve-shot [world]
-  (let [p   (:player world)
-        dmg (or (:damage (w-spec world)) 1)]
+  (let [p        (:player world)
+        base-dmg (or (:damage (w-spec world)) 1)
+        dmg      (if (berserk? world) (php/* base-dmg berserk-damage-mul) base-dmg)]
     (shoot (:enemies world) (:x p) (:y p) (:angle p)
            (cast-wall-distance world)
            shot-hit-radius shot-max-range dmg)))

--- a/src/modules/core/level.phel
+++ b/src/modules/core/level.phel
@@ -109,6 +109,16 @@
       [{:x ax :y ay}])
     []))
 
+(defn- maybe-spawn-berserk
+  "Rare berserk sphere — roughly one in four levels. Picked up via
+   `pickup-berserks`; arms `:berserk-secs berserk-seconds` for a
+   2x-damage rage window."
+  [grid]
+  (if (php/=== 0 (mod (rand-int 4) 4))
+    (let [[bx by] (random-spawn grid)]
+      [{:x bx :y by}])
+    []))
+
 (defn- ammo-box-count
   "Per-level ammo-box budget. Scales with the expected shot count
    (`enemies * max-lives`) so bigger maps with tougher monsters get
@@ -168,6 +178,7 @@
                    :lives       lives
                    :hearts      (maybe-spawn-heart grid lives px py)
                    :armors      (maybe-spawn-armor grid)
+                   :berserks    (maybe-spawn-berserk grid)
                    :ammo-boxes  (spawn-ammo-boxes grid (ammo-box-count cfg))
                    :chase-speed (:chase cfg)
                    :enemy-head-code     (:head-code cfg)

--- a/src/modules/core/state.phel
+++ b/src/modules/core/state.phel
@@ -47,6 +47,12 @@
    :fire-cooldown 0.0
    :reload-cooldown 0.0
    :empty-click-secs 0.0
+   ;; Powerup timers. Decayed each frame in combat/decay-timers.
+   ;; While > 0 the buff is active; render samples them for the
+   ;; full-screen tint, combat reads them for damage / vulnerability
+   ;; mods.
+   :berserk-secs    0.0
+   :berserks        []
    ;; Weapons. :weapon is the active slot. :weapon-state is the
    ;; per-weapon mag/reserve table (catalogue lives in weapons.phel).
    ;; :mag and :ammo-reserve mirror the active weapon's live state so

--- a/src/modules/io/render.phel
+++ b/src/modules/io/render.phel
@@ -54,7 +54,8 @@
 ;; on some iTerm2 themes) shows through and washes the overlay out.
 (def enemy-marker "\e[40;91;1mE\e[0m")
 (def heart-marker "\e[40;91;1m♥\e[0m")
-(def ammo-marker  "\e[40;93;1mA\e[0m")
+(def ammo-marker     "\e[40;93;1mA\e[0m")
+(def berserk-marker  "\e[40;91;1mB\e[0m")
 (def door-shade
   "Door body cell drawn when a ray hit a door. Frame glyph `▌` (left
    half block) on a dark steel BG with bright orange FG, so a column
@@ -141,6 +142,23 @@
   "Black ▣ on the yellow pulse BG so the icon flips contrast in tempo
    with the shade swap."
   "\e[48;5;220;38;5;52;1m▣")
+
+(def berserk-shade
+  "Berserk sphere idle BG: dark blood-red so it reads as 'rage' from
+   across the room, distinct from the dim heart red (52)."
+  "\e[48;5;88m ")
+
+(def berserk-shade-bright
+  "Berserk sphere pulse BG: saturated bright red flare."
+  "\e[48;5;196m ")
+
+(def berserk-glyph
+  "Yellow Ω on the dark-red BG — Greek omega reads as a 'fury sigil'."
+  "\e[48;5;88;38;5;226;1mΩ")
+
+(def berserk-glyph-bright
+  "White Ω on the bright pulse BG."
+  "\e[48;5;196;38;5;231;1mΩ")
 
 (def char-aspect 2.0)
 (def base-hud-rows 1)
@@ -396,6 +414,9 @@
 (defn- ammo-cells [boxes step out-w]
   (scaled-cells boxes step out-w (fn [_] true)))
 
+(defn- berserk-cells [bs step out-w]
+  (scaled-cells bs step out-w (fn [_] true)))
+
 (defn- minimap-rows
   "Render the world's grid into a PHP array of ANSI-coded strings,
    one per OUTPUT row. `step` collapses every step×step grid block
@@ -417,6 +438,7 @@
         emap                (enemy-cells (:enemies world) step out-w)
         hmap                (heart-cells (:hearts world) step out-w)
         amap                (ammo-cells  (:ammo-boxes world) step out-w)
+        bmap                (berserk-cells (:berserks world) step out-w)
         rows                (buf-mk)
         block-has-wall?     (fn [r0 c0]
                               (loop [dr 0]
@@ -464,6 +486,7 @@
                             (buf-get emap (php/+ (php/* row out-w) col)) enemy-marker
                             (buf-get hmap (php/+ (php/* row out-w) col)) heart-marker
                             (buf-get amap (php/+ (php/* row out-w) col)) ammo-marker
+                            (buf-get bmap (php/+ (php/* row out-w) col)) berserk-marker
                             :else                                        minimap-floor)))
               (recur (php/+ col 1))))
           (buf-set rows row (php/implode "" parts)))
@@ -951,6 +974,21 @@
                      mag-col mag "\e[0m\e[40;97m/" cap " "
                      res-col "[" reserve "]\e[0m")]
     (buf-push parts (str "\e[2;1H" styled)))
+  parts)
+
+(defn- paint-berserk-badge
+  "Centred top-of-screen `BERSERK Ns` banner while :berserk-secs is
+   ticking. Pulses red so the rage state is unmistakeable. Sits on
+   row 3 (under the row-2 game-info strip) so it doesn't fight the
+   compass / hearts."
+  [parts ^float t stats vw]
+  (let [secs (or (get stats :berserk-secs) 0.0)]
+    (when (and (php/> secs 0.0) (pulse t 6.0))
+      (let [text  (str " BERSERK " (php/intval (php/ceil secs)) "s ")
+            label (str "\e[48;5;52;38;5;226;1m" text "\e[0m")
+            col   (php/max 1 (php/- (php/intdiv vw 2)
+                                    (php/intdiv (php/strlen text) 2)))]
+        (buf-push parts (str "\e[3;" col "H" label)))))
   parts)
 
 (defn- paint-empty-click
@@ -1582,6 +1620,11 @@
         ammo-bright?                       (pulse t 7.0)
         ammo-shade-now                     (if ammo-bright? ammo-shade-bright ammo-shade)
         ammo-glyph-now                     (if ammo-bright? ammo-glyph-bright ammo-glyph)
+        ;; Berserk pulse — faster than ammo so a rage sphere flashes
+        ;; the most aggressively of any pickup, telegraphing the buff.
+        berserk-bright?                    (pulse t 9.0)
+        berserk-shade-now                  (if berserk-bright? berserk-shade-bright berserk-shade)
+        berserk-glyph-now                  (if berserk-bright? berserk-glyph-bright berserk-glyph)
         ;; Atmospheric haze pulls walls toward black as lives drop, so
         ;; the world reads as 'consumed by darkness' the closer the
         ;; player is to dying. Sky / floor untouched; doors keep their
@@ -1737,6 +1780,9 @@
           bp-ammos  (paint-pickups-into  bp-armors (or (:ammo-boxes world) [])
                                          (:player world) dists edists vw vh
                                          ammo-shade-now ammo-glyph-now)
+          bp-bers   (paint-pickups-into  bp-ammos (or (:berserks world) [])
+                                         (:player world) dists edists vw vh
+                                         berserk-shade-now berserk-glyph-now)
           parts     (buf-mk)]
       (dotimes [row vh]
                (loop [col 0 prev nil run 0]
@@ -1755,7 +1801,7 @@
                          flr-row   (buf-get (if in-blood? blood-floor-gradient floor-gradient) row)
                          c         (if (and (php/< row visible-mh) (php/>= col mini-col0))
                                      sky-row
-                                     (or (buf-get bp-ammos (php/+ (php/* row vw) col))
+                                     (or (buf-get bp-bers (php/+ (php/* row vw) col))
                                          (cond
                                            (php/< row (buf-get tops col))             sky-row
                                            (php/>= row (buf-get bots col))            flr-row
@@ -1804,7 +1850,7 @@
             c-row       (php/+ (php/intdiv vh 2) (if firing? -1 0))
             top-col     (buf-get tops c-col)
             bot-col     (buf-get bots c-col)
-            center-cell (or (buf-get bp-ammos (php/+ (php/* c-row vw) c-col))
+            center-cell (or (buf-get bp-bers (php/+ (php/* c-row vw) c-col))
                             (cond
                               (php/< c-row top-col)             (buf-get sky-gradient c-row)
                               (php/>= c-row bot-col)            (buf-get floor-gradient c-row)
@@ -1840,7 +1886,8 @@
             p13         (paint-rear-warning       p12 t stats vw)
             p14         (paint-low-ammo           p13 t stats vw)
             p15         (paint-game-info          p14 stats vw)
-            p16         (paint-hearts-hud         p15 t stats bloody?)
+            p15b        (paint-berserk-badge      p15 t stats vw)
+            p16         (paint-hearts-hud         p15b t stats bloody?)
             p17         (paint-pistol-hud         p16 stats vw vh floor-gradient)
             p18         (paint-empty-click        p17 stats vw vh)
             p19         (paint-reload-reminder    p18 stats vw vh)

--- a/tests/modules/core/combat-test.phel
+++ b/tests/modules/core/combat-test.phel
@@ -2,7 +2,7 @@
   (:require phel.test :refer [deftest is])
   (:require phel-doom.modules.core.state :refer [new-world new-player])
   (:require phel-doom.modules.core.combat
-            :refer [closest-attacker attacker-side can-fire? apply-heat empty-click-seconds knockback mag-size reload reloading? roll-loot-kind tick-shooting]))
+            :refer [closest-attacker attacker-side berserk? berserk-seconds can-fire? apply-heat empty-click-seconds knockback mag-size reload reloading? roll-loot-kind tick-shooting]))
 
 ;; ---------------------------------------------------------------------
 ;; closest-attacker: selection rule.
@@ -269,3 +269,12 @@
 (deftest test-roll-loot-kind-nothing-band
   (is (= nil (roll-loot-kind {:lives 3} 0.50)))
   (is (= nil (roll-loot-kind {:lives 3} 0.99))))
+
+;; ---------------------------------------------------------------------
+;; Berserk powerup
+;; ---------------------------------------------------------------------
+
+(deftest test-berserk-predicate-true-when-timer-active
+  (is (= true  (berserk? {:berserk-secs 5.0})))
+  (is (= false (berserk? {:berserk-secs 0.0})))
+  (is (= false (berserk? {}))))


### PR DESCRIPTION
20s rage window doubles every weapon's damage. Pickup spawns on ~25% of levels; HUD shows pulsing centred `BERSERK Ns` banner + red `B` on minimap. Stacking refreshes (not adds).

CI green (394 tests).