### PR TITLE
feat(weapons,level,render): backpack doubles every weapon's reserve cap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 - Armor caps at 3.
 - Berserk sphere pickup (rare, ~25% per level). Step on it for 20s of 2× damage on every weapon; rage state shows as a pulsing centred `BERSERK Ns` banner and a red `B` on the minimap.
 - Invulnerability sphere pickup (rarer, ~16% per level). 10s of damage immunity (contact hits are skipped while `:invuln-secs > 0`). Pulsing centred `INVULN Ns` banner on row 4 + cyan `I` on the minimap.
+- Backpack pickup (L2+, ~30% per qualifying level). One-shot that doubles every weapon's effective reserve cap for the rest of the run; persists across level cuts. HUD strip gains a `+pack` indicator; minimap shows yellow `P`.
 
 ## [0.2.0] - 2026-05-22
 

--- a/src/commands/play.phel
+++ b/src/commands/play.phel
@@ -9,7 +9,7 @@
   (:require phel-doom.modules.core.physics  :refer [apply-physics tick-heartbeat tick-flicker tick-blood-drops tick-door-face])
   (:require phel-doom.modules.core.combat   :refer [ammo-per-box berserk-seconds damage-step fire-anim-seconds invuln-seconds max-reserve reload reloading? reload-cooldown-seconds tick-shooting])
   (:require phel-doom.modules.core.enemy    :refer [advance tick-scare rear-attacker?])
-  (:require phel-doom.modules.core.weapons  :refer [switch-weapon weapon-spec weapon-order weapons])
+  (:require phel-doom.modules.core.weapons  :refer [effective-reserve-cap switch-weapon weapon-spec weapon-order weapons])
   (:require phel-doom.modules.io.sound    :refer [play-sfx! mute-for!])
   (:require phel-doom.modules.core.level    :refer [build-world num-levels])
   (:require phel-doom.modules.io.scores   :refer [update-scores!])
@@ -147,7 +147,7 @@
       world
       (let [sp       (or (weapon-spec world) {})
             per-box  (or (:ammo-per-box sp) ammo-per-box)
-            cap      (or (:reserve-cap sp)  max-reserve)
+            cap      (effective-reserve-cap world)
             refilled (assoc world :ammo-boxes kept)]
         (when (:sound-on world) (play-sfx! :door))
         (update refilled :ammo-reserve
@@ -196,6 +196,29 @@
                  :invulns     kept
                  :invuln-secs invuln-seconds)))))
 
+(defn- backpacks-not-at [bs px py]
+  (apply vector
+         (filter (fn [b]
+                   (not (and (php/=== (php/intval (:x b)) px)
+                             (php/=== (php/intval (:y b)) py))))
+                 (or bs []))))
+
+(defn- pickup-backpacks
+  "One-shot: stepping on a backpack flips `:backpack?` true for the
+   rest of the run. Every weapon's effective reserve cap doubles
+   from that frame on (see weapons/effective-reserve-cap). Pickup
+   carries across levels via build-world's 3-arity."
+  [world]
+  (let [kept (backpacks-not-at (:backpacks world)
+                               (php/intval (:x (:player world)))
+                               (php/intval (:y (:player world))))]
+    (if (= (count kept) (count (or (:backpacks world) [])))
+      world
+      (do (when (:sound-on world) (play-sfx! :door))
+          (assoc world
+                 :backpacks kept
+                 :backpack? true)))))
+
 (defn- on-door?
   "True when the player's current cell is a door (auto-advances level)."
   [world]
@@ -233,7 +256,8 @@
             w4b (pickup-ammos  w4)
             w4c (pickup-berserks w4b)
             w4d (pickup-invulns  w4c)
-            w5  (tick-enemies  w4d dt)
+            w4e (pickup-backpacks w4d)
+            w5  (tick-enemies  w4e dt)
             w5b (if (:reload edges)
                   (do
                     (when (and (:sound-on w5) (reloading? w5)) (play-sfx! :reload))
@@ -293,6 +317,7 @@
    :empty-click-secs (or (:empty-click-secs world) 0.0)
    :berserk-secs (or (:berserk-secs world) 0.0)
    :invuln-secs  (or (:invuln-secs world) 0.0)
+   :backpack?    (boolean (:backpack? world))
    :rear-warning? (rear-attacker? (:enemies world)
                                   (:x (:player world))
                                   (:y (:player world))
@@ -342,6 +367,7 @@
    :level      (php/+ (:level world) 1)
    :kills      (:kills world)
    :lives      (:lives world)
+   :backpack?  (boolean (:backpack? world))
    :survived-s (php/intval (php/- now t-start))})
 
 (defn- play-door-sfx [world]
@@ -477,23 +503,25 @@
          lives       max-lives
          carry-kills 0
          carry-time  0
-         seed        (php/mt_rand)]
+         seed        (php/mt_rand)
+         backpack?   false]
     (php/mt_srand seed)
-    (let [result (game-loop (build-world level lives))]
+    (let [result (game-loop (build-world level lives backpack?))]
       (cond
         (= result :quit)
         nil
 
         (and (map? result) (:next-level result))
         (let [[k t] (carry-on carry-kills carry-time result)]
-          (recur (:level result) (:lives result) k t (php/mt_rand)))
+          (recur (:level result) (:lives result) k t (php/mt_rand)
+                 (boolean (:backpack? result))))
 
         (and (map? result) (:victory result))
         (let [[k t]           (carry-on carry-kills carry-time result)
               [kind new-seed] (handle-end victory-loop k t result seed true)]
           (cond
-            (= kind :fresh) (recur 1 max-lives 0 0 (php/mt_rand))
-            (= kind :same)  (recur 1 max-lives 0 0 new-seed)
+            (= kind :fresh) (recur 1 max-lives 0 0 (php/mt_rand) false)
+            (= kind :same)  (recur 1 max-lives 0 0 new-seed false)
             :else           nil))
 
         (and (map? result) (:game-over result))
@@ -502,10 +530,10 @@
               died-on         (or (:level result) 1)]
           (cond
             ;; r: try the level you died on again with a fresh map.
-            (= kind :fresh) (recur died-on max-lives 0 0 (php/mt_rand))
+            (= kind :fresh) (recur died-on max-lives 0 0 (php/mt_rand) false)
             ;; R: replay the exact level you died on (same seed + same
             ;; level number reproduces identical geometry + enemies).
-            (= kind :same)  (recur died-on max-lives 0 0 new-seed)
+            (= kind :same)  (recur died-on max-lives 0 0 new-seed false)
             :else           nil))
 
         :else

--- a/src/modules/core/level.phel
+++ b/src/modules/core/level.phel
@@ -129,6 +129,20 @@
       [{:x ix :y iy}])
     []))
 
+(defn- maybe-spawn-backpack
+  "One-shot backpack: L2+ only (reserves matter more at higher
+   tiers), ~30% chance per qualifying level. Once picked up the
+   `:backpack?` flag stays true for the rest of the run; doubles
+   every weapon's effective reserve cap from that frame on. Don't
+   re-spawn if the player already owns one — pointless clutter."
+  [grid level-num backpack-owned?]
+  (if (or backpack-owned?
+          (php/< level-num 2)
+          (php/!== 0 (mod (rand-int 10) 3)))
+    []
+    (let [[bx by] (random-spawn grid)]
+      [{:x bx :y by}])))
+
 (defn- ammo-box-count
   "Per-level ammo-box budget. Scales with the expected shot count
    (`enemies * max-lives`) so bigger maps with tougher monsters get
@@ -171,38 +185,42 @@
    from the previous level. Walls, enemies, the single door, the
    player spawn, and (when lives < max-lives) one heart pickup are all
    randomised. Level tuning is stamped onto the world so render and
-   physics can read it without globals."
-  [level-num lives]
-  (let [cfg (config-for level-num)]
-    (let [[w h] (:size cfg)
-          grid  (seed-doors (random-grid w h (:walls cfg)) 1)]
-      (let [[px py] (random-spawn grid)]
-        (let [world (new-world grid (new-player px py (php/* (rand-int 360)
-                                                             (php// php/M_PI 180.0))))]
-          (let [with-foes (with-enemies world
-                                        (spawn-enemies grid (:enemies cfg)
-                                                       enemy-min-spawn-dist px py
-                                                       (or (:enemy-lives cfg) 1)))]
-            (assoc with-foes
-                   :level       level-num
-                   :lives       lives
-                   :hearts      (maybe-spawn-heart grid lives px py)
-                   :armors      (maybe-spawn-armor grid)
-                   :berserks    (maybe-spawn-berserk grid)
-                   :invulns     (maybe-spawn-invuln grid)
-                   :ammo-boxes  (spawn-ammo-boxes grid (ammo-box-count cfg))
-                   :chase-speed (:chase cfg)
-                   :enemy-head-code     (:head-code cfg)
-                   :enemy-body-code     (:body-code cfg)
-                   :enemy-legs-code     (:legs-code cfg)
-                   :enemy-body-glyph    (:body-glyph cfg)
-                   :enemy-body-glyph-alt (:body-glyph-alt cfg)
-                   :enemy-body-glyph-fg (:body-glyph-fg cfg)
-                   :enemy-face          (:face cfg)
-                   :enemy-face-alt      (:face-alt cfg)
-                   :enemy-face-attack   (:face-attack cfg)
-                   :level-name  (:name cfg)
+   physics can read it without globals. `backpack?` controls whether
+   the new level seeds another backpack — once owned, don't drop more."
+  ([level-num lives] (build-world level-num lives false))
+  ([lv life pack?]
+   (let [cfg (config-for lv)]
+     (let [[w h] (:size cfg)
+           grid  (seed-doors (random-grid w h (:walls cfg)) 1)]
+       (let [[px py] (random-spawn grid)]
+         (let [world (new-world grid (new-player px py (php/* (rand-int 360)
+                                                              (php// php/M_PI 180.0))))]
+           (let [with-foes (with-enemies world
+                                         (spawn-enemies grid (:enemies cfg)
+                                                        enemy-min-spawn-dist px py
+                                                        (or (:enemy-lives cfg) 1)))]
+             (assoc with-foes
+                    :level       lv
+                    :lives       life
+                    :backpack?   pack?
+                    :hearts      (maybe-spawn-heart grid life px py)
+                    :armors      (maybe-spawn-armor grid)
+                    :berserks    (maybe-spawn-berserk grid)
+                    :invulns     (maybe-spawn-invuln grid)
+                    :backpacks   (maybe-spawn-backpack grid lv pack?)
+                    :ammo-boxes  (spawn-ammo-boxes grid (ammo-box-count cfg))
+                    :chase-speed (:chase cfg)
+                    :enemy-head-code     (:head-code cfg)
+                    :enemy-body-code     (:body-code cfg)
+                    :enemy-legs-code     (:legs-code cfg)
+                    :enemy-body-glyph    (:body-glyph cfg)
+                    :enemy-body-glyph-alt (:body-glyph-alt cfg)
+                    :enemy-body-glyph-fg (:body-glyph-fg cfg)
+                    :enemy-face          (:face cfg)
+                    :enemy-face-alt      (:face-alt cfg)
+                    :enemy-face-attack   (:face-attack cfg)
+                    :level-name  (:name cfg)
                    ;; Show a centred splash for the first ~1.5s of the
                    ;; level. tick-world decays this each frame; render
                    ;; layer paints the overlay while it's > 0.
-                   :intro-secs  1.5)))))))
+                    :intro-secs  1.5))))))))

--- a/src/modules/core/state.phel
+++ b/src/modules/core/state.phel
@@ -55,6 +55,8 @@
    :berserks        []
    :invuln-secs     0.0
    :invulns         []
+   :backpack?       false
+   :backpacks       []
    ;; Weapons. :weapon is the active slot. :weapon-state is the
    ;; per-weapon mag/reserve table (catalogue lives in weapons.phel).
    ;; :mag and :ammo-reserve mirror the active weapon's live state so

--- a/src/modules/core/weapons.phel
+++ b/src/modules/core/weapons.phel
@@ -62,6 +62,15 @@
   [world]
   (get weapons (current-weapon world)))
 
+(defn effective-reserve-cap
+  "Active weapon's reserve cap, doubled when the player owns the
+   backpack pickup. Callers should use this in place of raw
+   `:reserve-cap` so the backpack buff propagates everywhere ammo
+   gets bumped (level pickups, kill drops, swap restores)."
+  [world]
+  (let [base (or (:reserve-cap (weapon-spec world)) 0)]
+    (if (:backpack? world) (php/* 2 base) base)))
+
 (defn initial-weapon-state
   "Per-weapon ammo state for a brand-new run: starting mag full,
    reserve at :reserve-start."

--- a/src/modules/io/render.phel
+++ b/src/modules/io/render.phel
@@ -57,6 +57,7 @@
 (def ammo-marker     "\e[40;93;1mA\e[0m")
 (def berserk-marker  "\e[40;91;1mB\e[0m")
 (def invuln-marker   "\e[40;96;1mI\e[0m")
+(def backpack-marker "\e[40;33;1mP\e[0m")
 (def door-shade
   "Door body cell drawn when a ray hit a door. Frame glyph `▌` (left
    half block) on a dark steel BG with bright orange FG, so a column
@@ -176,6 +177,22 @@
 (def invuln-glyph-bright
   "Yellow star on cyan pulse."
   "\e[48;5;51;38;5;226;1m★")
+
+(def backpack-shade
+  "Backpack idle BG: dim olive-tan crate so it reads as field gear."
+  "\e[48;5;58m ")
+
+(def backpack-shade-bright
+  "Backpack pulse BG: brighter tan flare."
+  "\e[48;5;142m ")
+
+(def backpack-glyph
+  "White ⊞ on the tan BG: stylised pack."
+  "\e[48;5;58;38;5;231;1m⊞")
+
+(def backpack-glyph-bright
+  "Black ⊞ on the bright pulse BG."
+  "\e[48;5;142;38;5;232;1m⊞")
 
 (def char-aspect 2.0)
 (def base-hud-rows 1)
@@ -437,6 +454,9 @@
 (defn- invuln-cells [is step out-w]
   (scaled-cells is step out-w (fn [_] true)))
 
+(defn- backpack-cells [bs step out-w]
+  (scaled-cells bs step out-w (fn [_] true)))
+
 (defn- minimap-rows
   "Render the world's grid into a PHP array of ANSI-coded strings,
    one per OUTPUT row. `step` collapses every step×step grid block
@@ -460,6 +480,7 @@
         amap                (ammo-cells  (:ammo-boxes world) step out-w)
         bmap                (berserk-cells (:berserks world) step out-w)
         imap                (invuln-cells  (:invulns world) step out-w)
+        pmap                (backpack-cells (:backpacks world) step out-w)
         rows                (buf-mk)
         block-has-wall?     (fn [r0 c0]
                               (loop [dr 0]
@@ -509,6 +530,7 @@
                             (buf-get amap (php/+ (php/* row out-w) col)) ammo-marker
                             (buf-get bmap (php/+ (php/* row out-w) col)) berserk-marker
                             (buf-get imap (php/+ (php/* row out-w) col)) invuln-marker
+                            (buf-get pmap (php/+ (php/* row out-w) col)) backpack-marker
                             :else                                        minimap-floor)))
               (recur (php/+ col 1))))
           (buf-set rows row (php/implode "" parts)))
@@ -990,11 +1012,12 @@
         res-col (cond (php/<= reserve 0)       "\e[1;91m"
                       (php/<= reserve res-low) "\e[1;93m"
                       :else                    "\e[2m")
+        pack    (if (get stats :backpack?) " \e[40;33;1m+pack\e[0m" "")
         styled  (str "\e[40;97m\e[1mL" lvl "\e[0m\e[40;97m " name'
                      "  \e[1mkills\e[0m " kills
                      "  \e[1m" wname "\e[0m\e[40;97m "
                      mag-col mag "\e[0m\e[40;97m/" cap " "
-                     res-col "[" reserve "]\e[0m")]
+                     res-col "[" reserve "]\e[0m" pack)]
     (buf-push parts (str "\e[2;1H" styled)))
   parts)
 
@@ -1666,6 +1689,12 @@
         invuln-bright?                     (pulse t 8.0)
         invuln-shade-now                   (if invuln-bright? invuln-shade-bright invuln-shade)
         invuln-glyph-now                   (if invuln-bright? invuln-glyph-bright invuln-glyph)
+        ;; Backpack pulse — slowest of the powerup family so the
+        ;; one-shot pickup reads as 'permanent gear' rather than a
+        ;; ticking buff.
+        backpack-bright?                   (pulse t 4.0)
+        backpack-shade-now                 (if backpack-bright? backpack-shade-bright backpack-shade)
+        backpack-glyph-now                 (if backpack-bright? backpack-glyph-bright backpack-glyph)
         ;; Atmospheric haze pulls walls toward black as lives drop, so
         ;; the world reads as 'consumed by darkness' the closer the
         ;; player is to dying. Sky / floor untouched; doors keep their
@@ -1827,6 +1856,9 @@
           bp-inv    (paint-pickups-into  bp-bers (or (:invulns world) [])
                                          (:player world) dists edists vw vh
                                          invuln-shade-now invuln-glyph-now)
+          bp-pack   (paint-pickups-into  bp-inv (or (:backpacks world) [])
+                                         (:player world) dists edists vw vh
+                                         backpack-shade-now backpack-glyph-now)
           parts     (buf-mk)]
       (dotimes [row vh]
                (loop [col 0 prev nil run 0]
@@ -1845,7 +1877,7 @@
                          flr-row   (buf-get (if in-blood? blood-floor-gradient floor-gradient) row)
                          c         (if (and (php/< row visible-mh) (php/>= col mini-col0))
                                      sky-row
-                                     (or (buf-get bp-inv (php/+ (php/* row vw) col))
+                                     (or (buf-get bp-pack (php/+ (php/* row vw) col))
                                          (cond
                                            (php/< row (buf-get tops col))             sky-row
                                            (php/>= row (buf-get bots col))            flr-row
@@ -1894,7 +1926,7 @@
             c-row       (php/+ (php/intdiv vh 2) (if firing? -1 0))
             top-col     (buf-get tops c-col)
             bot-col     (buf-get bots c-col)
-            center-cell (or (buf-get bp-inv (php/+ (php/* c-row vw) c-col))
+            center-cell (or (buf-get bp-pack (php/+ (php/* c-row vw) c-col))
                             (cond
                               (php/< c-row top-col)             (buf-get sky-gradient c-row)
                               (php/>= c-row bot-col)            (buf-get floor-gradient c-row)


### PR DESCRIPTION
One-shot pickup; L2+, ~30% spawn. Persists across level cuts via build-world's new 3-arity. effective-reserve-cap helper applies the 2x to pickup-ammos. HUD '+pack' indicator + minimap 'P' marker.

CI green (397 tests).