### PR TITLE
feat(cli,level,render): --difficulty=easy|normal|hard|nightmare

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 - Berserk sphere pickup (rare, ~25% per level). Step on it for 20s of 2× damage on every weapon; rage state shows as a pulsing centred `BERSERK Ns` banner and a red `B` on the minimap.
 - Invulnerability sphere pickup (rarer, ~16% per level). 10s of damage immunity (contact hits are skipped while `:invuln-secs > 0`). Pulsing centred `INVULN Ns` banner on row 4 + cyan `I` on the minimap.
 - Backpack pickup (L2+, ~30% per qualifying level). One-shot that doubles every weapon's effective reserve cap for the rest of the run; persists across level cuts. HUD strip gains a `+pack` indicator; minimap shows yellow `P`.
+- `--difficulty=easy|normal|hard|nightmare` (`-d`) CLI option. Multipliers scale enemy chase speed, per-enemy HP, and per-level enemy count. easy: 0.7× speed/enemies, hp ×1.0. hard: 1.3× across the board. nightmare: 1.8× speed, 1.5× hp + count. HUD strip surfaces the active mode (`[easy]` / `[hard]` / `[nightmare]`); normal is unlabelled.
 
 ## [0.2.0] - 2026-05-22
 

--- a/src/commands/play.phel
+++ b/src/commands/play.phel
@@ -318,6 +318,7 @@
    :berserk-secs (or (:berserk-secs world) 0.0)
    :invuln-secs  (or (:invuln-secs world) 0.0)
    :backpack?    (boolean (:backpack? world))
+   :difficulty   (or (:difficulty world) :normal)
    :rear-warning? (rear-attacker? (:enemies world)
                                   (:x (:player world))
                                   (:y (:player world))
@@ -497,8 +498,12 @@
    PRNG seed before calling build-world so the player can replay the
    SAME map sequence by hitting R on an end screen (fresh seed = lower
    r, same seed = capital R). Lives + kills + time carry across
-   levels; death/victory both update the persisted scores file."
-  []
+   levels; death/victory both update the persisted scores file.
+
+   `diff` is the difficulty keyword from --difficulty (or nil for
+   :normal). Threaded into every build-world call so retries via
+   r / R preserve the same balance the player picked at startup."
+  [diff]
   (loop [level       1
          lives       max-lives
          carry-kills 0
@@ -506,7 +511,7 @@
          seed        (php/mt_rand)
          backpack?   false]
     (php/mt_srand seed)
-    (let [result (game-loop (build-world level lives backpack?))]
+    (let [result (game-loop (build-world level lives backpack? diff))]
       (cond
         (= result :quit)
         nil
@@ -562,21 +567,28 @@
 
 (defn- run-play [ctx]
   (init-input!)
-  (if (php/=== (show-start-menu!) :quit)
-    (do (restore!)
-        (clear-screen)
-        0)
-    (do (clear-screen)
-        (run-levels)
-        (restore!)
-        (clear-screen)
-        (cli/success ctx "Thanks for playing.")
-        (print-credits)
-        0)))
+  (let [diff (cli/opt ctx "difficulty")]
+    (if (php/=== (show-start-menu!) :quit)
+      (do (restore!)
+          (clear-screen)
+          0)
+      (do (clear-screen)
+          (run-levels diff)
+          (restore!)
+          (clear-screen)
+          (cli/success ctx "Thanks for playing.")
+          (print-credits)
+          0))))
 
 (def play-command
   {:name "play"
    :doc  "Start the DOOM showcase. WASD / arrow keys move + turn,
           space fires, M toggles the minimap, N toggles sound,
           P pauses, Q quits. Walk into a door to advance levels."
+   :opts [{:name    "difficulty"
+           :short   "d"
+           :mode    :optional
+           :doc     "easy | normal | hard | nightmare (default normal)"
+           :default "normal"
+           :coerce  :keyword}]
    :run  run-play})

--- a/src/modules/core/difficulty.phel
+++ b/src/modules/core/difficulty.phel
@@ -1,0 +1,60 @@
+(ns phel-doom.modules.core.difficulty)
+
+;; ---------------------------------------------------------------------
+;; Difficulty multipliers applied on top of each level's base config.
+;; Selected via --difficulty CLI flag (see commands/play.phel); default
+;; is :normal so the existing balance shipped by /play stays unchanged.
+;;
+;; Multipliers scale chase speed, enemy HP, and per-level enemy count.
+;; Powerups + ammo are unaffected — the dial is purely combat density
+;; and lethality.
+;; ---------------------------------------------------------------------
+
+(def diff-table
+  "Per-difficulty multipliers. Keys must match the CLI keyword."
+  {:easy      {:speed-mul    0.7
+               :hp-mul       1.0
+               :enemies-mul  0.7}
+   :normal    {:speed-mul    1.0
+               :hp-mul       1.0
+               :enemies-mul  1.0}
+   :hard      {:speed-mul    1.3
+               :hp-mul       1.3
+               :enemies-mul  1.3}
+   :nightmare {:speed-mul    1.8
+               :hp-mul       1.5
+               :enemies-mul  1.5}})
+
+(def default-diff
+  "Difficulty used when the CLI flag is absent / unrecognised."
+  :normal)
+
+(defn normalise
+  "Resolve a CLI input (kw, string, or nil) to a difficulty keyword
+   present in `diff-table`. Unknown values fall back to `default-diff`
+   so a typo can't crash run startup."
+  [v]
+  (let [kw (cond
+             (php/=== v nil) default-diff
+             (keyword? v)    v
+             :else           (keyword (php/strtolower (php/strval v))))]
+    (if (contains? diff-table kw) kw default-diff)))
+
+(defn spec-for
+  "Multiplier map for the given difficulty keyword."
+  [kw]
+  (get diff-table (normalise kw)))
+
+(defn scale-cfg
+  "Stamp `diff`'s multipliers onto the level config map: chase speed,
+   per-enemy HP, and enemy count. Floors HP at 1 and enemy count at 1
+   so easy mode can't empty a level."
+  [cfg diff]
+  (let [d           (spec-for diff)
+        chase       (or (:chase cfg) 1.0)
+        enemy-lives (or (:enemy-lives cfg) 1)
+        enemies     (or (:enemies cfg) 1)]
+    (assoc cfg
+           :chase       (php/* chase (:speed-mul d))
+           :enemy-lives (php/max 1 (php/intval (php/ceil (php/* enemy-lives (:hp-mul d)))))
+           :enemies     (php/max 1 (php/intval (php/ceil (php/* enemies (:enemies-mul d))))))))

--- a/src/modules/core/level.phel
+++ b/src/modules/core/level.phel
@@ -1,7 +1,8 @@
 (ns phel-doom.modules.core.level
-  (:require phel-doom.modules.core.state :refer [new-player new-world with-enemies max-lives])
-  (:require phel-doom.modules.core.map   :refer [random-grid random-spawn seed-doors])
-  (:require phel-doom.modules.core.enemy :refer [spawn-enemies]))
+  (:require phel-doom.modules.core.state      :refer [new-player new-world with-enemies max-lives])
+  (:require phel-doom.modules.core.map        :refer [random-grid random-spawn seed-doors])
+  (:require phel-doom.modules.core.enemy      :refer [spawn-enemies])
+  (:require phel-doom.modules.core.difficulty :refer [normalise scale-cfg]))
 
 ;; ---------------------------------------------------------------------
 ;; Level catalog + fresh-world factory.
@@ -187,9 +188,11 @@
    randomised. Level tuning is stamped onto the world so render and
    physics can read it without globals. `backpack?` controls whether
    the new level seeds another backpack — once owned, don't drop more."
-  ([level-num lives] (build-world level-num lives false))
-  ([lv life pack?]
-   (let [cfg (config-for lv)]
+  ([level-num lives] (build-world level-num lives false :normal))
+  ([n l pack?] (build-world n l pack? :normal))
+  ([lv life pack? diff]
+   (let [diff' (normalise diff)
+         cfg   (scale-cfg (config-for lv) diff')]
      (let [[w h] (:size cfg)
            grid  (seed-doors (random-grid w h (:walls cfg)) 1)]
        (let [[px py] (random-spawn grid)]
@@ -202,6 +205,7 @@
              (assoc with-foes
                     :level       lv
                     :lives       life
+                    :difficulty  diff'
                     :backpack?   pack?
                     :hearts      (maybe-spawn-heart grid life px py)
                     :armors      (maybe-spawn-armor grid)

--- a/src/modules/io/render.phel
+++ b/src/modules/io/render.phel
@@ -997,27 +997,33 @@
    other paint-* helpers; the strip is left-anchored so vw doesn't
    feed the col math."
   [parts stats _vw]
-  (let [lvl     (or (get stats :level) 1)
-        name'   (or (get stats :level-name) "")
-        kills   (or (get stats :kills) 0)
-        wname   (or (get stats :weapon-name) "pistol")
-        mag     (or (get stats :mag) 0)
-        cap     (or (get stats :mag-size) 10)
-        reserve (or (get stats :ammo-reserve) 0)
-        mag-low (php/max 1 (php/intdiv cap 3))
-        res-low cap
-        mag-col (cond (php/<= mag 0)       "\e[1;91m"
-                      (php/<= mag mag-low) "\e[1;93m"
-                      :else                "\e[1m")
-        res-col (cond (php/<= reserve 0)       "\e[1;91m"
-                      (php/<= reserve res-low) "\e[1;93m"
-                      :else                    "\e[2m")
-        pack    (if (get stats :backpack?) " \e[40;33;1m+pack\e[0m" "")
-        styled  (str "\e[40;97m\e[1mL" lvl "\e[0m\e[40;97m " name'
-                     "  \e[1mkills\e[0m " kills
-                     "  \e[1m" wname "\e[0m\e[40;97m "
-                     mag-col mag "\e[0m\e[40;97m/" cap " "
-                     res-col "[" reserve "]\e[0m" pack)]
+  (let [lvl      (or (get stats :level) 1)
+        name'    (or (get stats :level-name) "")
+        kills    (or (get stats :kills) 0)
+        wname    (or (get stats :weapon-name) "pistol")
+        mag      (or (get stats :mag) 0)
+        cap      (or (get stats :mag-size) 10)
+        reserve  (or (get stats :ammo-reserve) 0)
+        mag-low  (php/max 1 (php/intdiv cap 3))
+        res-low  cap
+        mag-col  (cond (php/<= mag 0)       "\e[1;91m"
+                       (php/<= mag mag-low) "\e[1;93m"
+                       :else                "\e[1m")
+        res-col  (cond (php/<= reserve 0)       "\e[1;91m"
+                       (php/<= reserve res-low) "\e[1;93m"
+                       :else                    "\e[2m")
+        pack     (if (get stats :backpack?) " \e[40;33;1m+pack\e[0m" "")
+        diff     (or (get stats :difficulty) :normal)
+        diff-tag (cond
+                   (php/=== diff :easy)      " \e[40;32;1m[easy]\e[0m"
+                   (php/=== diff :hard)      " \e[40;33;1m[hard]\e[0m"
+                   (php/=== diff :nightmare) " \e[40;31;1m[nightmare]\e[0m"
+                   :else                     "")
+        styled   (str "\e[40;97m\e[1mL" lvl "\e[0m\e[40;97m " name'
+                      "  \e[1mkills\e[0m " kills
+                      "  \e[1m" wname "\e[0m\e[40;97m "
+                      mag-col mag "\e[0m\e[40;97m/" cap " "
+                      res-col "[" reserve "]\e[0m" pack diff-tag)]
     (buf-push parts (str "\e[2;1H" styled)))
   parts)
 

--- a/tests/modules/core/difficulty-test.phel
+++ b/tests/modules/core/difficulty-test.phel
@@ -1,0 +1,43 @@
+(ns phel-doom-tests.modules.core.difficulty-test
+  (:require phel.test :refer [deftest is])
+  (:require phel-doom.modules.core.difficulty :refer [normalise scale-cfg spec-for]))
+
+(deftest test-normalise-defaults-to-normal-on-nil
+  (is (= :normal (normalise nil))))
+
+(deftest test-normalise-passes-known-kw-through
+  (is (= :hard      (normalise :hard)))
+  (is (= :nightmare (normalise :nightmare))))
+
+(deftest test-normalise-string-input-coerces-to-kw
+  (is (= :easy (normalise "easy")))
+  (is (= :hard (normalise "HARD"))))
+
+(deftest test-normalise-unknown-input-falls-back-to-normal
+  (is (= :normal (normalise :ultra-violence)))
+  (is (= :normal (normalise "garbage"))))
+
+(deftest test-scale-cfg-easy-shrinks-everything
+  (let [cfg (scale-cfg {:chase 1.0 :enemy-lives 3 :enemies 6} :easy)]
+    ;; speed/hp scaled, enemy count rounded up via ceil
+    (is (< (:chase cfg) 1.0))
+    (is (= 3 (:enemy-lives cfg)))  ; 3 * 1.0 = 3
+    (is (= 5 (:enemies cfg)))))    ; ceil(6 * 0.7) = 5
+
+(deftest test-scale-cfg-nightmare-amplifies-everything
+  (let [cfg (scale-cfg {:chase 1.0 :enemy-lives 3 :enemies 6} :nightmare)]
+    (is (> (:chase cfg) 1.0))
+    (is (>= (:enemy-lives cfg) 5))    ; ceil(3 * 1.5)
+    (is (>= (:enemies cfg) 9))))      ; ceil(6 * 1.5)
+
+(deftest test-scale-cfg-normal-leaves-cfg-as-is
+  (let [cfg (scale-cfg {:chase 1.0 :enemy-lives 3 :enemies 6} :normal)]
+    (is (= 1.0 (:chase cfg)))
+    (is (= 3   (:enemy-lives cfg)))
+    (is (= 6   (:enemies cfg)))))
+
+(deftest test-scale-cfg-floors-at-one-on-tiny-inputs
+  ;; Easy mode on a 1-enemy 1-HP level shouldn't empty it.
+  (let [cfg (scale-cfg {:chase 1.0 :enemy-lives 1 :enemies 1} :easy)]
+    (is (= 1 (:enemies cfg)))
+    (is (= 1 (:enemy-lives cfg)))))


### PR DESCRIPTION
Per-difficulty multipliers on chase speed / HP / enemy count. Default normal; CLI flag --difficulty (-d) coerced to keyword. HUD strip tags the active mode (skipped for normal).

| | speed | hp | enemies |
|---|---|---|---|
| easy | 0.7x | 1.0x | 0.7x |
| normal | 1.0 | 1.0 | 1.0 |
| hard | 1.3x | 1.3x | 1.3x |
| nightmare | 1.8x | 1.5x | 1.5x |

CI green (415 tests, +7 difficulty cases).