### PR TITLE
feat(weapons,level,render): weapon pickups + distinct per-weapon silhouettes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 ### Changed
 
 - Loot drop chances tuned DOWN after v0.3 playtest: per-kill drop ~25% (was 50%), berserk spawn ~12% (was 25%), invuln ~8% (was 16%), backpack ~20% (was 30%). Floor no longer fills with pickups.
+- Weapons must be found on the map. Fresh runs only own the pistol. Shotgun pickup (`▤`) seeds on L2 and the chaingun (`▦`) on L3 — pickup auto-switches to the new weapon DOOM-style. `1`/`2`/`3` only switches to weapons in `:owned-weapons` so pressing 2 before finding the shotgun does nothing. Owned weapons persist across level cuts.
+- Each weapon now has its own silhouette: pistol slim single-barrel, shotgun wide twin-barrel with broad stock, chaingun multi-barrel cluster on a heavy housing.
 
 ## [0.2.0] - 2026-05-22
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -46,12 +46,13 @@ See [level-system.md](level-system.md), [map.md](map.md).
   aggro-distance (1.8 units)
 - Hitscan combat: blood splatter, muzzle flash, 5-stage death anim,
   3-6s respawn cooldown
-- 3-slot weapon loadout (1/2/3): pistol (10-mag, 0.12s cd, 1 dmg,
-  black-steel + amber-wood palette), shotgun (4-mag, 0.6s cd, 3 dmg,
-  walnut + steel palette), chaingun (30-mag, 0.05s cd, 1 dmg,
-  gun-metal + green-LED palette). Each weapon has its own mag size,
+- 3-slot weapon loadout (1/2/3) — fresh runs start with the pistol;
+  shotgun (L2 pickup) and chaingun (L3 pickup) must be found on the
+  map. Each weapon has its own silhouette (slim single-barrel vs
+  wide twin-barrel vs multi-barrel cluster), palette, mag size,
   fire cooldown, reload duration, damage, reserve cap, and
-  ammo-per-box rate. Switches preserve per-weapon mag + reserve.
+  ammo-per-box rate. Switches preserve per-weapon mag + reserve and
+  are gated by `:owned-weapons`; first-time pickup auto-switches.
   Drop / refill / raise reload animation; sprite kicks up 2 rows
   on every shot.
 - 5 lives, 1s i-frame window post-hit, directional red band on the

--- a/docs/state.md
+++ b/docs/state.md
@@ -31,6 +31,8 @@ Pure data shapes that every other module operates on. `src/modules/core/state.ph
  :difficulty <kw :easy|:normal|:hard|:nightmare>
  :door-lock  <kw :blue|:red|nil>           ; lock colour on this level's exit
  :weapon     <kw :pistol|:shotgun|:chaingun>  ; active weapon
+ :owned-weapons <set of kw>                ; pistol owned by default; others must be picked up
+ :weapon-pickups <vector of {:x :y :weapon}>
  :weapon-state {<kw> {:mag :reserve}}      ; per-weapon ammo bookkeeping
  :kills      <int>
  :lives      <int, 0..max-lives>

--- a/src/commands/play.phel
+++ b/src/commands/play.phel
@@ -9,7 +9,7 @@
   (:require phel-doom.modules.core.physics  :refer [apply-physics tick-heartbeat tick-flicker tick-blood-drops tick-door-face])
   (:require phel-doom.modules.core.combat   :refer [ammo-per-box berserk-seconds damage-step fire-anim-seconds invuln-seconds max-reserve reload reloading? reload-cooldown-seconds tick-shooting])
   (:require phel-doom.modules.core.enemy    :refer [advance tick-scare rear-attacker?])
-  (:require phel-doom.modules.core.weapons  :refer [effective-reserve-cap switch-weapon weapon-spec weapon-order weapons])
+  (:require phel-doom.modules.core.weapons  :refer [effective-reserve-cap give-weapon switch-weapon weapon-spec weapon-order weapons])
   (:require phel-doom.modules.io.sound    :refer [play-sfx! mute-for!])
   (:require phel-doom.modules.core.level    :refer [build-world num-levels])
   (:require phel-doom.modules.io.scores   :refer [update-scores!])
@@ -226,6 +226,35 @@
                              (php/=== (php/intval (:y k)) py))))
                  (or ks []))))
 
+(defn- weapon-pickups-not-at [ws px py]
+  (apply vector
+         (filter (fn [w]
+                   (not (and (php/=== (php/intval (:x w)) px)
+                             (php/=== (php/intval (:y w)) py))))
+                 (or ws []))))
+
+(defn- pickup-weapon-pickups
+  "Step-on consumes a weapon pickup, adds it to :owned-weapons, and
+   auto-switches to it DOOM-style (mid-fight reload-lockout check is
+   bypassed here because the pickup is the trigger, not user input)."
+  [world]
+  (let [px      (php/intval (:x (:player world)))
+        py      (php/intval (:y (:player world)))
+        on-pick (loop [ws (:weapon-pickups world)]
+                  (cond
+                    (php/=== ws nil) nil
+                    :else
+                    (let [w (first ws)]
+                      (if (and (php/=== (php/intval (:x w)) px)
+                               (php/=== (php/intval (:y w)) py))
+                        w
+                        (recur (next ws))))))]
+    (if (php/=== on-pick nil)
+      world
+      (let [kept (weapon-pickups-not-at (:weapon-pickups world) px py)]
+        (when (:sound-on world) (play-sfx! :door))
+        (give-weapon (assoc world :weapon-pickups kept) (:weapon on-pick))))))
+
 (defn- pickup-keycards
   "Step-on consumes the keycard + adds its colour to `:held-keys`.
    try-move uses the set to gate locked-door passage."
@@ -288,7 +317,8 @@
             w4d (pickup-invulns  w4c)
             w4e (pickup-backpacks w4d)
             w4f (pickup-keycards w4e)
-            w5  (tick-enemies  w4f dt)
+            w4g (pickup-weapon-pickups w4f)
+            w5  (tick-enemies  w4g dt)
             w5b (if (:reload edges)
                   (do
                     (when (and (:sound-on w5) (reloading? w5)) (play-sfx! :reload))
@@ -351,8 +381,9 @@
    :invuln-secs  (or (:invuln-secs world) 0.0)
    :backpack?    (boolean (:backpack? world))
    :difficulty   (or (:difficulty world) :normal)
-   :held-keys    (or (:held-keys world) #{})
-   :door-lock    (:door-lock world)
+   :held-keys      (or (:held-keys world) #{})
+   :door-lock      (:door-lock world)
+   :owned-weapons  (or (:owned-weapons world) #{:pistol})
    :rear-warning? (rear-attacker? (:enemies world)
                                   (:x (:player world))
                                   (:y (:player world))
@@ -398,12 +429,13 @@
    :survived-s (php/intval (php/- now t-start))})
 
 (defn- result-next-level [world ^float t-start ^float now]
-  {:next-level true
-   :level      (php/+ (:level world) 1)
-   :kills      (:kills world)
-   :lives      (:lives world)
-   :backpack?  (boolean (:backpack? world))
-   :survived-s (php/intval (php/- now t-start))})
+  {:next-level    true
+   :level         (php/+ (:level world) 1)
+   :kills         (:kills world)
+   :lives         (:lives world)
+   :backpack?     (boolean (:backpack? world))
+   :owned-weapons (or (:owned-weapons world) #{:pistol})
+   :survived-s    (php/intval (php/- now t-start))})
 
 (defn- play-door-sfx [world]
   (when (:sound-on world) (play-sfx! :door)))
@@ -543,9 +575,10 @@
          carry-kills 0
          carry-time  0
          seed        (php/mt_rand)
-         backpack?   false]
+         backpack?   false
+         owned       #{:pistol}]
     (php/mt_srand seed)
-    (let [result (game-loop (build-world level lives backpack? diff))]
+    (let [result (game-loop (build-world level lives backpack? diff owned))]
       (cond
         (= result :quit)
         nil
@@ -553,14 +586,15 @@
         (and (map? result) (:next-level result))
         (let [[k t] (carry-on carry-kills carry-time result)]
           (recur (:level result) (:lives result) k t (php/mt_rand)
-                 (boolean (:backpack? result))))
+                 (boolean (:backpack? result))
+                 (or (:owned-weapons result) #{:pistol})))
 
         (and (map? result) (:victory result))
         (let [[k t]           (carry-on carry-kills carry-time result)
               [kind new-seed] (handle-end victory-loop k t result seed true)]
           (cond
-            (= kind :fresh) (recur 1 max-lives 0 0 (php/mt_rand) false)
-            (= kind :same)  (recur 1 max-lives 0 0 new-seed false)
+            (= kind :fresh) (recur 1 max-lives 0 0 (php/mt_rand) false #{:pistol})
+            (= kind :same)  (recur 1 max-lives 0 0 new-seed false #{:pistol})
             :else           nil))
 
         (and (map? result) (:game-over result))
@@ -569,10 +603,10 @@
               died-on         (or (:level result) 1)]
           (cond
             ;; r: try the level you died on again with a fresh map.
-            (= kind :fresh) (recur died-on max-lives 0 0 (php/mt_rand) false)
+            (= kind :fresh) (recur died-on max-lives 0 0 (php/mt_rand) false #{:pistol})
             ;; R: replay the exact level you died on (same seed + same
             ;; level number reproduces identical geometry + enemies).
-            (= kind :same)  (recur died-on max-lives 0 0 new-seed false)
+            (= kind :same)  (recur died-on max-lives 0 0 new-seed false #{:pistol})
             :else           nil))
 
         :else

--- a/src/modules/core/level.phel
+++ b/src/modules/core/level.phel
@@ -184,6 +184,24 @@
               (assoc-in grid [y door-x] target)
               (recur (php/+ y 1)))))))))
 
+(defn- maybe-spawn-weapon-pickups
+  "Per-level weapon drops. L2 always seeds a shotgun, L3 always a
+   chaingun. Both skipped if the player already owns the weapon so a
+   re-played level doesn't spam duplicate pickups. Returns a vector
+   of `{:x :y :weapon kw}` items."
+  [grid level-num owned]
+  (let [owned'     (or owned #{:pistol})
+        candidates
+        (cond
+          (php/=== level-num 2) (if (contains? owned' :shotgun)  [] [:shotgun])
+          (php/=== level-num 3) (if (contains? owned' :chaingun) [] [:chaingun])
+          :else                 [])]
+    (apply vector
+           (map (fn [kw]
+                  (let [[wx wy] (random-spawn grid)]
+                    {:x wx :y wy :weapon kw}))
+                candidates))))
+
 (defn- maybe-spawn-keycard
   "Drop one keycard at a random open cell when the level is locked.
    Returns [] on unlocked levels so render / pickup skips."
@@ -224,9 +242,10 @@
    randomised. Level tuning is stamped onto the world so render and
    physics can read it without globals. `backpack?` controls whether
    the new level seeds another backpack — once owned, don't drop more."
-  ([level-num lives] (build-world level-num lives false :normal))
-  ([n l pack?] (build-world n l pack? :normal))
-  ([lv life pack? diff]
+  ([level-num lives] (build-world level-num lives false :normal #{:pistol}))
+  ([n l pack?] (build-world n l pack? :normal #{:pistol}))
+  ([n l pack? diff] (build-world n l pack? diff #{:pistol}))
+  ([lv life pack? diff owned]
    (let [diff' (normalise diff)
          cfg   (scale-cfg (config-for lv) diff')
          lock  (:door-lock cfg)]
@@ -242,18 +261,20 @@
                                                         enemy-min-spawn-dist px py
                                                         (or (:enemy-lives cfg) 1)))]
              (assoc with-foes
-                    :level       lv
-                    :lives       life
-                    :difficulty  diff'
-                    :backpack?   pack?
-                    :hearts      (maybe-spawn-heart grid life px py)
-                    :armors      (maybe-spawn-armor grid)
-                    :berserks    (maybe-spawn-berserk grid)
-                    :invulns     (maybe-spawn-invuln grid)
-                    :backpacks   (maybe-spawn-backpack grid lv pack?)
-                    :keycards    (maybe-spawn-keycard grid lock)
-                    :door-lock   lock
-                    :ammo-boxes  (spawn-ammo-boxes grid (ammo-box-count cfg))
+                    :level         lv
+                    :lives         life
+                    :difficulty    diff'
+                    :backpack?     pack?
+                    :owned-weapons (or owned #{:pistol})
+                    :hearts        (maybe-spawn-heart grid life px py)
+                    :armors        (maybe-spawn-armor grid)
+                    :berserks      (maybe-spawn-berserk grid)
+                    :invulns       (maybe-spawn-invuln grid)
+                    :backpacks     (maybe-spawn-backpack grid lv pack?)
+                    :keycards      (maybe-spawn-keycard grid lock)
+                    :weapon-pickups (maybe-spawn-weapon-pickups grid lv (or owned #{:pistol}))
+                    :door-lock     lock
+                    :ammo-boxes    (spawn-ammo-boxes grid (ammo-box-count cfg))
                     :chase-speed (:chase cfg)
                     :enemy-head-code     (:head-code cfg)
                     :enemy-body-code     (:body-code cfg)

--- a/src/modules/core/state.phel
+++ b/src/modules/core/state.phel
@@ -66,8 +66,11 @@
    ;; :mag and :ammo-reserve mirror the active weapon's live state so
    ;; combat / render / HUD code can read them without an extra hop;
    ;; weapons/switch keeps the mirror in sync.
-   :weapon        :pistol
-   :weapon-state  (initial-weapon-state)
+   :weapon         :pistol
+   ;; Fresh runs only own the pistol. Shotgun + chaingun must be
+   ;; found on the map (level.phel/maybe-spawn-weapon-pickup).
+   :owned-weapons  #{:pistol}
+   :weapon-state   (initial-weapon-state)
    :mag           10
    :ammo-reserve  30
    :heat        0.0

--- a/src/modules/core/weapons.phel
+++ b/src/modules/core/weapons.phel
@@ -107,15 +107,23 @@
                                  :reserve (:reserve-start s)})))]
     (reduce build {} weapon-order)))
 
+(defn owns?
+  "True when the player has picked up weapon `kw`. Pistol is always
+   owned (fresh-run default). Other weapons require a map pickup."
+  [world kw]
+  (contains? (or (:owned-weapons world) #{:pistol}) kw))
+
 (defn switch-weapon
   "Snap to weapon `to`. Persists the current weapon's mag + reserve
    back into `:weapon-state`, then loads `to`'s saved state into the
-   mirrored top-level `:mag` / `:ammo-reserve` fields. No-op when
-   the target weapon doesn't exist OR the player is mid-reload (so
-   you can't dodge a reload by hot-swapping)."
+   mirrored top-level `:mag` / `:ammo-reserve` fields. No-op when:
+     - the target weapon doesn't exist
+     - the player hasn't picked it up yet (must find on the map)
+     - the player is mid-reload (no hot-swap to dodge the lockout)"
   [world to]
   (cond
     (php/=== (get weapons to) nil)                world
+    (not (owns? world to))                        world
     (php/> (or (:reload-cooldown world) 0.0) 0.0) world
     :else
     (let [from   (current-weapon world)
@@ -129,3 +137,30 @@
              :weapon-state  saved
              :mag           (:mag loaded)
              :ammo-reserve  (:reserve loaded)))))
+
+(defn give-weapon
+  "Add `kw` to `:owned-weapons` AND snap to it (DOOM-style auto-switch
+   on first pickup). Refills the weapon's mag+reserve to its starting
+   values so the player can immediately fire the new weapon. No-op
+   if the weapon is unknown OR already owned (skip the auto-switch
+   so the player doesn't get yanked off their current weapon by a
+   redundant pickup)."
+  [world kw]
+  (cond
+    (php/=== (get weapons kw) nil) world
+    (owns? world kw)               world
+    :else
+    (let [owned (conj (or (:owned-weapons world) #{:pistol}) kw)
+          sp    (get weapons kw)
+          ;; Stash current weapon's state then load the new one fresh.
+          from  (current-weapon world)
+          saved (assoc (or (:weapon-state world) {})
+                       from {:mag     (or (:mag world) 0)
+                             :reserve (or (:ammo-reserve world) 0)})
+          fresh {:mag (:mag-size sp) :reserve (:reserve-start sp)}]
+      (assoc world
+             :owned-weapons owned
+             :weapon        kw
+             :weapon-state  (assoc saved kw fresh)
+             :mag           (:mag fresh)
+             :ammo-reserve  (:reserve fresh)))))

--- a/src/modules/io/render.phel
+++ b/src/modules/io/render.phel
@@ -62,6 +62,8 @@
 (def keycard-red-marker  "\e[40;91;1mk\e[0m")
 (def door-blue-marker    "\e[40;94;1m▌\e[0m")
 (def door-red-marker     "\e[40;91;1m▌\e[0m")
+(def shotgun-pickup-marker  "\e[40;33;1mS\e[0m")
+(def chaingun-pickup-marker "\e[40;32;1mC\e[0m")
 (def door-shade
   "Door body cell drawn when a ray hit a door. Frame glyph `▌` (left
    half block) on a dark steel BG with bright orange FG, so a column
@@ -197,6 +199,16 @@
 (def backpack-glyph-bright
   "Black ⊞ on the bright pulse BG."
   "\e[48;5;142;38;5;232;1m⊞")
+
+(def shotgun-pickup-shade  "\e[48;5;94m ")
+(def shotgun-pickup-bright "\e[48;5;130m ")
+(def shotgun-pickup-glyph  "\e[48;5;94;38;5;253;1m▤")
+(def shotgun-pickup-glyph-bright "\e[48;5;130;38;5;253;1m▤")
+
+(def chaingun-pickup-shade  "\e[48;5;238m ")
+(def chaingun-pickup-bright "\e[48;5;244m ")
+(def chaingun-pickup-glyph  "\e[48;5;238;38;5;46;1m▦")
+(def chaingun-pickup-glyph-bright "\e[48;5;244;38;5;46;1m▦")
 
 (def keycard-blue-shade  "\e[48;5;21m ")
 (def keycard-blue-bright "\e[48;5;33m ")
@@ -498,6 +510,10 @@
                                           (fn [k] (php/=== (:colour k) :blue)))
         krmap               (scaled-cells (:keycards world) step out-w
                                           (fn [k] (php/=== (:colour k) :red)))
+        wsmap               (scaled-cells (:weapon-pickups world) step out-w
+                                          (fn [w] (php/=== (:weapon w) :shotgun)))
+        wcmap               (scaled-cells (:weapon-pickups world) step out-w
+                                          (fn [w] (php/=== (:weapon w) :chaingun)))
         rows                (buf-mk)
         block-has-wall?     (fn [r0 c0]
                               (loop [dr 0]
@@ -552,6 +568,8 @@
                             (buf-get pmap (php/+ (php/* row out-w) col))  backpack-marker
                             (buf-get kbmap (php/+ (php/* row out-w) col)) keycard-blue-marker
                             (buf-get krmap (php/+ (php/* row out-w) col)) keycard-red-marker
+                            (buf-get wsmap (php/+ (php/* row out-w) col)) shotgun-pickup-marker
+                            (buf-get wcmap (php/+ (php/* row out-w) col)) chaingun-pickup-marker
                             :else                                         minimap-floor)))
               (recur (php/+ col 1))))
           (buf-set rows row (php/implode "" parts)))
@@ -1383,20 +1401,43 @@
           grip-hi   (:grip-hi   palette)
           grip-lo   (:grip-lo   palette)]
       ;; Gradient indices are 0-based for vh rows; cursor positions
-      ;; are 1-based. Map cursor row → gradient idx by subtracting 1.
-      (buf-push parts
-                (str
-                 (paint-row (php/- vh 5) (php/+ cc 1) (php/- vh 6) muzzle    "▄▄")
-                 (paint-row (php/- vh 4) cc           (php/- vh 5) slide     "▐██▌")
-                 (paint-row (php/- vh 3) (php/- cc 1) (php/- vh 4) slide     "▐████▌")
-                 (paint-row (php/- vh 2) (php/- cc 2) (php/- vh 3) slide-dim "▐██████▌")
-                 ;; Upper grip row mixes frame + grip-hi SGRs; pre-bake
-                 ;; the full glyph string so paint-row's clip logic
-                 ;; still owns the cursor + bg + skip-if-offscreen.
-                 (paint-row (php/- vh 1) (php/- cc 2) (php/- vh 2) frame
-                            (str "▐█" grip-hi "▓▓▓▓" frame "█▌"))
-                 (paint-row vh           (php/- cc 1) (php/- vh 1) grip-lo "▐▓▓▓▓▌")
-                 "\e[0m"))
+      ;; are 1-based. Per-weapon silhouette dispatches on :weapon —
+      ;; pistol stays narrow + single barrel, shotgun widens with a
+      ;; double-barrel muzzle + heavy stock, chaingun adds a multi-
+      ;; barrel cluster + wider housing.
+      (let [weapon (or (get stats :weapon) :pistol)
+            rows
+            (cond
+              (php/=== weapon :shotgun)
+              (str
+               (paint-row (php/- vh 5) (php/- cc 1) (php/- vh 6) muzzle    "▄▄▄▄▄▄")
+               (paint-row (php/- vh 4) (php/- cc 2) (php/- vh 5) slide     "▐██████▌")
+               (paint-row (php/- vh 3) (php/- cc 2) (php/- vh 4) slide     "▐████████▌")
+               (paint-row (php/- vh 2) (php/- cc 3) (php/- vh 3) slide-dim "▐██████████▌")
+               (paint-row (php/- vh 1) (php/- cc 3) (php/- vh 2) frame
+                          (str "▐█" grip-hi "▓▓▓▓▓▓▓▓" frame "█▌"))
+               (paint-row vh           (php/- cc 2) (php/- vh 1) grip-lo "▐▓▓▓▓▓▓▓▓▌"))
+
+              (php/=== weapon :chaingun)
+              (str
+               (paint-row (php/- vh 5) cc           (php/- vh 6) muzzle    "▄ ▄ ▄")
+               (paint-row (php/- vh 4) (php/- cc 2) (php/- vh 5) slide     "▐██████▌")
+               (paint-row (php/- vh 3) (php/- cc 3) (php/- vh 4) slide     "▐████████▌")
+               (paint-row (php/- vh 2) (php/- cc 3) (php/- vh 3) slide-dim "▐██████████▌")
+               (paint-row (php/- vh 1) (php/- cc 3) (php/- vh 2) frame
+                          (str "▐█" grip-hi "▓▓▓▓▓▓▓▓" frame "█▌"))
+               (paint-row vh           (php/- cc 2) (php/- vh 1) grip-lo "▐▓▓▓▓▓▓▓▓▌"))
+
+              :else
+              (str
+               (paint-row (php/- vh 5) (php/+ cc 1) (php/- vh 6) muzzle    "▄▄")
+               (paint-row (php/- vh 4) cc           (php/- vh 5) slide     "▐██▌")
+               (paint-row (php/- vh 3) (php/- cc 1) (php/- vh 4) slide     "▐████▌")
+               (paint-row (php/- vh 2) (php/- cc 2) (php/- vh 3) slide-dim "▐██████▌")
+               (paint-row (php/- vh 1) (php/- cc 2) (php/- vh 2) frame
+                          (str "▐█" grip-hi "▓▓▓▓" frame "█▌"))
+               (paint-row vh           (php/- cc 1) (php/- vh 1) grip-lo "▐▓▓▓▓▌")))]
+        (buf-push parts (str rows "\e[0m")))
       ;; Muzzle flash suppressed during a reload (drop > 0). Tracks
       ;; the recoil so the flash hangs above the muzzle through the
       ;; kick instead of floating in stale screen space.
@@ -1735,6 +1776,11 @@
         keycard-blue-glyph-now             (if keycard-bright? keycard-blue-glyph-bright keycard-blue-glyph)
         keycard-red-shade-now              (if keycard-bright? keycard-red-bright keycard-red-shade)
         keycard-red-glyph-now              (if keycard-bright? keycard-red-glyph-bright keycard-red-glyph)
+        weapon-pickup-bright?              (pulse t 3.0)
+        shotgun-pickup-shade-now           (if weapon-pickup-bright? shotgun-pickup-bright shotgun-pickup-shade)
+        shotgun-pickup-glyph-now           (if weapon-pickup-bright? shotgun-pickup-glyph-bright shotgun-pickup-glyph)
+        chaingun-pickup-shade-now          (if weapon-pickup-bright? chaingun-pickup-bright chaingun-pickup-shade)
+        chaingun-pickup-glyph-now          (if weapon-pickup-bright? chaingun-pickup-glyph-bright chaingun-pickup-glyph)
         ;; Atmospheric haze pulls walls toward black as lives drop, so
         ;; the world reads as 'consumed by darkness' the closer the
         ;; player is to dying. Sky / floor untouched; doors keep their
@@ -1911,6 +1957,18 @@
                                                         (or (:keycards world) [])))
                                          (:player world) dists edists vw vh
                                          keycard-red-shade-now keycard-red-glyph-now)
+          bp-ws     (paint-pickups-into  bp-kr
+                                         (apply vector
+                                                (filter (fn [w] (php/=== (:weapon w) :shotgun))
+                                                        (or (:weapon-pickups world) [])))
+                                         (:player world) dists edists vw vh
+                                         shotgun-pickup-shade-now shotgun-pickup-glyph-now)
+          bp-wc     (paint-pickups-into  bp-ws
+                                         (apply vector
+                                                (filter (fn [w] (php/=== (:weapon w) :chaingun))
+                                                        (or (:weapon-pickups world) [])))
+                                         (:player world) dists edists vw vh
+                                         chaingun-pickup-shade-now chaingun-pickup-glyph-now)
           parts     (buf-mk)]
       (dotimes [row vh]
                (loop [col 0 prev nil run 0]
@@ -1929,7 +1987,7 @@
                          flr-row   (buf-get (if in-blood? blood-floor-gradient floor-gradient) row)
                          c         (if (and (php/< row visible-mh) (php/>= col mini-col0))
                                      sky-row
-                                     (or (buf-get bp-kr (php/+ (php/* row vw) col))
+                                     (or (buf-get bp-wc (php/+ (php/* row vw) col))
                                          (cond
                                            (php/< row (buf-get tops col))             sky-row
                                            (php/>= row (buf-get bots col))            flr-row
@@ -1978,7 +2036,7 @@
             c-row       (php/+ (php/intdiv vh 2) (if firing? -1 0))
             top-col     (buf-get tops c-col)
             bot-col     (buf-get bots c-col)
-            center-cell (or (buf-get bp-kr (php/+ (php/* c-row vw) c-col))
+            center-cell (or (buf-get bp-wc (php/+ (php/* c-row vw) c-col))
                             (cond
                               (php/< c-row top-col)             (buf-get sky-gradient c-row)
                               (php/>= c-row bot-col)            (buf-get floor-gradient c-row)

--- a/tests/modules/core/weapons-test.phel
+++ b/tests/modules/core/weapons-test.phel
@@ -1,7 +1,7 @@
 (ns phel-doom-tests.modules.core.weapons-test
   (:require phel.test :refer [deftest is])
   (:require phel-doom.modules.core.state :refer [new-player new-world])
-  (:require phel-doom.modules.core.weapons :refer [current-weapon initial-weapon-state switch-weapon weapon-spec weapons]))
+  (:require phel-doom.modules.core.weapons :refer [current-weapon give-weapon initial-weapon-state owns? switch-weapon weapon-spec weapons]))
 
 (def empty-grid [[1 1 1] [1 0 1] [1 1 1]])
 
@@ -28,9 +28,24 @@
     (is (= 8  (get-in s [:shotgun  :reserve])))
     (is (= 0  (get-in s [:chaingun :reserve])))))
 
-(deftest test-switch-weapon-saves-current-and-loads-target
-  ;; Player burns 3 pistol rounds (mag 7), then swaps to shotgun.
-  (let [w0 (assoc (fresh-world) :mag 7 :ammo-reserve 25)
+(deftest test-fresh-run-owns-only-pistol
+  (let [w (fresh-world)]
+    (is (= true  (owns? w :pistol)))
+    (is (= false (owns? w :shotgun)))
+    (is (= false (owns? w :chaingun)))))
+
+(deftest test-switch-weapon-noop-when-not-owned
+  ;; Player pressing 2 with only the pistol in inventory: no swap.
+  (let [w (switch-weapon (fresh-world) :shotgun)]
+    (is (= :pistol (:weapon w)))))
+
+(deftest test-switch-weapon-saves-current-and-loads-target-when-owned
+  ;; Player burns 3 pistol rounds (mag 7), picks up shotgun first,
+  ;; then explicitly swaps. give-weapon already auto-switched, so
+  ;; verify a manual swap back round-trips state.
+  (let [w0 (assoc (fresh-world)
+                  :mag 7 :ammo-reserve 25
+                  :owned-weapons #{:pistol :shotgun})
         w1 (switch-weapon w0 :shotgun)]
     (is (= :shotgun (:weapon w1)))
     (is (= 4 (:mag w1)))           ; shotgun mag-size fresh
@@ -40,7 +55,9 @@
     (is (= 25 (get-in w1 [:weapon-state :pistol :reserve])))))
 
 (deftest test-switch-weapon-is-noop-mid-reload
-  (let [w0 (assoc (fresh-world) :reload-cooldown 0.5)
+  (let [w0 (assoc (fresh-world)
+                  :owned-weapons #{:pistol :shotgun}
+                  :reload-cooldown 0.5)
         w1 (switch-weapon w0 :shotgun)]
     (is (= :pistol (:weapon w1)))))
 
@@ -50,10 +67,35 @@
     (is (= :pistol (:weapon w1)))))
 
 (deftest test-switch-weapon-round-trip-preserves-state
-  ;; Pistol mag 7, swap to shotgun, swap back -> pistol still mag 7.
-  (let [w0 (assoc (fresh-world) :mag 7 :ammo-reserve 25)
+  ;; Pistol mag 7, owned both, swap to shotgun, swap back -> pistol
+  ;; still mag 7.
+  (let [w0 (assoc (fresh-world)
+                  :mag 7 :ammo-reserve 25
+                  :owned-weapons #{:pistol :shotgun})
         w1 (switch-weapon w0 :shotgun)
         w2 (switch-weapon w1 :pistol)]
     (is (= :pistol (:weapon w2)))
     (is (= 7  (:mag w2)))
     (is (= 25 (:ammo-reserve w2)))))
+
+(deftest test-give-weapon-adds-to-owned-and-autoswitches
+  ;; First-time pickup snaps to the new weapon DOOM-style.
+  (let [w0 (assoc (fresh-world) :mag 7 :ammo-reserve 25)
+        w1 (give-weapon w0 :shotgun)]
+    (is (= true (owns? w1 :shotgun)))
+    (is (= :shotgun (:weapon w1)))
+    (is (= 4 (:mag w1)))                  ; shotgun mag-size
+    (is (= 8 (:ammo-reserve w1)))         ; shotgun reserve-start
+    ;; Pistol's mid-mag count stashed for the eventual swap back.
+    (is (= 7  (get-in w1 [:weapon-state :pistol :mag])))))
+
+(deftest test-give-weapon-second-pickup-is-noop
+  ;; Picking up a duplicate weapon shouldn't yank the player back to it.
+  (let [w0 (give-weapon (fresh-world) :shotgun)
+        w1 (give-weapon w0 :shotgun)]
+    (is (= :shotgun (:weapon w1)))))      ; unchanged
+
+(deftest test-give-weapon-unknown-is-noop
+  (let [w (give-weapon (fresh-world) :rocket-launcher)]
+    (is (= :pistol (:weapon w)))
+    (is (= false (owns? w :rocket-launcher)))))


### PR DESCRIPTION
Player starts with pistol only; shotgun spawns on L2, chaingun on L3. Pickup auto-switches DOOM-style. 1/2/3 only switches to owned weapons.

Each weapon has distinct silhouette: slim pistol, wide twin-barrel shotgun, multi-barrel chaingun cluster.

447 tests, CI green.