### PR TITLE
feat(sprint): hold SHIFT or x to sprint with stamina bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 
 ### Added
 
+**Movement**
+- Sprint verb (closes #35). Hold **SHIFT** (kitty / Ghostty / WezTerm / iTerm2 ≥ 3.5) or **`x`** (any terminal) to multiply forward + strafe speed by `sprint-multiplier` (1.6×) at the cost of draining a `:stamina` pool. Pool defaults to `max-stamina` (100), drains at 30 units/sec while sprinting AND moving, regenerates at 20 units/sec after a 0.5s post-sprint cooldown. Hitting empty latches `:sprint-blocked?` until stamina recovers to `sprint-engage-threshold` (20) — prevents stutter-sprint at zero. HUD top-left strip gets a new chip `STA ████████░░` (10 cells, white → amber under 33% → red at 0). Turn-speed is unchanged. Kitty path parses the SHIFT bit out of the CSI-u mods field; legacy path uses the plain `"x"` byte; both refresh a new `:sprint` movement slot that decays alongside WASD so sprint intent evaporates the frame the player lets go.
+
 **Weapons + combat**
 - 3-slot loadout (1/2/3) with DPS-balanced niches: pistol 1 dmg @ 0.12s cd (8 dps fallback), shotgun 3 dmg @ 0.6s cd (5 dps burst killer — 1-shots L1-L3 enemies, 2-shots the L5 baron), chaingun 1 dmg @ 0.05s cd (20 dps sustained spray, ammo hog). Picking up a chaingun does NOT obsolete the shotgun — they own different niches. Per-weapon mag + reserve persist across switches. Each weapon has its own SGR palette so the bottom sprite reads as a distinct piece of kit.
 - Auto-fire while space held for pistol + chaingun (`:auto-fire? true` in weapons spec). Without it, the chaingun's 0.05s cd was capped by the player's tap rate, so the 20 dps niche was unreachable. Shotgun stays single-action — each shell requires a fresh trigger pull.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ make play
 | `w` / `s` / ↑↓ | Move forward / back          |
 | `a` / `d`      | Strafe left / right          |
 | `←` / `→`      | Turn left / right            |
+| `SHIFT` / `x`  | Sprint (1.6× speed, drains stamina) |
 | `e`            | About-face (snap 180°)       |
 | `space`        | Fire                         |
 | `r`            | Reload (draws from reserve) |

--- a/docs/features.md
+++ b/docs/features.md
@@ -57,7 +57,7 @@ See [monsters.md](monsters.md), [combat.md](combat.md).
 
 ## HUD + screens
 
-- Top-left strip: row 1 hearts + armor + `GOD` badge (dev mode), row 2 `L1 imps · kills · weapon · ammo · +pack · ⚿ · [diff]`
+- Top-left strip: row 1 hearts + armor + `GOD` badge (dev mode), row 2 `L1 imps · kills · weapon · ammo · +pack · STA ████████░░ · ⚿ · [diff]`
 - Compass top-centre (facing letter yellow; on locked levels the letter pointing at the un-picked key tints blue/red). Top-right minimap auto-scales to ≤ 1/3 width on narrow terminals.
 - F3 debug overlay (frame-ms, cast/render split, bytes, RLE, mem, pos, angle, fps) — off by default, zero overhead when off
 - Ammo cues: pulsing `! LOW AMMO N !` top-right when firepower drops to 3/2/1; periodic `press R to RELOAD`; dry-fire `CLICK` prompt
@@ -117,5 +117,6 @@ See [scores.md](scores.md).
   reader, not wired to render yet
 - Movement uses kitty keyboard protocol for instant release on
   supported terminals; legacy hold-frames fallback elsewhere
+- Sprint: hold **SHIFT** (kitty) or **`x`** (anywhere) for 1.6× move/strafe speed. Drains a 100-unit `:stamina` pool at 30/s; regenerates at 20/s after a 0.5s cooldown. At empty, sprint stays locked until stamina recovers to 20. HUD shows a 10-cell `STA ████████░░` bar that turns amber under 33% and red at 0.
 
 See [wad-parser.md](wad-parser.md), [input.md](input.md).

--- a/docs/input.md
+++ b/docs/input.md
@@ -54,10 +54,21 @@ Arrows arrive as 3-byte CSI escapes: `\e[A` up, `\e[B` down, `\e[C` right, `\e[D
    "<" :turn-left
    ">" :turn-right
    "a" :strafe-left
-   "d" :strafe-right})
+   "d" :strafe-right
+   "x" :sprint})
 ```
 
 Each byte refreshes its slot's counter on `:moves`. Counter is the only thing physics reads. See [state.md](state.md).
+
+## Sprint
+
+Hold **SHIFT** (kitty terminals) or **`x`** (anywhere) to sprint. Sprint multiplies forward + strafe speed by `sprint-multiplier` (1.6×) and drains the `:stamina` pool (`max-stamina` 100, drain 30/s). Stamina regenerates at 20/s after a 0.5s post-sprint cooldown. Hitting empty latches `:sprint-blocked?` until stamina recovers to `sprint-engage-threshold` (20) — prevents stutter-sprint at zero.
+
+Two input paths:
+- **Kitty path**: `apply-kitty-events` / `apply-kitty-arrow-events` parse the `mods` field of `\e[<code>;<mods>(:<event>)?u` / `\e[1;<mods>:<event><letter>`. Mods are encoded as `bits + 1`; bit 0 = SHIFT. Press/repeat events on a movement key (WASD or arrows) with the SHIFT bit set refresh the `:sprint` slot too — so holding SHIFT+W keeps the slot warm. Release events do NOT refresh sprint (player let go).
+- **Legacy path**: `key->slot` maps the plain `"x"` byte to `:sprint` so terminals without kitty (Terminal.app, basic xterm) get a working sprint key too. Under kitty, `"x"` arrives as `\e[120u` and resolves via `ascii->slot` to the same `:sprint` refresh.
+
+The `:sprint` slot decays alongside the other movement counters in `decay-move-counters`, so sprint intent naturally evaporates the frame the player lets go.
 
 ## Hold-frames trade-off
 

--- a/docs/rendering.md
+++ b/docs/rendering.md
@@ -46,7 +46,7 @@
   │     - crosshair (centre), kill-streak counter, compass
   │     - rear-warning (centre row 2 when :rear-warning?)
   │     - LOW AMMO N pulse (right row 1 when firepower ≤ 3)
-  │     - game-info strip (top-left row 2: L# · kills · ammo)
+  │     - game-info strip (top-left row 2: L# · kills · weapon · ammo · +pack · STA bar · keys · [diff])
   │     - top-left hearts + armor HUD (row 1)
   │     - pistol sprite + reload-drop animation (centre-bottom)
   │     - muzzle flash (when :fire-anim > 0 and drop = 0)

--- a/docs/state.md
+++ b/docs/state.md
@@ -48,7 +48,10 @@ Pure data shapes that every other module operates on. `src/modules/core/state.ph
  :empty-click-secs <float seconds>    ; dry-fire CLICK prompt timer
  :heat          <float 0..1>          ; pistol heat; ≥ 1 triggers jam
  :jam-secs      <float seconds>       ; jammed-pistol lockout
- :moves      {:fwd :back :strafe-left :strafe-right :turn-left :turn-right}}
+ :stamina              <float 0..max-stamina>  ; sprint pool, default 100.0
+ :sprint-cooldown-secs <float seconds>         ; regen lockout post-sprint
+ :sprint-blocked?      <bool>                  ; latches at 0, clears at threshold
+ :moves      {:fwd :back :strafe-left :strafe-right :turn-left :turn-right :sprint}}
 ```
 
 After `build-world` from `core/level.phel` stamps level metadata, the world also carries:
@@ -89,7 +92,7 @@ On grid mutation (door turning into floor, etc.) **both** must update. See `pick
 
 ## Movement counters (`:moves`)
 
-Six time-limited counters drive directional motion:
+Seven time-limited counters drive directional motion + sprint intent:
 
 ```phel
 {:fwd          <int frames remaining>
@@ -97,10 +100,13 @@ Six time-limited counters drive directional motion:
  :strafe-left  <int>
  :strafe-right <int>
  :turn-left    <int>
- :turn-right   <int>}
+ :turn-right   <int>
+ :sprint       <int>}    ; SHIFT (kitty) or `x` press refresh
 ```
 
 Each input byte from `glue/controls.phel` refreshes the matching counter. Each frame `core/physics.phel` consumes whatever is non-zero (scaled by `dt`) and decays every counter by 1. Counter hits 0 = direction stops.
+
+`:sprint` is intent only — the actual speed boost is gated by `:stamina > 0` AND `not :sprint-blocked?`. See `physics.phel`'s `tick-stamina` + `sprinting?`.
 
 Hold-frame size is the only "feel" knob: shorter = snappier stop, longer = smoother sustained-hold (bridges OS auto-repeat gaps). Current: `move-hold-frames=12`, `turn-hold-frames=3`.
 

--- a/src/commands/play.phel
+++ b/src/commands/play.phel
@@ -1,12 +1,12 @@
 (ns phel-doom.commands.play
   (:require phel.cli :as cli)
   (:require phel.string :as str)
-  (:require phel-doom.modules.core.state    :refer [advance-game-time gain-life max-armor max-lives
+  (:require phel-doom.modules.core.state    :refer [advance-game-time gain-life max-armor max-lives max-stamina
                                                     toggle-debug toggle-map toggle-pause toggle-sound])
   (:require phel-doom.modules.core.map      :refer [door?])
   (:require phel-doom.modules.glue.controls :refer [refresh-from-keys key-states rising-edges
                                                     initial-key-snapshot])
-  (:require phel-doom.modules.core.physics  :refer [apply-physics tick-heartbeat tick-flicker tick-blood-drops tick-door-face])
+  (:require phel-doom.modules.core.physics  :refer [apply-physics tick-heartbeat tick-flicker tick-blood-drops tick-door-face tick-stamina])
   (:require phel-doom.modules.core.combat   :refer [ammo-per-box berserk-seconds damage-step fire-anim-seconds invuln-seconds max-reserve reload reloading? reload-cooldown-seconds tick-shooting])
   (:require phel-doom.modules.core.enemy    :refer [advance tick-scare rear-attacker?])
   (:require phel-doom.modules.core.weapons  :refer [effective-reserve-cap give-weapon switch-weapon weapon-spec weapon-order weapons])
@@ -362,7 +362,14 @@
                   (:select-weapon2 edges) (switch-weapon w1 (get weapon-order 1))
                   (:select-weapon3 edges) (switch-weapon w1 (get weapon-order 2))
                   :else                   w1)
-            w2  (apply-physics w1a dt)
+            ;; tick-stamina runs BEFORE apply-physics so that, on the
+            ;; frame the player's pool empties, the `:sprint-blocked?`
+            ;; latch fires before physics samples it — apply-physics
+            ;; then walks at base speed instead of getting one final
+            ;; 1.6x frame "for free". Drain reads the just-refreshed
+            ;; :moves slots (refresh-from-keys above), so the player
+            ;; pays for the intent the same frame they signal it.
+            w2  (apply-physics (tick-stamina w1a dt) dt)
             w3  (pickup-hearts w2)
             w4  (pickup-armors w3)
             w4b (pickup-ammos  w4)
@@ -443,6 +450,9 @@
    :locked-door-bump-colour (:locked-door-bump-colour world)
    :owned-weapons  (or (:owned-weapons world) #{:pistol})
    :weapon-state   (or (:weapon-state world) {})
+   :stamina        (or (:stamina world) max-stamina)
+   :max-stamina    max-stamina
+   :sprint-blocked? (boolean (:sprint-blocked? world))
    :rear-warning? (rear-attacker? (:enemies world)
                                   (:x (:player world))
                                   (:y (:player world))
@@ -691,6 +701,10 @@
         nil
 
         (and (map? result) (:next-level result))
+        ;; Stamina + sprint-cooldown + :sprint-blocked? are deliberately
+        ;; NOT carried across the door — stepping into the next level
+        ;; counts as a breather, the pool refills to max via new-world.
+        ;; Lives, weapons, mag/reserve and player toggles do carry.
         (let [[k t] (carry-on carry-kills carry-time result)]
           (recur (:level result) (:lives result) k t (php/mt_rand)
                  (boolean (:backpack? result))

--- a/src/modules/core/physics.phel
+++ b/src/modules/core/physics.phel
@@ -1,5 +1,5 @@
 (ns phel-doom.modules.core.physics
-  (:require phel-doom.modules.core.state :refer [move-player turn-player])
+  (:require phel-doom.modules.core.state :refer [max-stamina move-player turn-player])
   (:require phel-doom.modules.core.map   :refer [missing-key-for passable? wall?]))
 
 (def locked-bump-secs
@@ -29,6 +29,37 @@
 (def turn-speed
   "Radians per second of sustained rotation."
   2.0)
+
+(def sprint-multiplier
+  "Speed multiplier applied to longitudinal + lateral motion while the
+   sprint slot is on AND stamina is available. Turn-speed is NOT
+   scaled — sprint is a translation modifier, not a rotation one."
+  1.6)
+
+(def stamina-drain
+  "Stamina units burned per second while sprinting AND moving. At
+   max-stamina (100) this gives ~3.3s of sustained sprint before the
+   pool empties."
+  30.0)
+
+(def stamina-regen
+  "Stamina units recovered per second while NOT sprinting and once
+   the post-sprint cooldown has elapsed. Slower than drain so the
+   chase-then-recover loop has a real tactical cost."
+  20.0)
+
+(def sprint-cooldown-after
+  "Seconds the regen is held back after a sprint stops. Prevents
+   tap-shift-tap-shift abuse — the player needs a brief beat off
+   the trigger before the pool starts refilling."
+  0.5)
+
+(def sprint-engage-threshold
+  "Stamina value (out of max-stamina) the player must recover to
+   before sprint can re-engage after a full depletion. Below this
+   :sprint-blocked? stays latched even though stamina > 0, so the
+   player can't stutter-sprint at empty."
+  20.0)
 
 (defn try-move
   "Translate the player by (dx, dy) unless the destination cell holds
@@ -62,17 +93,38 @@
   [moves slot ^float speed ^float dt]
   (if (counter-on? moves slot) (php/* speed dt) 0.0))
 
+(defn- sprinting?
+  "True when the player is actively burning sprint this frame: sprint
+   intent armed AND stamina pool not empty AND not latched-blocked."
+  [world]
+  (let [moves (:moves world)]
+    (and (counter-on? moves :sprint)
+         (php/> (or (:stamina world) 0.0) 0.0)
+         (not (:sprint-blocked? world)))))
+
+(defn- sprint-factor
+  "Speed multiplier to apply this frame — sprint-multiplier when the
+   sprint gate is open, 1.0 otherwise."
+  [world]
+  (if (sprinting? world) sprint-multiplier 1.0))
+
 (defn- turn-delta [moves ^float dt]
   (php/- (contribution moves :turn-right turn-speed dt)
          (contribution moves :turn-left  turn-speed dt)))
 
-(defn- longitudinal-delta [moves ^float dt]
-  (php/- (contribution moves :fwd  move-speed dt)
-         (contribution moves :back move-speed dt)))
+(defn- longitudinal-delta [world ^float dt]
+  (let [moves (:moves world)
+        sf    (sprint-factor world)]
+    (php/* sf
+           (php/- (contribution moves :fwd  move-speed dt)
+                  (contribution moves :back move-speed dt)))))
 
-(defn- lateral-delta [moves ^float dt]
-  (php/- (contribution moves :strafe-right strafe-speed dt)
-         (contribution moves :strafe-left  strafe-speed dt)))
+(defn- lateral-delta [world ^float dt]
+  (let [moves (:moves world)
+        sf    (sprint-factor world)]
+    (php/* sf
+           (php/- (contribution moves :strafe-right strafe-speed dt)
+                  (contribution moves :strafe-left  strafe-speed dt)))))
 
 (defn- apply-rotation [world ^float turn-by]
   (if (php/=== turn-by 0.0)
@@ -98,18 +150,65 @@
             :strafe-left  (decay-counter (:strafe-left m))
             :strafe-right (decay-counter (:strafe-right m))
             :turn-left    (decay-counter (:turn-left m))
-            :turn-right   (decay-counter (:turn-right m))})))
+            :turn-right   (decay-counter (:turn-right m))
+            :sprint       (decay-counter (or (:sprint m) 0))})))
+
+(defn- any-movement-on? [world]
+  (let [m (:moves world)]
+    (or (counter-on? m :fwd)
+        (counter-on? m :back)
+        (counter-on? m :strafe-left)
+        (counter-on? m :strafe-right))))
 
 (defn apply-physics
   "Per-frame: rotate, then translate using the new heading, then
-   decay every counter by one frame."
+   decay every counter by one frame. Translation deltas read both
+   `:moves` AND the sprint state (via sprint-factor) so sprint
+   intent x stamina > 0 x not-blocked yields a 1.6x boost."
   [world ^float dt]
   (let [moves (:moves world)]
     (let [turned (apply-rotation world (turn-delta moves dt))]
       (let [walked (apply-translation turned
-                                      (longitudinal-delta moves dt)
-                                      (lateral-delta moves dt))]
+                                      (longitudinal-delta turned dt)
+                                      (lateral-delta turned dt))]
         (decay-move-counters walked)))))
+
+(defn tick-stamina
+  "Drain stamina while sprinting + moving, regenerate while not (after
+   a brief cooldown), and manage the :sprint-blocked? latch.
+
+   - sprinting + moving: stamina -= stamina-drain * dt (clamped >= 0).
+     On hitting 0, latch :sprint-blocked? true and arm cooldown.
+   - not sprinting: tick cooldown down; once 0, regen by
+     stamina-regen * dt (clamped <= max-stamina). Once stamina recovers
+     past sprint-engage-threshold, clear :sprint-blocked? so the player
+     can sprint again."
+  [world ^float dt]
+  (let [stam  (or (:stamina world) max-stamina)
+        cd    (or (:sprint-cooldown-secs world) 0.0)
+        blkd? (boolean (:sprint-blocked? world))
+        spr?  (sprinting? world)
+        move? (any-movement-on? world)]
+    (cond
+      (and spr? move?)
+      (let [stam'  (php/max 0.0 (php/- stam (php/* stamina-drain dt)))
+            empty? (php/<= stam' 0.0)]
+        (assoc world
+               :stamina               stam'
+               :sprint-blocked?       (or blkd? empty?)
+               :sprint-cooldown-secs  (if empty? sprint-cooldown-after cd)))
+
+      :else
+      (let [cd'        (php/max 0.0 (php/- cd dt))
+            regen?     (php/<= cd' 0.0)
+            stam'      (if regen?
+                         (php/min max-stamina (php/+ stam (php/* stamina-regen dt)))
+                         stam)
+            unblocked? (and blkd? (php/>= stam' sprint-engage-threshold))]
+        (assoc world
+               :stamina               stam'
+               :sprint-cooldown-secs  cd'
+               :sprint-blocked?       (and blkd? (not unblocked?)))))))
 
 (def blood-drop-spawn-rate
   "Expected new drops per second (Bernoulli per-frame using dt)."

--- a/src/modules/core/state.phel
+++ b/src/modules/core/state.phel
@@ -17,6 +17,13 @@
    ignored so the player can't farm an indestructible buffer."
   3)
 
+(def max-stamina
+  "Hard cap on the sprint stamina pool. Fresh runs start at this value
+   so the player has a full burst available the moment they spawn.
+   Physics drains it while sprinting and regenerates it (after a short
+   cooldown) while not."
+  100.0)
+
 (defn new-world
   "Bundle map grid and player into the world state. Stores a PHP-native
    copy of the grid under :pgrid so the raycast hot loop can read cells
@@ -93,12 +100,23 @@
    :scare-secs          0.0
    :fx          []
    :game-time   0.0
+   ;; Sprint pool + latches. :stamina decays while sprinting (and
+   ;; moving), regenerates while not. :sprint-cooldown-secs holds
+   ;; regen back for a short window after the player lets go so a
+   ;; tap-shift-tap-shift player can't hide the drain. :sprint-blocked?
+   ;; latches true when stamina hits 0 mid-sprint and unlatches when
+   ;; stamina recovers past sprint-engage-threshold — prevents
+   ;; stutter-sprint at empty.
+   :stamina                  max-stamina
+   :sprint-cooldown-secs     0.0
+   :sprint-blocked?          false
    :moves      {:fwd          0
                 :back         0
                 :strafe-left  0
                 :strafe-right 0
                 :turn-left    0
-                :turn-right   0}})
+                :turn-right   0
+                :sprint       0}})
 
 (defn gain-life
   "Add one life to the player, capped at max-lives."

--- a/src/modules/glue/controls.phel
+++ b/src/modules/glue/controls.phel
@@ -31,23 +31,39 @@
    way the game can tell the player let go."
   3)
 
+(def sprint-hold-frames
+  "Frames the :sprint slot stays warm after a SHIFT-mod or 'x' byte.
+   Short (~50ms) because there is no explicit SHIFT-release signal
+   on the kitty path — sprint MUST decay fast enough that releasing
+   SHIFT while still walking forward stops the speed boost (and the
+   stamina drain) within a frame or two. Without this the 18-frame
+   move-hold-frames bridge would leave sprint hot for ~300ms after
+   release, which the HUD bar exposes as a phantom drain."
+  3)
+
 (def key->slot
   "Map a single-byte input to the direction-counter slot it activates.
    Arrow-key escape sequences are normalised to ^ _ < > before lookup
-   so they slot in alongside WASD."
+   so they slot in alongside WASD. `x` arms the sprint slot — the
+   legacy / non-kitty fallback for terminals that don't expose SHIFT
+   modifier bits via CSI-u."
   {"^" :fwd    "w" :fwd
    "_" :back   "s" :back
    "<" :turn-left
    ">" :turn-right
    "a" :strafe-left
-   "d" :strafe-right})
+   "d" :strafe-right
+   "x" :sprint})
 
 (def turn-slots
   "Slots that use turn-hold-frames instead of move-hold-frames."
   #{:turn-left :turn-right})
 
 (defn- hold-frames-for [slot]
-  (if (turn-slots slot) turn-hold-frames move-hold-frames))
+  (cond
+    (turn-slots slot)      turn-hold-frames
+    (php/=== slot :sprint) sprint-hold-frames
+    :else                  move-hold-frames))
 
 (defn refresh-move
   "If `byte` maps to a direction slot, refresh that slot's counter on
@@ -91,12 +107,15 @@
 ;; ---------------------------------------------------------------------
 
 (def ascii->slot
-  "ASCII codepoint -> direction-counter slot. Only WASD movement +
-   ←→ turn (kitty reports left-arrow as 57351, right as 57349)."
+  "ASCII codepoint -> direction-counter slot. WASD movement, ←→ turn
+   (kitty reports left-arrow as 57351, right as 57349), and 'x' (120)
+   as the legacy sprint key — works under kitty too without needing
+   the SHIFT modifier bit."
   {119 :fwd
    115 :back
    97 :strafe-left
    100 :strafe-right
+   120 :sprint
    57351 :turn-left
    57349 :turn-right})
 
@@ -110,17 +129,39 @@
   [world slot]
   (assoc-in world [:moves slot] (hold-frames-for slot)))
 
+(def movement-slots
+  "Slots whose press counts as 'the player is trying to walk' for
+   SHIFT-modifier sprint arming. Turn slots are excluded — sprint is
+   a translation modifier, not a rotation one (issue #35 design)."
+  #{:fwd :back :strafe-left :strafe-right})
+
+(defn- shift-mods?
+  "Kitty encodes the mod field as `bits + 1`, so plain SHIFT alone
+   arrives as mods=2 (bits=1, bit 0 = SHIFT). 0 / missing means no
+   mods. Returns true when the SHIFT bit is set."
+  [mods]
+  (and (php/> mods 0)
+       (php/=== (php/intval (php/% (php/- mods 1) 2)) 1)))
+
 (defn- handle-kitty-event
-  "Apply one parsed kitty event [code event-type] to `world`. Press +
-   repeat refresh the slot's hold; release clears the slot to 0 so
-   the player stops the instant they let go."
-  [world code event-type]
+  "Apply one parsed kitty event [code event-type mods] to `world`.
+   Press + repeat refresh the slot's hold; release clears the slot
+   to 0 so the player stops the instant they let go. When the event
+   is press/repeat AND the SHIFT modifier bit is set AND the slot is
+   a movement slot, also refresh `:sprint` so SHIFT+WASD primes the
+   sprint pool (this is the kitty path of the user-picked
+   `SHIFT (kitty) + x fallback` binding from issue #35)."
+  [world code event-type mods]
   (let [slot (get ascii->slot code)]
-    (if (nil? slot)
-      world
-      (cond
-        (php/=== event-type 3) (clear-slot world slot)
-        :else                  (press-slot world slot)))))
+    (cond
+      (php/=== event-type 3)
+      (if (nil? slot) world (clear-slot world slot))
+
+      :else
+      (let [w1 (if (nil? slot) world (press-slot world slot))]
+        (if (and (shift-mods? mods) (contains? movement-slots slot))
+          (press-slot w1 :sprint)
+          w1)))))
 
 (defn- apply-kitty-events
   "Scan `keys` for kitty CSI-u sequences and fold them into `world`.
@@ -130,24 +171,28 @@
   [world keys]
   (let [matches (php/array)
         ;; Regex: ESC [ <code> ( ; mods ( : event )? )? u
-        ;; - code is digits
-        ;; - optional ;mods (digits)
-        ;; - optional :event (digits) inside the mods group
-        re      "/\\x1b\\[(\\d+)(?:;\\d+(?::(\\d+))?)?u/"]
+        ;; - code  is digits
+        ;; - mods  optional digits after the first ';' (kitty encodes
+        ;;         as bits+1; bit 0 = SHIFT — used by sprint arming)
+        ;; - event optional digits after ':' (1=press 2=repeat 3=release)
+        re      "/\\x1b\\[(\\d+)(?:;(\\d+)(?::(\\d+))?)?u/"]
     (php/preg_match_all re keys matches)
-    (let [codes  (php/aget matches 1)
-          events (php/aget matches 2)
-          n      (php/count codes)]
+    (let [codes-arr (php/aget matches 1)
+          mods-arr  (php/aget matches 2)
+          ev-arr    (php/aget matches 3)
+          n         (php/count codes-arr)]
       (loop [i 0 w world]
         (if (php/>= i n)
           [w (php/preg_replace re "" keys)]
-          (let [code (php/intval (php/aget codes i))]
-            (let [evraw (php/aget events i)]
-              ;; Missing :event capture means press (event-type 1).
-              (let [event (if (or (php/=== evraw nil) (php/=== evraw ""))
-                            1
-                            (php/intval evraw))]
-                (recur (php/+ i 1) (handle-kitty-event w code event))))))))))
+          (let [code  (php/intval (php/aget codes-arr i))
+                mraw  (php/aget mods-arr i)
+                mods  (if (or (php/=== mraw nil) (php/=== mraw "")) 0 (php/intval mraw))
+                evraw (php/aget ev-arr i)
+                ;; Missing :event capture means press (event-type 1).
+                event (if (or (php/=== evraw nil) (php/=== evraw ""))
+                        1
+                        (php/intval evraw))]
+            (recur (php/+ i 1) (handle-kitty-event w code event mods))))))))
 
 (def arrow-letter->slot
   "Kitty-enhanced arrow CSI sequences (`\\e[1;<mods>(:<event>)?<letter>`)
@@ -162,30 +207,39 @@
   "Strip kitty-enhanced arrow sequences from `keys` and fold them
    into `world`. Pattern: ESC [ 1 [;mods[:event]] <A|B|C|D>. Event 3
    = release (clear slot); anything else = press/repeat (refresh hold).
+   When the mods bitfield has SHIFT set AND the slot is a movement
+   slot, also refresh `:sprint` so SHIFT+arrow keeps the player
+   sprinting (mirrors the SHIFT+WASD path in apply-kitty-events).
    Plain legacy arrows (\\e[A etc.) are untouched here and handled
    downstream by normalise-arrows. Returns [world leftover]."
   [world keys]
   (let [matches (php/array)
-        re      "/\\x1b\\[1(?:;\\d+(?::(\\d+))?)?([ABCD])/"]
+        re      "/\\x1b\\[1(?:;(\\d+)(?::(\\d+))?)?([ABCD])/"]
     (php/preg_match_all re keys matches)
-    (let [events  (php/aget matches 1)
-          letters (php/aget matches 2)
-          n       (php/count letters)]
+    (let [mods-arr (php/aget matches 1)
+          ev-arr   (php/aget matches 2)
+          letters  (php/aget matches 3)
+          n        (php/count letters)]
       (loop [i 0 w world]
         (if (php/>= i n)
           [w (php/preg_replace re "" keys)]
           (let [letter (php/aget letters i)
-                evraw  (php/aget events i)
+                mraw   (php/aget mods-arr i)
+                mods   (if (or (php/=== mraw nil) (php/=== mraw "")) 0 (php/intval mraw))
+                evraw  (php/aget ev-arr i)
                 event  (if (or (php/=== evraw nil) (php/=== evraw ""))
                          1
                          (php/intval evraw))
                 slot   (get arrow-letter->slot letter)]
             (recur (php/+ i 1)
-                   (if (nil? slot)
-                     w
-                     (cond
-                       (php/=== event 3) (clear-slot w slot)
-                       :else             (press-slot w slot))))))))))
+                   (cond
+                     (nil? slot)       w
+                     (php/=== event 3) (clear-slot w slot)
+                     :else
+                     (let [w1 (press-slot w slot)]
+                       (if (and (shift-mods? mods) (contains? movement-slots slot))
+                         (press-slot w1 :sprint)
+                         w1))))))))))
 
 (defn refresh-from-keys
   "Fold every input byte into `world`. Three-stage parse: kitty CSI-u

--- a/src/modules/io/render.phel
+++ b/src/modules/io/render.phel
@@ -1263,6 +1263,44 @@
             (buf-push parts (str "\e[" row ";" col "H" label)))))))
   parts)
 
+(def stamina-bar-cells
+  "Width of the STA bar in cells. 10 is wide enough to read the pool
+   level at a glance without crowding the HUD strip on narrow
+   terminals (40-col)."
+  10)
+
+(defn- stamina-chip
+  "Render the sprint stamina HUD chip:
+       ` STA ████████░░`
+   - 10 cells total, filled = (intval (* cells (stam/max))).
+   - Fill colour: white at ≥33%, amber under 33%, red when latched
+     blocked OR at 0 — so the player sees the colour shift before the
+     pool empties and notices the cooldown latch.
+   - Same `\\e[40m` BG-wash + `\\e[40;97m` close pattern as the +pack
+     / [diff] chips so the leading space + trailing handoff stay on
+     the dark HUD wash on light-bg terminals."
+  [stats]
+  ;; :stamina + :max-stamina always populated by frame-stats; no
+  ;; fallback so a missing field surfaces as a visible render bug
+  ;; instead of a silently-wrong bar.
+  (let [stam      (get stats :stamina)
+        smax      (get stats :max-stamina)
+        ratio     (php// stam smax)
+        clamped   (php/max 0.0 (php/min 1.0 ratio))
+        filled    (php/intval (php/floor (php/* stamina-bar-cells clamped)))
+        empty-n   (php/- stamina-bar-cells filled)
+        blocked?  (boolean (get stats :sprint-blocked?))
+        fill-col  (cond
+                    (or blocked? (php/<= stam 0.0)) "\e[40;91;1m"
+                    (php/< clamped 0.33)            "\e[40;33;1m"
+                    :else                           "\e[40;97;1m")
+        empty-col "\e[40;38;5;240m"]
+    (str "\e[40m " fill-col "STA "
+         (php/str_repeat "█" filled)
+         empty-col
+         (php/str_repeat "░" empty-n)
+         "\e[40;97m")))
+
 (defn- paint-game-info
   "Top-left game-state strip: `L1 imps · kills 12 · ammo 7/10 [23]`,
    anchored at row 2 col 1 directly under the hearts/armor row. Left
@@ -1302,6 +1340,7 @@
         keys'    (or (get stats :held-keys) #{})
         keys-tag (str (if (contains? keys' :blue) "\e[40m \e[40;94;1m⚿\e[40;97m" "")
                       (if (contains? keys' :red)  "\e[40m \e[40;91;1m⚿\e[40;97m" ""))
+        sta-chip (stamina-chip stats)
         ;; Same wash-preserving pattern for the inline mag / reserve
         ;; recolours: replace bare \e[0m resets with \e[40;97m so
         ;; the row never falls off the dark BG mid-string.
@@ -1310,7 +1349,7 @@
                       "  \e[1m" wname "\e[22m "
                       mag-col mag "\e[22;97m/" cap " "
                       res-col "[" reserve "]\e[22;97m"
-                      pack keys-tag diff-tag "\e[0m")]
+                      pack sta-chip keys-tag diff-tag "\e[0m")]
     (buf-push parts (str "\e[2;1H" styled)))
   parts)
 

--- a/tests/modules/core/physics-test.phel
+++ b/tests/modules/core/physics-test.phel
@@ -1,7 +1,7 @@
 (ns phel-doom-tests.modules.core.physics-test
   (:require phel.test :refer [deftest is])
-  (:require phel-doom.modules.core.state   :refer [new-world new-player])
-  (:require phel-doom.modules.core.physics :refer [try-move apply-physics tick-heartbeat tick-flicker tick-blood-drops tick-door-face]))
+  (:require phel-doom.modules.core.state   :refer [max-stamina new-world new-player])
+  (:require phel-doom.modules.core.physics :refer [try-move apply-physics sprint-engage-threshold sprint-multiplier stamina-drain stamina-regen tick-heartbeat tick-flicker tick-stamina tick-blood-drops tick-door-face]))
 
 ;; Tiny 3x3 grid: walls around the perimeter, open centre.
 (def open-world
@@ -262,3 +262,135 @@
     (is (< (php/abs (- (:door-face-active-secs w') 0.4)) 0.0001))
     ;; Cooldown frozen while active.
     (is (= 10.0 (:door-face-cooldown w')))))
+
+;; ---------------------------------------------------------------------
+;; Sprint + stamina. Hold SHIFT (kitty) or 'x' (any term) refreshes the
+;; :sprint move-slot. While the slot is on AND the player is actually
+;; moving AND stamina > 0, longitudinal/lateral speed is multiplied
+;; by sprint-multiplier and stamina drains at stamina-drain units/sec.
+;; While the slot is off, stamina regenerates after a brief cooldown.
+;; Hitting 0 latches :sprint-blocked? until stamina recovers to
+;; sprint-engage-threshold so the player can't stutter-sprint at empty.
+;; ---------------------------------------------------------------------
+
+(deftest test-tick-stamina-drains-while-sprinting-and-moving
+  (let [w  (-> empty-world
+               (assoc-in [:moves :sprint] 5)
+               (assoc-in [:moves :fwd] 5)
+               (assoc :stamina max-stamina))
+        w' (tick-stamina w 0.1)]
+    (is (< (:stamina w') max-stamina))
+    (is (< (php/abs (- (:stamina w') (- max-stamina (* stamina-drain 0.1)))) 0.0001))))
+
+(deftest test-tick-stamina-no-drain-when-sprint-pressed-but-not-moving
+  ;; Holding SHIFT alone (no WASD) must not bleed stamina.
+  (let [w  (-> empty-world
+               (assoc-in [:moves :sprint] 5)
+               (assoc :stamina max-stamina))
+        w' (tick-stamina w 0.1)]
+    (is (= max-stamina (:stamina w')))))
+
+(deftest test-tick-stamina-regenerates-when-not-sprinting
+  (let [w  (-> empty-world
+               (assoc-in [:moves :sprint] 0)
+               (assoc :stamina 50.0 :sprint-cooldown-secs 0.0))
+        w' (tick-stamina w 0.1)]
+    (is (< (php/abs (- (:stamina w') (+ 50.0 (* stamina-regen 0.1)))) 0.0001))))
+
+(deftest test-tick-stamina-regen-blocked-during-cooldown
+  (let [w  (-> empty-world
+               (assoc-in [:moves :sprint] 0)
+               (assoc :stamina 50.0 :sprint-cooldown-secs 0.5))
+        w' (tick-stamina w 0.1)]
+    (is (= 50.0 (:stamina w')))
+    ;; Cooldown ticks down by dt.
+    (is (< (php/abs (- (:sprint-cooldown-secs w') 0.4)) 0.0001))))
+
+(deftest test-tick-stamina-cooldown-clears-then-regen-resumes
+  (let [w  (-> empty-world
+               (assoc-in [:moves :sprint] 0)
+               (assoc :stamina 50.0 :sprint-cooldown-secs 0.05))
+        w' (tick-stamina w 0.1)]
+    ;; Cooldown ran out (0.05 - 0.1 → 0.0).
+    (is (= 0.0 (:sprint-cooldown-secs w')))
+    ;; Regen runs with the full dt this frame — keeps the impl
+    ;; simple. Once :sprint-cooldown-secs hits 0 the same frame, the
+    ;; whole dt feeds into regen.
+    (is (< (php/abs (- (:stamina w') (+ 50.0 (* stamina-regen 0.1)))) 0.0001))))
+
+(deftest test-tick-stamina-clamps-at-max
+  (let [w  (-> empty-world
+               (assoc-in [:moves :sprint] 0)
+               (assoc :stamina (- max-stamina 1.0) :sprint-cooldown-secs 0.0))
+        w' (tick-stamina w 5.0)]
+    (is (= max-stamina (:stamina w')))))
+
+(deftest test-tick-stamina-blocks-sprint-at-zero
+  ;; Drain past zero in one big frame; expect :sprint-blocked? to latch.
+  (let [w  (-> empty-world
+               (assoc-in [:moves :sprint] 5)
+               (assoc-in [:moves :fwd] 5)
+               (assoc :stamina 1.0))
+        w' (tick-stamina w 1.0)]
+    (is (= 0.0 (:stamina w')))
+    (is (= true (:sprint-blocked? w')))))
+
+(deftest test-tick-stamina-unblocks-only-at-engage-threshold
+  ;; Below threshold: still blocked.
+  (let [w  (-> empty-world
+               (assoc-in [:moves :sprint] 0)
+               (assoc :stamina (- sprint-engage-threshold 5.0)
+                      :sprint-blocked? true
+                      :sprint-cooldown-secs 0.0))
+        w' (tick-stamina w 0.01)]
+    (is (= true (:sprint-blocked? w'))))
+  ;; Above threshold: unblocks.
+  (let [w  (-> empty-world
+               (assoc-in [:moves :sprint] 0)
+               (assoc :stamina sprint-engage-threshold
+                      :sprint-blocked? true
+                      :sprint-cooldown-secs 0.0))
+        w' (tick-stamina w 0.01)]
+    (is (= false (:sprint-blocked? w')))))
+
+(deftest test-apply-physics-sprint-multiplier-applies-to-fwd
+  ;; Same fwd counter + dt, with vs without :sprint slot. Ratio of the
+  ;; resulting deltas must equal sprint-multiplier.
+  (let [base   (-> empty-world
+                   (assoc-in [:moves :fwd] 5)
+                   (assoc :stamina max-stamina))
+        slow   (apply-physics base 0.1)
+        fast-w (-> empty-world
+                   (assoc-in [:moves :fwd] 5)
+                   (assoc-in [:moves :sprint] 5)
+                   (assoc :stamina max-stamina))
+        fast   (apply-physics fast-w 0.1)
+        slow-d (- (:x (:player slow)) 1.5)
+        fast-d (- (:x (:player fast)) 1.5)]
+    (is (php/> fast-d slow-d))
+    (is (< (php/abs (- (/ fast-d slow-d) sprint-multiplier)) 0.0001))))
+
+(deftest test-apply-physics-sprint-no-multiplier-when-blocked
+  ;; Sprint slot pressed but :sprint-blocked? latched → walks at base speed.
+  (let [base  (-> empty-world
+                  (assoc-in [:moves :fwd] 5)
+                  (assoc :stamina max-stamina))
+        slow  (apply-physics base 0.1)
+        blk-w (-> empty-world
+                  (assoc-in [:moves :fwd] 5)
+                  (assoc-in [:moves :sprint] 5)
+                  (assoc :stamina max-stamina :sprint-blocked? true))
+        blk   (apply-physics blk-w 0.1)]
+    (is (< (php/abs (- (:x (:player blk)) (:x (:player slow)))) 0.0001))))
+
+(deftest test-apply-physics-sprint-no-multiplier-at-zero-stamina
+  (let [base   (-> empty-world
+                   (assoc-in [:moves :fwd] 5)
+                   (assoc :stamina max-stamina))
+        slow   (apply-physics base 0.1)
+        empty- (-> empty-world
+                   (assoc-in [:moves :fwd] 5)
+                   (assoc-in [:moves :sprint] 5)
+                   (assoc :stamina 0.0))
+        out    (apply-physics empty- 0.1)]
+    (is (< (php/abs (- (:x (:player out)) (:x (:player slow)))) 0.0001))))

--- a/tests/modules/glue/controls-test.phel
+++ b/tests/modules/glue/controls-test.phel
@@ -1,7 +1,19 @@
 (ns phel-doom-tests.modules.glue.controls-test
   (:require phel.test :refer [deftest is])
   (:require phel-doom.modules.glue.controls
-            :refer [key-states rising-edges initial-key-snapshot]))
+            :refer [key-states refresh-from-keys rising-edges initial-key-snapshot]))
+
+(def blank-moves
+  {:fwd          0
+   :back         0
+   :strafe-left  0
+   :strafe-right 0
+   :turn-left    0
+   :turn-right   0
+   :sprint       0})
+
+(def blank-world
+  {:moves blank-moves})
 
 ;; ---------------------------------------------------------------------
 ;; key-states: snapshot of which one-shot keys appear in the byte
@@ -192,3 +204,49 @@
 (deftest test-rising-edges-escape-does-not-refire-while-held
   (let [held (assoc initial-key-snapshot :esc true)]
     (is (= false (:escape (rising-edges held held))))))
+
+;; ---------------------------------------------------------------------
+;; Sprint: SHIFT-modified kitty CSI-u press of any movement key OR plain
+;; 'x' byte refreshes the :sprint slot. Release events / plain
+;; movement (no SHIFT mod) must NOT light up :sprint.
+;;
+;; Kitty CSI-u mods are encoded as (bits + 1); bit 0 = SHIFT, so SHIFT
+;; alone is mods=2. Event 3 = release.
+;; ---------------------------------------------------------------------
+
+(deftest test-kitty-shift-mod-on-w-refreshes-sprint-slot
+  ;; \e[119;2u — press of 'w' (codepoint 119) with mods=2 (SHIFT).
+  ;; Also refreshes :fwd (W is still W).
+  (let [w' (refresh-from-keys blank-world "\e[119;2u")]
+    (is (php/> (:sprint (:moves w')) 0))
+    (is (php/> (:fwd    (:moves w')) 0))))
+
+(deftest test-kitty-no-mod-on-w-leaves-sprint-untouched
+  (let [w' (refresh-from-keys blank-world "\e[119u")]
+    (is (= 0 (:sprint (:moves w'))))
+    (is (php/> (:fwd (:moves w')) 0))))
+
+(deftest test-kitty-shift-mod-release-does-not-refresh-sprint
+  ;; \e[119;2:3u — release event with shift held. Sprint slot stays 0.
+  (let [w' (refresh-from-keys blank-world "\e[119;2:3u")]
+    (is (= 0 (:sprint (:moves w'))))
+    (is (= 0 (:fwd    (:moves w'))))))
+
+(deftest test-x-byte-refreshes-sprint-slot
+  ;; Legacy / non-kitty fallback: plain 'x' byte arms sprint.
+  (let [w' (refresh-from-keys blank-world "x")]
+    (is (php/> (:sprint (:moves w')) 0))))
+
+(deftest test-x-still-works-under-kitty-as-codepoint-120
+  ;; Under kitty, 'x' arrives wrapped as \e[120u. Must still hit :sprint.
+  (let [w' (refresh-from-keys blank-world "\e[120u")]
+    (is (php/> (:sprint (:moves w')) 0))))
+
+(deftest test-sprint-slot-uses-short-hold-frames
+  ;; Regression: the :sprint slot must NOT inherit the 18-frame
+  ;; move-hold-frames bridge. Otherwise releasing SHIFT while still
+  ;; walking forward would leave sprint hot for ~300ms — phantom
+  ;; drain. sprint-hold-frames (3) matches turn-hold-frames so
+  ;; release feels instant.
+  (let [w' (refresh-from-keys blank-world "x")]
+    (is (php/<= (:sprint (:moves w')) 5))))


### PR DESCRIPTION
## 📚 Description

Adds a sprint verb to the game: hold **SHIFT** (kitty / Ghostty / WezTerm / iTerm2 ≥ 3.5) or **`x`** (any terminal) to move 1.6× faster at the cost of a depleting stamina pool. Standard FPS pacing tool — chase pickups, dodge enemies, retreat, all gated by a recharging resource.

Closes #35

## 🔖 Changes

**Input** (`src/modules/glue/controls.phel`)
- Extended kitty CSI-u regex to capture the `mods` field (was previously swallowed). SHIFT bit (mods bit 0) on a movement key press/repeat refreshes a new `:sprint` slot. Mirror behaviour on enhanced arrow events (`\e[1;<mods>:<event><A|B|C|D>`).
- Added `"x"` → `:sprint` in both `key->slot` (legacy byte path) and `ascii->slot` (kitty codepoint 120).
- New `sprint-hold-frames` = 3 (~50ms) so the sprint slot decays fast — releasing SHIFT/x stops the speed boost + drain almost instantly, not after the 300ms movement-hold bridge.

**Physics** (`src/modules/core/physics.phel`)
- New tunables: `sprint-multiplier 1.6`, `stamina-drain 30.0`, `stamina-regen 20.0`, `sprint-cooldown-after 0.5`, `sprint-engage-threshold 20.0`.
- New `sprinting?` predicate gates on intent + stamina + not-blocked. `sprint-factor` multiplies `longitudinal-delta` + `lateral-delta` (turn-speed unchanged). New `tick-stamina` drains while sprinting + moving, regens after cooldown, manages the `:sprint-blocked?` latch.

**State** (`src/modules/core/state.phel`)
- New fields: `:stamina` (default `max-stamina` 100.0), `:sprint-cooldown-secs`, `:sprint-blocked?`. Added `:sprint` to the `:moves` map.

**Game loop** (`src/commands/play.phel`)
- `tick-stamina` runs **before** `apply-physics` each frame so the blocked latch gates same-frame motion (no one-frame bleed-through).
- `:stamina` / `:max-stamina` / `:sprint-blocked?` added to `frame-stats`.
- Stamina + cooldown + latch reset on level cut (door = breather, documented in `run-levels`).

**HUD** (`src/modules/io/render.phel`)
- New `stamina-chip` in `paint-game-info`: 10-cell `STA ████████░░` bar. White fill ≥ 33%, amber under 33%, red when at 0 or `:sprint-blocked?`. Uses the existing `\e[40m` BG-wash + `\e[40;97m` close pattern (same fix as commit `dcf4dfa` for the `+pack` chip).

**Tests**
- `tests/modules/core/physics-test.phel` — 12 new tests covering drain / no-drain-when-still / regen / cooldown / threshold latch / multiplier applied / multiplier suppressed when blocked / multiplier suppressed at zero.
- `tests/modules/glue/controls-test.phel` — 6 new tests covering SHIFT mod on W refreshes sprint, no-mod doesn't, release doesn't, `x` byte fallback, `\e[120u` kitty fallback, sprint-slot uses short hold-frames.

**Docs**
- `docs/input.md` — sprint section + extended `key->slot` snippet.
- `docs/state.md` — new world fields + `:sprint` slot.
- `docs/rendering.md` — game-info strip composition updated.
- `docs/features.md` — sprint bullet under Misc.
- `README.md` — controls table row.

## 🧪 Test plan

- [x] `composer ci` — 0 warnings, 550 tests pass.
- [x] `clean-code-reviewer` pass — initially surfaced two blocking issues (tick-stamina ordering + SHIFT release leaving sprint hot 300ms); both fixed in this commit.
- [ ] Smoke `make play`: hold SHIFT in kitty / Ghostty / WezTerm + verify bar drains + speed felt + bar regenerates + cannot re-engage until ~20%.
- [ ] Smoke on macOS Terminal.app: hold `x` instead of SHIFT, same checks.