### PR TITLE
ref(levels): enemy-types catalog + slim entries + mixed-room + layout opt-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 
 ## [Unreleased]
 
+### Changed
+
+- Enemy catalog extracted to `core/enemies.phel`. Levels are now slim data: `{:size :walls :enemy :imp :enemies 4 :chase 0.8}`. Visuals (head/body/legs/face/glyph) live in `enemy-types` keyed by kw (`:imp :demon :caco :baron :cyber` + 5 stubs ready for L6-L10: `:spectre :revenant :archvile :mancubus :pinky`). Adding a new room = one map literal in `levels`; adding a new monster = one map literal in `enemy-types`.
+- `:enemies` accepts either an `int` (single-type, uses level's `:enemy`) OR a vector of mixed specs `[{:type :imp :count 4 :lives 1} {:type :baron :count 2}]`. Each enemy carries `:type` so render reads visuals per-sprite — enables mixed-monster rooms + boss arenas.
+- Level entry can opt in to a hand-authored `:layout` (vector of ASCII strings parsed via `map/parse-layout` — `#` wall, `.` floor, `@` spawn, `D`/`B`/`R` doors) that bypasses `random-grid` + `seed-doors`. Random procgen remains the default.
+- World no longer stamps per-level enemy visual fields (`:enemy-head-code`, `:enemy-body-glyph`, `:enemy-face`, …). Render reads the catalog directly via the per-enemy `:type` kw with the level's primary `:enemy` as fallback.
+
 ## [0.3.0] - 2026-05-24
 
 ### Added

--- a/docs/level-system.md
+++ b/docs/level-system.md
@@ -1,29 +1,66 @@
 # Level system
 
-5-level progression catalog + `build-world` factory. `src/modules/core/level.phel`.
+Progression catalog + `build-world` factory. `src/modules/core/level.phel`.
 
 ## Catalog
 
 ```phel
 (def levels
-  [{:size [22 16] :walls 12 :enemies 4  :chase 0.8 :enemy-lives 1 :name "imps"}
-   {:size [28 20] :walls 22 :enemies 6  :chase 1.0 :enemy-lives 2 :name "demons"}
-   {:size [36 24] :walls 38 :enemies 8  :chase 1.3 :enemy-lives 3 :name "cacodemons"}
-   {:size [44 28] :walls 55 :enemies 5  :chase 1.6 :enemy-lives 4 :door-lock :blue :name "barons"}
-   {:size [52 32] :walls 75 :enemies 7  :chase 2.0 :enemy-lives 5 :door-lock :red  :name "cyberdemons"}])
+  [{:size [22 16] :walls 12 :enemy :imp   :enemies 4 :chase 0.8 :name "imps"}
+   {:size [28 20] :walls 22 :enemy :demon :enemies 6 :chase 1.0 :name "demons"}
+   {:size [36 24] :walls 38 :enemy :caco  :enemies 8 :chase 1.3 :name "cacodemons"}
+   {:size [44 28] :walls 55 :enemy :baron :enemies 5 :chase 1.6 :name "barons"      :door-lock :blue}
+   {:size [52 32] :walls 75 :enemy :cyber :enemies 7 :chase 2.0 :name "cyberdemons" :door-lock :red}])
 ```
+
+Required fields:
 
 | Field | Meaning |
 |---|---|
-| `:size`        | `[width height]` of grid in cells |
-| `:walls`       | Random wall blobs scattered inside |
-| `:enemies`     | Monsters to spawn |
-| `:chase`       | Chase AI speed (units/sec) |
-| `:enemy-lives` | Per-enemy HP; controls hit-flash digit, wounded body shade |
-| `:door-lock`   | `:blue` / `:red` / absent — colour required to pass the exit |
-| `:name`        | Display name (HUD + intro splash) |
+| `:size`     | `[width height]` of grid in cells |
+| `:walls`    | Random wall blobs (procedural path only) |
+| `:enemy`    | Catalog kw — see [monsters.md](monsters.md) for the type list |
+| `:enemies`  | Int (count of `:enemy`) OR vector of mixed specs (see below) |
+| `:chase`    | Chase AI speed (units/sec) |
+| `:name`     | HUD + intro-splash label |
 
-Plus enemy visual fields covered in [monsters.md](monsters.md): `:head-code`, `:body-code`, `:legs-code`, `:body-glyph`, `:body-glyph-fg`, `:face`, `:face-alt`, `:face-attack`.
+Optional:
+
+| Field | Meaning |
+|---|---|
+| `:enemy-lives` | Override the catalog's `:default-lives` (single-type entries only) |
+| `:door-lock`   | `:blue` / `:red` — adds a matching keycard pickup and locks the exit |
+| `:layout`      | Hand-authored ASCII grid (vector of strings) — bypasses `random-grid` |
+
+### Mixed-monster rooms
+
+When `:enemies` is a vector, each spec spawns its own count + HP and the enemy carries `:type` for render lookup:
+
+```phel
+{:size [40 30] :walls 50 :enemy :imp :name "the brood" :chase 1.8
+ :enemies [{:type :pinky :count 3 :lives 2}
+           {:type :baron :count 3 :lives 4}
+           {:type :mancubus :count 2}]}   ; :lives omitted → catalog default
+```
+
+### Hand-authored arenas (`:layout`)
+
+`[" ###### " " #....# " " #..@.# " " #....D " " ###### "]` parses via `map/parse-layout`. Char map:
+
+| Char | Cell |
+|---|---|
+| `#` | wall |
+| `.` | floor |
+| `@` | floor + player spawn |
+| `D` | unlocked door |
+| `B` | blue-locked door |
+| `R` | red-locked door |
+
+`:layout` skips `random-grid`, `seed-doors`, and `lock-the-door` — the author placed everything explicitly. Enemy spawn (random / mixed-spec) still applies on top.
+
+### Adding a new room
+
+Append one map literal to `levels`. Adding a new enemy type = append one entry to `enemies/enemy-types` (see [monsters.md](monsters.md)).
 
 ## `config-for`
 
@@ -38,16 +75,15 @@ Level N config (1-indexed). Clamps out-of-range to nearest valid.
 
 Signature: `(build-world level-num lives backpack? diff owned)`. Sequence per build:
 
-1. `random-grid` with `:walls` random 1×1 / 2×2 blobs
-2. `seed-doors` carves one exit. `lock-the-door` upgrades it to `cell-door-blue` / `cell-door-red` when `:door-lock` is set.
-3. Player spawn at a random open cell with random angle.
-4. `:enemies` monsters at ≥ `enemy-min-spawn-dist 3.0` from player, each with HP = `:enemy-lives`.
-5. `maybe-spawn-heart` only if `lives < max-lives`.
-6. `maybe-spawn-armor` (50%); `maybe-spawn-berserk` (1/8); `maybe-spawn-invuln` (1/12); `maybe-spawn-backpack` (L2+, 1/5, skipped when already owned).
-7. `maybe-spawn-keycard` when `:door-lock` is set.
-8. `maybe-spawn-weapon-pickups`: shotgun on L2 / chaingun on L3, skipped when already owned. Pistol never spawns as a pickup.
-9. `spawn-ammo-boxes` count = `ceil(enemies × max-lives / 8)`, floor 2.
-10. Stamp enemy visuals, `:level-name`, `:difficulty`, 1.5s `:intro-secs`.
+1. Grid: hand-authored (`map/parse-layout` of `:layout`) OR procedural (`random-grid` + `seed-doors` + `lock-the-door`).
+2. Player spawn: `:layout`'s `@` cell OR `random-spawn`. Random angle either way.
+3. Enemies: `spawn-enemies-mixed` from the normalised spec vector. Each enemy carries `:type` for per-enemy render visuals.
+4. `maybe-spawn-heart` only if `lives < max-lives`.
+5. `maybe-spawn-armor` (50%); `maybe-spawn-berserk` (1/8); `maybe-spawn-invuln` (1/12); `maybe-spawn-backpack` (L2+, 1/5, skipped when already owned).
+6. `maybe-spawn-keycard` when `:door-lock` is set.
+7. `maybe-spawn-weapon-pickups`: shotgun on L2 / chaingun on L3, skipped when already owned.
+8. `spawn-ammo-boxes` count = `ceil(sum(count × lives) / 8)`, floor 2.
+9. Stamp `:enemy` (primary type), `:level-name`, `:difficulty`, 1.5s `:intro-secs`.
 
 `run-levels` (in `commands/play.phel`) wraps the call and overlays cross-level carries on top of the fresh world: **active weapon + per-weapon mag/reserve state**, minimap + sound toggles, `:god?` flag.
 

--- a/docs/monsters.md
+++ b/docs/monsters.md
@@ -1,26 +1,34 @@
 # Monsters
 
-`src/modules/core/enemy.phel` (data + AI) and `src/modules/core/level.phel` (per-type catalog). Visual rendering by `io/render.phel`.
+- `src/modules/core/enemies.phel` — type catalog (visuals + default HP)
+- `src/modules/core/enemy.phel` — record + spawn + chase AI
+- Visual rendering in `io/render.phel` (per-enemy `:type` lookup).
 
-## Five types
+## Catalog (`enemy-types`)
 
-| Level | Name | HP | Head | Body | Legs | Face | Body pattern |
-|---|---|---|---|---|---|---|---|
-| 1 | imps        | 1 | 196 (bright red) | 124 (dark red) | 52 (black-red) | ●/◯ yellow | `░` |
-| 2 | demons      | 2 | 165 (magenta) | 126 (purple) | 90 (deep magenta) | ▼/▾ white | `▒` |
-| 3 | cacodemons  | 3 | 51 (bright cyan) | 38 (cyan) | 24 (dark cyan) | ◉/◎ black | `⋄` |
-| 4 | barons      | 4 | 46 (bright green) | 34 (green) | 22 (forest) | Λ/λ black | `▓` |
-| 5 | cyberdemons | 5 | 240 (grey helmet) | 124 (red flesh) | 238 (grey legs) | ■/□ red blink | `▦` |
+Each entry has: `:name :default-lives :head-code :body-code :legs-code :body-glyph :body-glyph-alt :body-glyph-fg :face :face-alt :face-attack`. Render reads them by kw per enemy.
 
-Each enemy carries `:lives` (current HP) and `:max-lives` (level cap). `enemy/shoot` decrements `:lives` per hit; only flips `:alive false` and arms the respawn timer when `:lives` hits zero. The renderer reads `damage-ratio = 1 - lives/max-lives` from `project-enemy` and adds it to the per-frame distance fade so the body zone shades darker (toward black) as HP drops — wounded enemies read as "bloodied" from across the room without needing extra glyphs or a HUD bar.
+| Kw | Name | Default HP | Head | Body | Face | Notes |
+|---|---|---|---|---|---|---|
+| `:imp`      | imp        | 1 | 196 red    | 124 red    | ●/◯ yellow      | L1 default |
+| `:demon`    | demon      | 2 | 165 magenta| 126 purple | ▼/▾ white       | L2 default |
+| `:caco`     | cacodemon  | 3 | 51  cyan   | 38  cyan   | ◉/◎ black       | L3 default |
+| `:baron`    | baron      | 4 | 46  green  | 34  green  | Λ/λ black       | L4 default |
+| `:cyber`    | cyberdemon | 5 | 240 grey   | 124 red    | ■/□ red blink   | L5 default |
+| `:spectre`  | spectre    | 3 | 117 cyan   | 67  steel  | ○/◌ white       | L6+ stub |
+| `:revenant` | revenant   | 4 | 255 bone   | 245 grey   | ☠/◔ black       | L6+ stub |
+| `:archvile` | archvile   | 5 | 208 orange | 166 amber  | ∺/≋ black       | L6+ stub |
+| `:mancubus` | mancubus   | 4 | 137 tan    | 94  brown  | ═/─ black       | L6+ stub |
+| `:pinky`    | pinky      | 2 | 213 pink   | 199 hot-pk | ≣/≡ black       | L6+ stub |
 
-On every non-killing hit, `shoot` also stamps `:hit-flash-secs hit-flash-seconds` (1.2s) onto the wounded enemy. `paint-enemy-hp-flashes` reads the timer and floats the remaining HP digit above the head for that window, bright yellow on a dark BG; `advance` decays the timer each frame so the digit fades on its own without a separate ticker. 1-HP enemies skip the digit (any hit is a kill).
+Adding a new type = append one entry to `enemy-types`. Adding a level that uses it = one entry in `levels` (see [level-system.md](level-system.md)).
 
-Each row is one map entry under `levels` in `core/level.phel`. Adding a 6th monster is a single map literal.
+Each enemy carries `:lives` / `:max-lives` / `:type`. `enemy/shoot` drops `:lives` per hit; only flips `:alive false` and arms respawn when 0. `damage-ratio = 1 - lives/max-lives` darkens the body shade — wounded enemies read as "bloodied" from across the room without a HUD bar. Non-killing hits also stamp `:hit-flash-secs 1.2` so a yellow HP digit floats above the head.
 
 ## Spawning
 
-`spawn-enemies` places N enemies on random open cells at least `min-dist-from` units from the player. Used at level start (`build-world`) and on respawn.
+- `spawn-enemies grid n min-dist px py [max-lives [type-kw]]` — single-type rooms.
+- `spawn-enemies-mixed grid specs min-dist px py` — multi-type. Spec shape: `{:type :count [:lives N]}`. Each enemy carries `:type` for render lookup. Used by `build-world` whenever a level's `:enemies` field is a vector (and for the L10 boss arena where `{:type :cyber :count 1 :lives 20}` + `{:type :imp :count 4}` paints one boss surrounded by minions).
 
 ## Chase AI
 

--- a/src/commands/play.phel
+++ b/src/commands/play.phel
@@ -457,15 +457,11 @@
                                   (:x (:player world))
                                   (:y (:player world))
                                   (:angle (:player world)))
-   :enemy-head-code      (:enemy-head-code world)
-   :enemy-body-code      (:enemy-body-code world)
-   :enemy-legs-code      (:enemy-legs-code world)
-   :enemy-body-glyph     (:enemy-body-glyph world)
-   :enemy-body-glyph-alt (:enemy-body-glyph-alt world)
-   :enemy-body-glyph-fg  (:enemy-body-glyph-fg world)
-   :enemy-face           (:enemy-face world)
-   :enemy-face-alt       (:enemy-face-alt world)
-   :enemy-face-attack    (:enemy-face-attack world)})
+   ;; Primary enemy type kw — render uses this as the fallback
+   ;; visual when a per-enemy `:type` field is missing. Mixed-monster
+   ;; rooms still stamp `:type` per enemy at spawn so the renderer
+   ;; can branch.
+   :enemy                (or (:enemy world) :imp)})
 
 (defn- ms-since
   "Whole-millisecond delta between two microtime samples. Args tagged

--- a/src/modules/core/enemies.phel
+++ b/src/modules/core/enemies.phel
@@ -1,0 +1,187 @@
+(ns phel-doom.modules.core.enemies)
+
+;; ---------------------------------------------------------------------
+;; Enemy catalog.
+;;
+;; One map literal per monster type. Level entries pick a type by kw
+;; (e.g. `:enemy :imp`) — render reads visuals from this catalog so
+;; the level layer stays purely about disposition (size / wall count /
+;; counts / chase speed / lock colour).
+;;
+;; Adding a new monster type = append one entry here. Adding a new
+;; level that uses it = one entry in levels.phel.
+;;
+;; Visual fields per entry:
+;;   :name             short label (HUD intro + tests)
+;;   :default-lives    HP fallback when a level / spec doesn't override
+;;   :head-code        256-color BG code for the head zone
+;;   :body-code        256-color BG code for the body zone
+;;   :legs-code        256-color BG code for the legs zone
+;;   :body-glyph       1-char texture stamped over the body
+;;   :body-glyph-alt   alt-frame glyph (walk cycle)
+;;   :body-glyph-fg    256-color FG for the body texture
+;;   :face             ANSI escape sequence for the face overlay (idle)
+;;   :face-alt         alt-frame face glyph (eye blink / fang flicker)
+;;   :face-attack      face shown within aggro distance — flashes
+;; ---------------------------------------------------------------------
+
+(def enemy-types
+  {;; --- Current catalog (L1-L5) ----------------------------------
+   :imp
+   {:name           "imp"
+    :default-lives  1
+    :head-code      196
+    :body-code      124
+    :legs-code      52
+    :body-glyph     "░"
+    :body-glyph-alt "▒"
+    :body-glyph-fg  88
+    :face           "\e[48;5;196;38;5;226;1m●\e[0m"
+    :face-alt       "\e[48;5;196;38;5;226;1m◯\e[0m"
+    :face-attack    "\e[5;48;5;196;38;5;226;1m✸\e[0m"}
+
+   :demon
+   {:name           "demon"
+    :default-lives  2
+    :head-code      165
+    :body-code      126
+    :legs-code      90
+    :body-glyph     "▒"
+    :body-glyph-alt "░"
+    :body-glyph-fg  96
+    :face           "\e[48;5;165;38;5;231;1m▼\e[0m"
+    :face-alt       "\e[48;5;165;38;5;231;1m▾\e[0m"
+    :face-attack    "\e[5;48;5;165;38;5;231;1m★\e[0m"}
+
+   :caco
+   {:name           "cacodemon"
+    :default-lives  3
+    :head-code      51
+    :body-code      38
+    :legs-code      24
+    :body-glyph     "⋄"
+    :body-glyph-alt "◇"
+    :body-glyph-fg  24
+    :face           "\e[48;5;51;38;5;232;1m◉\e[0m"
+    :face-alt       "\e[48;5;51;38;5;232;1m◎\e[0m"
+    :face-attack    "\e[5;48;5;51;38;5;196;1m✺\e[0m"}
+
+   :baron
+   {:name           "baron"
+    :default-lives  4
+    :head-code      46
+    :body-code      34
+    :legs-code      22
+    :body-glyph     "▓"
+    :body-glyph-alt "▒"
+    :body-glyph-fg  22
+    :face           "\e[48;5;46;38;5;232;1mΛ\e[0m"
+    :face-alt       "\e[48;5;46;38;5;232;1mλ\e[0m"
+    :face-attack    "\e[5;48;5;46;38;5;196;1m▲\e[0m"}
+
+   :cyber
+   {:name           "cyberdemon"
+    :default-lives  5
+    :head-code      240
+    :body-code      124
+    :legs-code      238
+    :body-glyph     "▦"
+    :body-glyph-alt "▤"
+    :body-glyph-fg  240
+    :face           "\e[48;5;240;38;5;196;1m■\e[0m"
+    :face-alt       "\e[48;5;240;38;5;196;1m□\e[0m"
+    :face-attack    "\e[5;48;5;240;38;5;226;1m✖\e[0m"}
+
+   ;; --- Stubs ready for L6-L10 ------------------------------------
+   :spectre
+   ;; Cyan ghost: pale head + ash-grey body, semi-transparent feel
+   ;; from the high-FG glyph. Hollow eye blinks open.
+   {:name           "spectre"
+    :default-lives  3
+    :head-code      117
+    :body-code      67
+    :legs-code      60
+    :body-glyph     "▒"
+    :body-glyph-alt "░"
+    :body-glyph-fg  153
+    :face           "\e[48;5;117;38;5;231;1m○\e[0m"
+    :face-alt       "\e[48;5;117;38;5;231;1m◌\e[0m"
+    :face-attack    "\e[5;48;5;117;38;5;226;1m✦\e[0m"}
+
+   :revenant
+   ;; White bone, black-grey body, the classic skeletal silhouette.
+   ;; Skull-face stares; the alt frame shows a jaw drop.
+   {:name           "revenant"
+    :default-lives  4
+    :head-code      255
+    :body-code      245
+    :legs-code      237
+    :body-glyph     "▤"
+    :body-glyph-alt "▦"
+    :body-glyph-fg  250
+    :face           "\e[48;5;255;38;5;232;1m☠\e[0m"
+    :face-alt       "\e[48;5;255;38;5;232;1m◔\e[0m"
+    :face-attack    "\e[5;48;5;255;38;5;196;1m✠\e[0m"}
+
+   :archvile
+   ;; Orange caster: bright orange head over a deep amber body.
+   ;; Two-eye face that flickers to a flame on attack.
+   {:name           "archvile"
+    :default-lives  5
+    :head-code      208
+    :body-code      166
+    :legs-code      94
+    :body-glyph     "▓"
+    :body-glyph-alt "▒"
+    :body-glyph-fg  130
+    :face           "\e[48;5;208;38;5;232;1m∺\e[0m"
+    :face-alt       "\e[48;5;208;38;5;232;1m≋\e[0m"
+    :face-attack    "\e[5;48;5;208;38;5;226;1m♨\e[0m"}
+
+   :mancubus
+   ;; Bulky brown: warm tan head, mid-brown body, bog-brown legs.
+   ;; Sneering mouth; gun-barrel on attack.
+   {:name           "mancubus"
+    :default-lives  4
+    :head-code      137
+    :body-code      94
+    :legs-code      58
+    :body-glyph     "▓"
+    :body-glyph-alt "▦"
+    :body-glyph-fg  58
+    :face           "\e[48;5;137;38;5;232;1m═\e[0m"
+    :face-alt       "\e[48;5;137;38;5;232;1m─\e[0m"
+    :face-attack    "\e[5;48;5;137;38;5;226;1m◐\e[0m"}
+
+   :pinky
+   ;; Pink rusher: hot-pink head, magenta body, low HP high speed.
+   ;; Gnashing teeth — fast face cycle for animated chomp.
+   {:name           "pinky"
+    :default-lives  2
+    :head-code      213
+    :body-code      199
+    :legs-code      161
+    :body-glyph     "░"
+    :body-glyph-alt "▒"
+    :body-glyph-fg  89
+    :face           "\e[48;5;213;38;5;232;1m≣\e[0m"
+    :face-alt       "\e[48;5;213;38;5;232;1m≡\e[0m"
+    :face-attack    "\e[5;48;5;213;38;5;226;1m≢\e[0m"}})
+
+(def required-keys
+  "Every entry must carry these — tests pin completeness."
+  [:name :default-lives :head-code :body-code :legs-code
+   :body-glyph :body-glyph-alt :body-glyph-fg
+   :face :face-alt :face-attack])
+
+(defn type-spec
+  "Lookup the spec for a type kw. Returns nil for unknown kws so
+   callers can decide whether to crash or fall back."
+  [type-kw]
+  (get enemy-types type-kw))
+
+(defn default-lives-for
+  "HP fallback when a level / spec doesn't override. Defaults to 1
+   so an unknown type still spawns as a single-shot enemy."
+  [type-kw]
+  (or (get-in enemy-types [type-kw :default-lives]) 1))

--- a/src/modules/core/enemy.phel
+++ b/src/modules/core/enemy.phel
@@ -33,10 +33,15 @@
 (defn new-enemy
   "Create an enemy record. `x` and `y` are world-space floats; `:alive`
    flips to false when `:lives` hits zero. Default lives = 1 keeps the
-   one-shot-kill semantics for callers that don't care about HP."
-  ([x y]               (new-enemy x y 1))
-  ([ex ey max-lives]   {:x ex :y ey :alive true :lives max-lives :max-lives max-lives
-                        :hit-flash-secs 0.0}))
+   one-shot-kill semantics for callers that don't care about HP. The
+   optional `type-kw` records which monster catalog entry (see
+   `enemies/enemy-types`) this enemy belongs to — render reads it
+   for per-enemy visuals, so mixed-type rooms (boss + minions) work
+   without world-level fields."
+  ([x y]                      (new-enemy x y 1 nil))
+  ([ex ey max-lives]          (new-enemy ex ey max-lives nil))
+  ([ex ey max-lives type-kw]  {:x ex :y ey :alive true :lives max-lives :max-lives max-lives
+                               :hit-flash-secs 0.0 :type type-kw}))
 
 (def chase-angle-offsets
   "Angle deltas (radians) tried when an enemy can't walk straight at the
@@ -299,10 +304,14 @@
   "Place `n` enemies on random open cells of `grid`, well away from the
    player's spawn so the first frame isn't an ambush. `max-lives`
    stamps the per-level HP onto every fresh enemy; default 1 keeps
-   the older one-shot-kill callers working."
+   the older one-shot-kill callers working. The 7-arity variant
+   also stamps `:type` so the renderer can pick the right visuals
+   per enemy (mixed-type rooms)."
   ([grid n min-dist-from player-x player-y]
-   (spawn-enemies grid n min-dist-from player-x player-y 1))
+   (spawn-enemies grid n min-dist-from player-x player-y 1 nil))
   ([g n-need min-d px py max-lives]
+   (spawn-enemies g n-need min-d px py max-lives nil))
+  ([g n-need min-d px py max-lives type-kw]
    (loop [acc       []
           attempts  0
           remaining n-need]
@@ -316,6 +325,26 @@
                        (php/+ (php/* dx dx) (php/* dy dy)))]
          (if (php/< d2 (php/* min-d min-d))
            (recur acc (php/+ attempts 1) remaining)
-           (recur (conj acc (new-enemy ex ey max-lives))
+           (recur (conj acc (new-enemy ex ey max-lives type-kw))
                   (php/+ attempts 1)
                   (php/- remaining 1))))))))
+
+(defn spawn-enemies-mixed
+  "Spawn from a vector of `{:type kw :count N [:lives M]}` specs. Each
+   spec emits `:count` enemies of `:type` with `:lives` HP (falls back
+   to 1 if missing). Returns one flat vector of enemies, each carrying
+   `:type` for render lookup. Used by mixed-monster rooms — the L10
+   boss + surrounding imps falls out of this naturally."
+  [grid specs min-d px py]
+  (loop [remaining specs
+         acc       []]
+    (cond
+      (php/=== remaining nil)       acc
+      (php/=== (count remaining) 0) acc
+      :else
+      (let [spec  (first remaining)
+            t     (:type spec)
+            n     (or (:count spec) 0)
+            lives (or (:lives spec) 1)
+            batch (spawn-enemies grid n min-d px py lives t)]
+        (recur (next remaining) (apply vector (concat acc batch)))))))

--- a/src/modules/core/level.phel
+++ b/src/modules/core/level.phel
@@ -1,7 +1,8 @@
 (ns phel-doom.modules.core.level
   (:require phel-doom.modules.core.state      :refer [new-player new-world with-enemies max-lives])
-  (:require phel-doom.modules.core.map        :refer [cell-door cell-door-blue cell-door-red random-grid random-spawn seed-doors])
-  (:require phel-doom.modules.core.enemy      :refer [spawn-enemies])
+  (:require phel-doom.modules.core.map        :refer [cell-door cell-door-blue cell-door-red parse-layout random-grid random-spawn seed-doors])
+  (:require phel-doom.modules.core.enemy      :refer [spawn-enemies spawn-enemies-mixed])
+  (:require phel-doom.modules.core.enemies    :refer [enemy-types type-spec default-lives-for])
   (:require phel-doom.modules.core.difficulty :refer [normalise scale-cfg]))
 
 ;; ---------------------------------------------------------------------
@@ -23,63 +24,32 @@
   3.0)
 
 (def levels
-  "Per-level configuration. Each entry bumps difficulty: bigger room,
-   more enemies, faster chase, a distinct monster *type* with its own
-   silhouette. Each sprite splits into three vertical zones (head /
-   body / legs) plus a face glyph painted over the head's centre
-   column as a post-pass overlay — gives each monster a recognisable
-   silhouette + face from across the room."
-  [{:size [22 16] :walls 12 :enemies 4 :chase 0.8 :enemy-lives 1
-    :name "imps"
-    ;; Bright red head, dark red body, blackened legs. Body shows
-    ;; a stippled scale pattern in a darker red. Eye blinks between
-    ;; ● (open) and ◯ (squinting). Atmosphere: hellish red haze.
-    :head-code 196 :body-code 124 :legs-code 52
-    :body-glyph "░" :body-glyph-fg 88 :body-glyph-alt "▒"
-    :face     "\e[48;5;196;38;5;226;1m●\e[0m"
-    :face-alt "\e[48;5;196;38;5;226;1m◯\e[0m"
-    :face-attack "\e[5;48;5;196;38;5;226;1m✸\e[0m"}
-   {:size [28 20] :walls 22 :enemies 6 :chase 1.0 :enemy-lives 2
-    :name "demons"
-    ;; Magenta with a white fang. Body has a 'medium shade' muscle
-    ;; texture in a darker purple. Fang flickers. Atmosphere: dim
-    ;; purple sanctum.
-    :head-code 165 :body-code 126 :legs-code 90
-    :body-glyph "▒" :body-glyph-fg 96 :body-glyph-alt "░"
-    :face     "\e[48;5;165;38;5;231;1m▼\e[0m"
-    :face-alt "\e[48;5;165;38;5;231;1m▾\e[0m"
-    :face-attack "\e[5;48;5;165;38;5;231;1m★\e[0m"}
-   {:size [36 24] :walls 38 :enemies 8 :chase 1.3 :enemy-lives 3
-    :name "cacodemons"
-    ;; Floating cyan ball with a single eye that dilates. Body
-    ;; (= bottom half of the orb) shows small diamond spots.
-    ;; Atmosphere: deep cold void.
-    :head-code 51 :body-code 38 :legs-code 24
-    :body-glyph "⋄" :body-glyph-fg 24 :body-glyph-alt "◇"
-    :face     "\e[48;5;51;38;5;232;1m◉\e[0m"
-    :face-alt "\e[48;5;51;38;5;232;1m◎\e[0m"
-    :face-attack "\e[5;48;5;51;38;5;196;1m✺\e[0m"}
-   {:size [44 28] :walls 55 :enemies 5 :chase 1.6 :enemy-lives 4 :door-lock :blue
-    :name "barons"
-    ;; Green muscle with horn that tilts on the alt frame. Body
-    ;; reads as thick muscle via dark-shade fill. Atmosphere:
-    ;; bile-green chamber.
-    :head-code 46 :body-code 34 :legs-code 22
-    :body-glyph "▓" :body-glyph-fg 22 :body-glyph-alt "▒"
-    :face     "\e[48;5;46;38;5;232;1mΛ\e[0m"
-    :face-alt "\e[48;5;46;38;5;232;1mλ\e[0m"
-    :face-attack "\e[5;48;5;46;38;5;196;1m▲\e[0m"}
-   {:size [52 32] :walls 75 :enemies 7 :chase 2.0 :enemy-lives 5 :door-lock :red
-    :name "cyberdemons"
-    ;; Classic DOOM cyberdemon silhouette: grey helmet up top, red
-    ;; flesh torso in the middle, grey cyborg legs below. Body
-    ;; pattern shows grey armor plates over the red flesh. LED
-    ;; switches off on the alt frame. Atmosphere: industrial smog.
-    :head-code 240 :body-code 124 :legs-code 238
-    :body-glyph "▦" :body-glyph-fg 240 :body-glyph-alt "▤"
-    :face     "\e[48;5;240;38;5;196;1m■\e[0m"
-    :face-alt "\e[48;5;240;38;5;196;1m□\e[0m"
-    :face-attack "\e[5;48;5;240;38;5;226;1m✖\e[0m"}])
+  "Per-level configuration. Each entry is intentionally tiny — visuals
+   live in `enemies.phel` so a new level needs only disposition data
+   (size / walls / enemy type / count / chase speed). Required fields
+   per entry:
+
+     :size       [w h] room dimensions in grid cells
+     :walls      random wall-blob count for procgen rooms
+     :enemy      catalog kw (see enemies/enemy-types) — single type
+     :enemies    int (count of :enemy) OR vector of mixed specs
+                 `[{:type :imp :count 4 :lives 1} {:type :baron …}]`
+     :chase      enemy speed (units/sec)
+     :name       short label used in the intro splash + HUD chip
+
+   Optional:
+
+     :enemy-lives  override the catalog's :default-lives (single-type only)
+     :door-lock    :blue | :red — adds a keycard + locked exit
+     :layout       vector of ASCII strings (see map/parse-layout) —
+                   bypasses random-grid for hand-authored arenas
+
+   Adding a new room = append one map literal here."
+  [{:size [22 16] :walls 12 :enemy :imp   :enemies 4 :chase 0.8 :name "imps"}
+   {:size [28 20] :walls 22 :enemy :demon :enemies 6 :chase 1.0 :name "demons"}
+   {:size [36 24] :walls 38 :enemy :caco  :enemies 8 :chase 1.3 :name "cacodemons"}
+   {:size [44 28] :walls 55 :enemy :baron :enemies 5 :chase 1.6 :name "barons"     :door-lock :blue}
+   {:size [52 32] :walls 75 :enemy :cyber :enemies 7 :chase 2.0 :name "cyberdemons" :door-lock :red}])
 
 (def num-levels
   "Total levels in the catalog; clamped on every lookup."
@@ -138,18 +108,33 @@
     (let [[bx by] (random-spawn grid)]
       [{:x bx :y by}])))
 
+(defn- specs-total-hp
+  "Sum `count * lives` across a mixed-spec vector. Used to size the
+   ammo box budget per level — the player needs roughly enough
+   bullets to cover every monster's HP."
+  [specs]
+  (loop [xs specs total 0]
+    (cond
+      (php/=== xs nil)       total
+      (php/=== (count xs) 0) total
+      :else
+      (let [s (first xs)]
+        (recur (next xs)
+               (php/+ total (php/* (or (:count s) 0) (or (:lives s) 1))))))))
+
 (defn- ammo-box-count
   "Per-level ammo-box budget. Scales with the expected shot count
-   (`enemies * max-lives`) so bigger maps with tougher monsters get
-   more refill points — at L5 the player faces ~60 HP across the
-   level and needs steady restocks; at L1 two boxes already cover
-   the 4 imps with reserve to spare. Floor of 2 so every level has
-   at least one fallback. Divisor 8 was tuned to give roughly
-   1.3 mags of ammo per expected kill."
+   (sum of `count * lives` across enemies) so bigger maps with
+   tougher monsters get more refill points. Floor of 2 so every
+   level has at least one fallback. Divisor 8 tuned to give
+   roughly 1.3 mags of ammo per expected kill."
   [cfg]
-  (let [enemies   (or (:enemies cfg) 0)
-        max-lives (or (:enemy-lives cfg) 1)]
-    (php/max 2 (php/intval (php/ceil (php// (php/* enemies max-lives) 8))))))
+  (let [enemies (:enemies cfg)
+        hp      (cond
+                  (vector? enemies) (specs-total-hp enemies)
+                  :else             (php/* (or enemies 0)
+                                           (or (:enemy-lives cfg) 1)))]
+    (php/max 2 (php/intval (php/ceil (php// hp 8))))))
 
 (defn- lock-cell-for
   "Map a lock-colour kw to the matching locked-door cell value."
@@ -235,58 +220,98 @@
           (recur acc (php/+ attempts 1))
           (recur (conj acc {:x bx :y by}) (php/+ attempts 1)))))))
 
+(defn- build-grid
+  "Two paths: hand-authored `:layout` (parsed via map/parse-layout —
+   bypasses random + seed-doors + lock-the-door, the author put doors
+   + locks directly in the ASCII) OR random `random-grid + seed-doors
+   + lock-the-door` for the procedural path. Returns `{:grid :spawn}`."
+  [cfg]
+  (if (:layout cfg)
+    (or (parse-layout (:layout cfg))
+        (throw (php/new php/InvalidArgumentException
+                        (str "Level layout missing player spawn '@': "
+                             (:name cfg)))))
+    (let [[w h] (:size cfg)
+          grid  (lock-the-door
+                 (seed-doors (random-grid w h (:walls cfg)) 1)
+                 (:door-lock cfg))]
+      {:grid grid :spawn (random-spawn grid)})))
+
+(defn- normalise-enemies
+  "Coerce the level's `:enemies` field into a vector of mixed specs
+   `[{:type :count :lives}]`. Single-type entries (int + `:enemy` +
+   optional `:enemy-lives`) become a 1-element vector. Already-mixed
+   entries pass through unchanged, with `:type` falling back to
+   `:enemy` and `:lives` to the catalog default when the spec omits
+   either field."
+  [cfg]
+  (let [es (:enemies cfg)]
+    (cond
+      (vector? es)
+      (apply vector
+             (map (fn [spec]
+                    (let [t (or (:type spec) (:enemy cfg) :imp)]
+                      {:type  t
+                       :count (or (:count spec) 0)
+                       :lives (or (:lives spec) (default-lives-for t))}))
+                  es))
+
+      :else
+      (let [t (or (:enemy cfg) :imp)]
+        [{:type  t
+          :count (or es 0)
+          :lives (or (:enemy-lives cfg) (default-lives-for t))}]))))
+
 (defn build-world
   "Construct a brand-new world for `level-num` carrying `lives` over
-   from the previous level. Walls, enemies, the single door, the
-   player spawn, and (when lives < max-lives) one heart pickup are all
-   randomised. Level tuning is stamped onto the world so render and
-   physics can read it without globals. `backpack?` controls whether
-   the new level seeds another backpack — once owned, don't drop more."
+   from the previous level. Walls, enemies, doors, player spawn, and
+   pickups are randomised by default; a level entry can opt into a
+   hand-authored `:layout` for boss arenas. Enemies stamp `:type` so
+   render reads per-enemy visuals from the catalog."
   ([level-num lives] (build-world level-num lives false :normal #{:pistol}))
   ([n l pack?] (build-world n l pack? :normal #{:pistol}))
   ([n l pack? diff] (build-world n l pack? diff #{:pistol}))
   ([lv life pack? diff owned]
-   (let [diff' (normalise diff)
-         cfg   (scale-cfg (config-for lv) diff')
-         lock  (:door-lock cfg)]
-     (let [[w h] (:size cfg)
-           grid  (lock-the-door
-                  (seed-doors (random-grid w h (:walls cfg)) 1)
-                  lock)]
-       (let [[px py] (random-spawn grid)]
-         (let [world (new-world grid (new-player px py (php/* (rand-int 360)
-                                                              (php// php/M_PI 180.0))))]
-           (let [with-foes (with-enemies world
-                                         (spawn-enemies grid (:enemies cfg)
-                                                        enemy-min-spawn-dist px py
-                                                        (or (:enemy-lives cfg) 1)))]
-             (assoc with-foes
-                    :level         lv
-                    :lives         life
-                    :difficulty    diff'
-                    :backpack?     pack?
-                    :owned-weapons (or owned #{:pistol})
-                    :hearts        (maybe-spawn-heart grid life px py)
-                    :armors        (maybe-spawn-armor grid)
-                    :berserks      (maybe-spawn-berserk grid)
-                    :invulns       (maybe-spawn-invuln grid)
-                    :backpacks     (maybe-spawn-backpack grid lv pack?)
-                    :keycards      (maybe-spawn-keycard grid lock)
-                    :weapon-pickups (maybe-spawn-weapon-pickups grid lv (or owned #{:pistol}))
-                    :door-lock     lock
-                    :ammo-boxes    (spawn-ammo-boxes grid (ammo-box-count cfg))
-                    :chase-speed (:chase cfg)
-                    :enemy-head-code     (:head-code cfg)
-                    :enemy-body-code     (:body-code cfg)
-                    :enemy-legs-code     (:legs-code cfg)
-                    :enemy-body-glyph    (:body-glyph cfg)
-                    :enemy-body-glyph-alt (:body-glyph-alt cfg)
-                    :enemy-body-glyph-fg (:body-glyph-fg cfg)
-                    :enemy-face          (:face cfg)
-                    :enemy-face-alt      (:face-alt cfg)
-                    :enemy-face-attack   (:face-attack cfg)
-                    :level-name  (:name cfg)
-                   ;; Show a centred splash for the first ~1.5s of the
-                   ;; level. tick-world decays this each frame; render
-                   ;; layer paints the overlay while it's > 0.
-                    :intro-secs  1.5))))))))
+   (let [diff'                (normalise diff)
+         raw                  (config-for lv)
+         ;; Resolve :enemy-lives from the catalog BEFORE scale-cfg —
+         ;; otherwise scale-cfg's missing-field default of 1 masks
+         ;; the catalog default and every monster spawns with 1 HP.
+         primed               (if (or (vector? (:enemies raw)) (:enemy-lives raw))
+                                raw
+                                (assoc raw :enemy-lives
+                                       (default-lives-for (or (:enemy raw) :imp))))
+         cfg                  (scale-cfg primed diff')
+         lock                 (:door-lock cfg)
+         {:keys [grid spawn]} (build-grid cfg)
+         [px py]              spawn
+         specs                (normalise-enemies cfg)
+         world                (new-world grid (new-player px py (php/* (rand-int 360)
+                                                                       (php// php/M_PI 180.0))))
+         with-foes            (with-enemies world
+                                            (spawn-enemies-mixed grid specs
+                                                                 enemy-min-spawn-dist px py))]
+     (assoc with-foes
+            :level         lv
+            :lives         life
+            :difficulty    diff'
+            :backpack?     pack?
+            :owned-weapons (or owned #{:pistol})
+            :hearts        (maybe-spawn-heart grid life px py)
+            :armors        (maybe-spawn-armor grid)
+            :berserks      (maybe-spawn-berserk grid)
+            :invulns       (maybe-spawn-invuln grid)
+            :backpacks     (maybe-spawn-backpack grid lv pack?)
+            :keycards      (maybe-spawn-keycard grid lock)
+            :weapon-pickups (maybe-spawn-weapon-pickups grid lv (or owned #{:pistol}))
+            :door-lock     lock
+            :ammo-boxes    (spawn-ammo-boxes grid (ammo-box-count cfg))
+            :chase-speed   (:chase cfg)
+            ;; Primary type fallback for render — used when an enemy
+            ;; doesn't carry its own :type (defensive only, every
+            ;; enemy from spawn-enemies-mixed has one).
+            :enemy         (or (:enemy cfg) (:type (first specs)))
+            :level-name    (:name cfg)
+            ;; Centred 1.5s intro splash. tick-world decays this; render
+            ;; paints the overlay while > 0.
+            :intro-secs    1.5))))

--- a/src/modules/core/map.phel
+++ b/src/modules/core/map.phel
@@ -218,3 +218,58 @@
         (if (= cell-floor (get (get grid y) x))
           [(+ 0.5 x) (+ 0.5 y)]
           (recur))))))
+
+;; ---------------------------------------------------------------------
+;; Hand-authored layouts.
+;;
+;; A layout is a vector of equal-length strings — one per row, top-down.
+;; Char map:
+;;   '#' wall            '.' floor
+;;   'D' unlocked door   'B' blue-locked door   'R' red-locked door
+;;   '@' floor + records [x y] as the player spawn (cell centre)
+;;
+;; parse-layout returns {:grid <vec-of-vec> :spawn [x y]} when the
+;; layout is well-formed, nil when no '@' is found. Used by level.phel
+;; when a level entry carries :layout to bypass the random-grid path.
+;; ---------------------------------------------------------------------
+
+(def ^:private layout-char->cell
+  {"#" cell-wall
+   "." cell-floor
+   "@" cell-floor
+   "D" cell-door
+   "B" cell-door-blue
+   "R" cell-door-red})
+
+(defn- parse-row
+  "Convert one layout string into [row-vec maybe-spawn-x]. Returns
+   nil for spawn-x when the row doesn't contain '@'. Unknown chars
+   fall back to floor so a typo doesn't crash."
+  [s y]
+  (let [w (php/strlen s)]
+    (loop [x       0
+           row     []
+           spawn-x nil]
+      (if (php/>= x w)
+        [row spawn-x]
+        (let [ch    (php/substr s x 1)
+              cell  (or (get layout-char->cell ch) cell-floor)
+              spawn (if (= ch "@") x spawn-x)]
+          (recur (php/+ x 1) (conj row cell) spawn))))))
+
+(defn parse-layout
+  "Parse a hand-authored ASCII grid into `{:grid :spawn}`. Returns
+   nil when the layout has no '@' (no player spawn)."
+  [rows]
+  (let [h (count rows)]
+    (loop [y     0
+           grid  []
+           spawn nil]
+      (if (php/>= y h)
+        (when (not (nil? spawn))
+          {:grid grid :spawn spawn})
+        (let [[row sx] (parse-row (get rows y) y)
+              spawn'   (if (and (nil? spawn) (not (nil? sx)))
+                         [(+ 0.5 sx) (+ 0.5 y)]
+                         spawn)]
+          (recur (php/+ y 1) (conj grid row) spawn'))))))

--- a/src/modules/io/render.phel
+++ b/src/modules/io/render.phel
@@ -1,4 +1,5 @@
 (ns phel-doom.modules.io.render
+  (:require phel-doom.modules.core.enemies :refer [enemy-types])
   (:require phel-doom.modules.core.engine  :refer [cast-frame max-depth proj-dist])
   (:require phel-doom.modules.core.map     :refer [find-door-cell])
   (:require phel-doom.modules.core.weapons :refer [weapon-order weapons]))
@@ -689,7 +690,8 @@
           {:col          (php/intval (php/+ (php/* 0.5 vw) (php/* (php/tan rel-norm) proj-dist)))
            :half-width   (php/max 1 (php/intval (php// proj-dist (php/* (php/max 0.5 dist) 3.0))))
            :dist         dist
-           :damage-ratio dmg})))))
+           :damage-ratio dmg
+           :type         (:type enemy)})))))
 
 (defn- collect-enemy-projs
   "Project every alive enemy and return a vector sorted by distance
@@ -1009,33 +1011,48 @@
    scare-secs window."
   "\e[5;48;5;201;38;5;231;1m☠\e[0m")
 
+(defn- visuals-for-type
+  "Catalog lookup for a type kw, falling back to the level's primary
+   `:enemy` type from stats when the enemy carries no `:type`, then
+   to `:imp` as a last resort so visuals are never empty (every enemy
+   gets a face overlay, no silent skips on unknown types)."
+  [type-kw stats]
+  (or (get enemy-types type-kw)
+      (get enemy-types (or (get stats :enemy) :imp))
+      (get enemy-types :imp)))
+
 (defn- paint-face-overlay
-  "At each visible alive enemy's centre column paint the level's
-   :enemy-face glyph at the upper-third of the sprite. Three modes:
+  "At each visible alive enemy's centre column paint that enemy's
+   catalog face glyph at the upper-third of the sprite. Three modes:
      - scare-secs active  → wide-eyed scare glyph (one-shot beat)
      - d < aggro-distance → :face-attack telegraph
-     - else               → resting :face"
-  [parts world stats vw vh dists eface]
-  (when eface
-    (let [face-attack (get stats :enemy-face-attack)
-          scare?      (php/> (or (get stats :scare-secs) 0.0) 0.0)]
-      (doseq [proj (collect-enemy-projs (:enemies world) (:player world) vw)]
-             (let [col   (:col proj)
-                   d     (:dist proj)
-                   glyph (cond
-                           scare?                                     scare-face-glyph
-                           (and face-attack (php/< d aggro-distance)) face-attack
-                           :else                                      eface)]
-               (when (and (php/>= col 0)
-                          (php/< col vw)
-                          (php/< d (buf-get dists col)))
-                 (let [h        (php/min vh (php/intval (php// proj-dist
-                                                               (php/* (php/max 0.5 d) char-aspect))))
-                       face-row (php/+ (php/intdiv (php/- vh h) 2) (php/intdiv h 6))]
-                   (when (and (php/>= face-row 1) (php/<= face-row vh))
-                     (buf-push parts
-                               (str "\e[" face-row ";"
-                                    (php/+ col 1) "H" glyph)))))))))
+     - else               → resting :face (alternates with :face-alt
+                            on the global face-phase beat)"
+  [parts world stats vw vh dists face-phase]
+  (let [scare? (php/> (or (get stats :scare-secs) 0.0) 0.0)]
+    (doseq [proj (collect-enemy-projs (:enemies world) (:player world) vw)]
+           (let [col         (:col proj)
+                 d           (:dist proj)
+                 visuals     (visuals-for-type (:type proj) stats)
+                 face        (get visuals :face)
+                 face-alt    (or (get visuals :face-alt) face)
+                 face-attack (get visuals :face-attack)
+                 idle        (if (php/> face-phase 0.0) face face-alt)
+                 glyph       (cond
+                               scare?                                     scare-face-glyph
+                               (and face-attack (php/< d aggro-distance)) face-attack
+                               :else                                      idle)]
+             (when (and glyph
+                        (php/>= col 0)
+                        (php/< col vw)
+                        (php/< d (buf-get dists col)))
+               (let [h        (php/min vh (php/intval (php// proj-dist
+                                                             (php/* (php/max 0.5 d) char-aspect))))
+                     face-row (php/+ (php/intdiv (php/- vh h) 2) (php/intdiv h 6))]
+                 (when (and (php/>= face-row 1) (php/<= face-row vh))
+                   (buf-push parts
+                             (str "\e[" face-row ";"
+                                  (php/+ col 1) "H" glyph))))))))
   parts)
 
 (defn- paint-wall-lights
@@ -2037,17 +2054,9 @@
         ;; col-setup loop below. One vw-sized PHP array built per
         ;; frame; lookup is O(1) inside the loop.
         blood-cols                         (build-blood-cols vw bloody? (get stats :hurt-side))
-        ;; Per-enemy distance-fade is composed in the projection loop
-        ;; below and assigned to the per-column arrays. These are the
-        ;; FALLBACK shades used when no level config provides codes
-        ;; (e.g. test worlds built via new-world without going through
-        ;; build-world).
-        ehead                              (or (get stats :enemy-head) enemy-head)
-        ebody                              (or (get stats :enemy-body) enemy-body)
-        elegs                              (or (get stats :enemy-legs) enemy-body)
-        head-code                          (get stats :enemy-head-code)
-        body-code                          (get stats :enemy-body-code)
-        legs-code                          (get stats :enemy-legs-code)
+        ehead                              enemy-head
+        ebody                              enemy-body
+        elegs                              enemy-body
         ;; Pause-aware clock: render samples its blinks/pulses from
         ;; this instead of wall time so every time-driven animation
         ;; freezes the moment the game is paused (issue #7).
@@ -2057,16 +2066,6 @@
         ;; the face. Eye blinks and scales/muscles shift on alternating
         ;; beats so the monster looks animated without per-enemy state.
         face-phase                         (php/sin (php/* t 3.0))
-        eface                              (if (php/> face-phase 0.0)
-                                             (get stats :enemy-face)
-                                             (or (get stats :enemy-face-alt)
-                                                 (get stats :enemy-face)))
-        body-glyph-base                    (get stats :enemy-body-glyph)
-        body-glyph                         (if (php/< face-phase 0.0)
-                                             body-glyph-base
-                                             (or (get stats :enemy-body-glyph-alt)
-                                                 body-glyph-base))
-        body-glyph-fg                      (get stats :enemy-body-glyph-fg)
         ;; Cast phase. When the F3 overlay is on, sample microtime
         ;; around the call so render! can split cast-ms from total
         ;; frame-ms. The branch is the only debug-gated cost in the
@@ -2231,27 +2230,40 @@
                    ;; enemy never fades to invisible.
                    body-fade (php/min 0.85 (php/+ dist-fade (php/* dmg 0.35)))]
                (let [e-top (php/intdiv (php/- vh h) 2)]
-                 (let [e-bot   (php/+ e-top h)
-                       e-mid   (php/+ e-top (php/intdiv h 3))
-                       e-lower (php/+ e-top (php/intdiv (php/* h 2) 3))
+                 (let [e-bot         (php/+ e-top h)
+                       e-mid         (php/+ e-top (php/intdiv h 3))
+                       e-lower       (php/+ e-top (php/intdiv (php/* h 2) 3))
+                       ;; Per-enemy catalog lookup — mixed-monster rooms
+                       ;; (boss + minions) pick the right palette per
+                       ;; sprite, single-type rooms hit the same kw on
+                       ;; every iteration so the cost is one map get.
+                       visuals       (visuals-for-type (:type proj) stats)
+                       head-code     (get visuals :head-code)
+                       body-code     (get visuals :body-code)
+                       legs-code     (get visuals :legs-code)
+                       body-glyph-fg (get visuals :body-glyph-fg)
+                       body-glyph    (if (php/< face-phase 0.0)
+                                       (get visuals :body-glyph)
+                                       (or (get visuals :body-glyph-alt)
+                                           (get visuals :body-glyph)))
                        ;; Faded shade strings for this enemy at its
                        ;; current distance. Computed ONCE per enemy
                        ;; and assigned to every column it covers.
-                       fhead   (cond
-                                 (and head-code (php/< d aggro-distance))
-                                 (enemy-aggro-head-string head-code aggro-bright?)
-                                 head-code
-                                 (enemy-shade-string head-code dist-fade)
-                                 :else
-                                 ehead)
-                       fbody   (cond
-                                 (and body-code body-glyph body-glyph-fg)
-                                 (enemy-textured-shade-string body-code body-fade body-glyph body-glyph-fg)
-                                 body-code
-                                 (enemy-shade-string body-code body-fade)
-                                 :else
-                                 ebody)
-                       flegs   (if legs-code (enemy-shade-string legs-code dist-fade) elegs)]
+                       fhead         (cond
+                                       (and head-code (php/< d aggro-distance))
+                                       (enemy-aggro-head-string head-code aggro-bright?)
+                                       head-code
+                                       (enemy-shade-string head-code dist-fade)
+                                       :else
+                                       ehead)
+                       fbody         (cond
+                                       (and body-code body-glyph body-glyph-fg)
+                                       (enemy-textured-shade-string body-code body-fade body-glyph body-glyph-fg)
+                                       body-code
+                                       (enemy-shade-string body-code body-fade)
+                                       :else
+                                       ebody)
+                       flegs         (if legs-code (enemy-shade-string legs-code dist-fade) elegs)]
                    (loop [c c-from]
                      (when (php/<= c c-to)
                        (when (php/< d (buf-get dists c))
@@ -2413,7 +2425,7 @@
             ;; Numbered rebinds so phel lint's shadowed-binding stays
             ;; quiet without changing semantics. Threading (->) would
             ;; be cleaner but trips arity-mismatch lint.
-            p1          (paint-face-overlay       parts world stats vw vh dists eface)
+            p1          (paint-face-overlay       parts world stats vw vh dists face-phase)
             p2          (paint-wall-lights        p1 t vw vh hits hxs hys tops)
             p3          (paint-door-face          p2 stats vw vh hits tops bots)
             p4          (paint-crosshair          p3 stats vw vh center-bg)

--- a/tests/modules/core/enemies-test.phel
+++ b/tests/modules/core/enemies-test.phel
@@ -1,0 +1,74 @@
+(ns phel-doom-tests.modules.core.enemies-test
+  (:require phel.test :refer [deftest is])
+  (:require phel-doom.modules.core.enemies
+            :refer [default-lives-for enemy-types required-keys type-spec]))
+
+;; ---------------------------------------------------------------------
+;; Catalog completeness: every entry must carry every required field.
+;; A missing field shows up as a crashed sprite at runtime — caught
+;; here instead.
+;; ---------------------------------------------------------------------
+
+(deftest test-catalog-has-all-required-fields-for-every-type
+  (doseq [[type-kw spec] enemy-types]
+         (doseq [k required-keys]
+                (is (not (nil? (get spec k)))
+                    (str type-kw " is missing required field " k)))))
+
+(deftest test-catalog-has-the-expected-types
+  ;; Pin the set so a rename can't silently break level entries
+  ;; that reference these kws.
+  (let [expected #{:imp :demon :caco :baron :cyber
+                   :spectre :revenant :archvile :mancubus :pinky}]
+    (doseq [k expected]
+           (is (not (nil? (get enemy-types k)))
+               (str "Missing catalog entry: " k)))))
+
+;; ---------------------------------------------------------------------
+;; Visual regression: pin the SGR / glyphs for the L1-L5 monsters so a
+;; catalog refactor can't silently change what the player sees.
+;; Just the head-code and face are pinned; if we want a full repaint
+;; we'll update these intentionally.
+;; ---------------------------------------------------------------------
+
+(deftest test-imp-visual-pin
+  (let [s (type-spec :imp)]
+    (is (= 196 (:head-code s)))
+    (is (= "\e[48;5;196;38;5;226;1m●\e[0m" (:face s)))))
+
+(deftest test-demon-visual-pin
+  (let [s (type-spec :demon)]
+    (is (= 165 (:head-code s)))
+    (is (= "\e[48;5;165;38;5;231;1m▼\e[0m" (:face s)))))
+
+(deftest test-caco-visual-pin
+  (let [s (type-spec :caco)]
+    (is (= 51 (:head-code s)))
+    (is (= "\e[48;5;51;38;5;232;1m◉\e[0m" (:face s)))))
+
+(deftest test-baron-visual-pin
+  (let [s (type-spec :baron)]
+    (is (= 46 (:head-code s)))
+    (is (= "\e[48;5;46;38;5;232;1mΛ\e[0m" (:face s)))))
+
+(deftest test-cyber-visual-pin
+  (let [s (type-spec :cyber)]
+    (is (= 240 (:head-code s)))
+    (is (= "\e[48;5;240;38;5;196;1m■\e[0m" (:face s)))))
+
+;; ---------------------------------------------------------------------
+;; default-lives-for + type-spec lookups.
+;; ---------------------------------------------------------------------
+
+(deftest test-default-lives-matches-catalog
+  (is (= 1 (default-lives-for :imp)))
+  (is (= 5 (default-lives-for :cyber))))
+
+(deftest test-default-lives-unknown-falls-back-to-1
+  ;; Used by spawn-enemies-mixed when a spec omits :lives AND the
+  ;; type is bogus. Must NOT crash — return 1 so the spawn at least
+  ;; produces a hittable enemy.
+  (is (= 1 (default-lives-for :totally-bogus-type))))
+
+(deftest test-type-spec-unknown-returns-nil
+  (is (nil? (type-spec :nope))))

--- a/tests/modules/core/enemy-test.phel
+++ b/tests/modules/core/enemy-test.phel
@@ -1,6 +1,6 @@
 (ns phel-doom-tests.modules.core.enemy-test
   (:require phel.test :refer [deftest is])
-  (:require phel-doom.modules.core.enemy :refer [new-enemy spawn-enemies shoot advance tick-scare rear-attacker?]))
+  (:require phel-doom.modules.core.enemy :refer [new-enemy spawn-enemies spawn-enemies-mixed shoot advance tick-scare rear-attacker?]))
 
 (def open-grid
   "Bordered 10x10 open arena, no interior walls."
@@ -251,3 +251,50 @@
 (deftest test-rear-attacker-side-arc-doesnt-trigger
   ;; Enemy due north (90° off facing) — flank, not back.
   (is (= false (rear-attacker? [{:x 5.0 :y 8.0 :alive true}] 5.0 5.0 0.0))))
+
+;; ---------------------------------------------------------------------
+;; :type on new-enemy + spawn-enemies — required by render's per-enemy
+;; visual lookup for mixed-monster rooms.
+;; ---------------------------------------------------------------------
+
+(deftest test-new-enemy-default-type-nil
+  ;; 2-arity callers (pre-mixed-rooms) get :type nil — render falls
+  ;; back to the level's primary type.
+  (is (nil? (:type (new-enemy 1.5 1.5)))))
+
+(deftest test-new-enemy-stamps-type-when-given
+  (is (= :baron (:type (new-enemy 1.5 1.5 4 :baron)))))
+
+(deftest test-spawn-enemies-stamps-type-on-each
+  ;; Open grid so spawn-enemies always succeeds for the small N here.
+  (let [g  (apply vector
+                  (map (fn [_] (apply vector (map (fn [__] 0) (range 0 8))))
+                       (range 0 8)))
+        ;; Border with walls so random-spawn-style placement has room
+        g' (assoc g 0 (apply vector (map (fn [_] 1) (range 0 8))))
+        es (spawn-enemies g' 3 0.0 0.0 0.0 4 :cyber)]
+    (is (= 3 (count es)))
+    (is (every? (fn [e] (= :cyber (:type e))) es))
+    (is (every? (fn [e] (= 4 (:lives e))) es))))
+
+;; ---------------------------------------------------------------------
+;; spawn-enemies-mixed: one spec per enemy type. Counts + lives + type
+;; must all line up.
+;; ---------------------------------------------------------------------
+
+(deftest test-spawn-enemies-mixed-counts-per-type
+  (let [g      (apply vector
+                      (map (fn [_] (apply vector (map (fn [__] 0) (range 0 12))))
+                           (range 0 12)))
+        specs  [{:type :imp   :count 3 :lives 1}
+                {:type :cyber :count 1 :lives 20}]
+        es     (spawn-enemies-mixed g specs 0.0 0.0 0.0)
+        imps   (filter (fn [e] (= :imp   (:type e))) es)
+        bosses (filter (fn [e] (= :cyber (:type e))) es)]
+    (is (= 4 (count es)))
+    (is (= 3 (count imps)))
+    (is (= 1 (count bosses)))
+    (is (= 20 (:lives (first bosses))))))
+
+(deftest test-spawn-enemies-mixed-empty-specs-returns-nothing
+  (is (= 0 (count (spawn-enemies-mixed [[0 0] [0 0]] [] 0.0 0.0 0.0)))))

--- a/tests/modules/core/level-test.phel
+++ b/tests/modules/core/level-test.phel
@@ -42,3 +42,39 @@
   (let [w (build-world 2 5)]
     (is (= 0 (count (:hearts w))))
     (is (= 5 (:lives w)))))
+
+;; ---------------------------------------------------------------------
+;; Slim-entry refactor regression: each level's `:enemy` kw is stamped
+;; on every enemy, and the world's primary `:enemy` matches the level's
+;; catalog type.
+;; ---------------------------------------------------------------------
+
+(deftest test-build-world-stamps-primary-enemy-kw
+  (is (= :imp   (:enemy (build-world 1 5))))
+  (is (= :demon (:enemy (build-world 2 5))))
+  (is (= :baron (:enemy (build-world 4 5))))
+  (is (= :cyber (:enemy (build-world 5 5)))))
+
+(deftest test-build-world-enemies-all-carry-type
+  (let [w  (build-world 1 5)
+        es (:enemies w)]
+    (is (every? (fn [e] (= :imp (:type e))) es))))
+
+(deftest test-build-world-enemy-lives-match-catalog-default
+  ;; L1 :imp has :default-lives 1; build-world's slim entry omits
+  ;; :enemy-lives so the catalog default flows through.
+  (let [w (build-world 1 5)
+        e (first (:enemies w))]
+    (is (= 1 (:lives e))))
+  ;; L5 :cyber has :default-lives 5 — same path.
+  (let [w (build-world 5 5)
+        e (first (:enemies w))]
+    (is (= 5 (:lives e)))))
+
+(deftest test-build-world-drops-world-level-enemy-visual-fields
+  ;; Refactor moved visuals out of the world. Sanity-check the dead
+  ;; fields really are gone so render can't accidentally re-read them.
+  (let [w (build-world 1 5)]
+    (is (nil? (:enemy-head-code w)))
+    (is (nil? (:enemy-body-code w)))
+    (is (nil? (:enemy-face w)))))

--- a/tests/modules/core/map-test.phel
+++ b/tests/modules/core/map-test.phel
@@ -2,6 +2,8 @@
   (:require phel.test :refer [deftest is])
   (:require phel-doom.modules.core.map :refer [default-grid wall? door?
                                                cell-floor cell-wall cell-door
+                                               cell-door-blue cell-door-red
+                                               parse-layout
                                                random-grid random-spawn seed-doors]))
 
 (deftest test-walls-on-perimeter
@@ -117,3 +119,52 @@
                [1 1 1 1 1]]
         [x y] (random-spawn g)]
     (is (= false (wall? g (php/intval x) (php/intval y))))))
+
+;; ---------------------------------------------------------------------
+;; parse-layout: hand-authored ASCII grids → {:grid :spawn}.
+;; ---------------------------------------------------------------------
+
+(deftest test-parse-layout-happy-path
+  (let [out (parse-layout ["#####"
+                           "#...#"
+                           "#.@.#"
+                           "#...#"
+                           "####D"])]
+    (is (not (nil? out)))
+    (let [g       (:grid out)
+          [sx sy] (:spawn out)]
+      (is (= 5 (count g)))
+      (is (= 5 (count (first g))))
+      ;; Walls on the border.
+      (is (= cell-wall (get-in g [0 0])))
+      ;; Spawn cell parsed as floor (so player stands on it).
+      (is (= cell-floor (get-in g [2 2])))
+      ;; Spawn coords centred on the '@' cell.
+      (is (= 2.5 sx))
+      (is (= 2.5 sy))
+      ;; Door in the bottom-right corner.
+      (is (= cell-door (get-in g [4 4]))))))
+
+(deftest test-parse-layout-locked-doors
+  (let [out (parse-layout ["#####"
+                           "#.@.B"
+                           "#...R"
+                           "#####"])
+        g   (:grid out)]
+    (is (= cell-door-blue (get-in g [1 4])))
+    (is (= cell-door-red  (get-in g [2 4])))))
+
+(deftest test-parse-layout-no-spawn-returns-nil
+  ;; Missing '@' = malformed layout. parse-layout returns nil so the
+  ;; caller can throw / fall back.
+  (is (nil? (parse-layout ["#####"
+                           "#...#"
+                           "#####"]))))
+
+(deftest test-parse-layout-unknown-chars-fall-back-to-floor
+  ;; Typos shouldn't crash — render an unknown char as walkable.
+  (let [out (parse-layout ["####"
+                           "#?@#"
+                           "####"])
+        g   (:grid out)]
+    (is (= cell-floor (get-in g [1 1])))))


### PR DESCRIPTION
## 📚 Description

Behaviour-preserving refactor that prepares the level system to scale to N rooms with low ceremony. Foundation for a follow-up PR that ships L6-L10 with mixed monsters + a final boss.

## 🔖 Changes

**New** — `src/modules/core/enemies.phel`
- `enemy-types` catalog: kw → `{:name :default-lives :head-code :body-code :legs-code :body-glyph :body-glyph-alt :body-glyph-fg :face :face-alt :face-attack}`.
- Current 5 (imp / demon / caco / baron / cyber) verbatim + 5 stubs ready for L6-L10 (spectre / revenant / archvile / mancubus / pinky).
- Public helpers: `type-spec`, `default-lives-for`, `required-keys`.

**`src/modules/core/level.phel`** — slim entries + mixed + layout
- `levels` shrinks from 15-field map literals to one line each: `{:size :walls :enemy :imp :enemies 4 :chase 0.8}`.
- `:enemies` accepts int (single-type, uses `:enemy`) OR vector of specs `[{:type :imp :count 4 :lives 1}]` for mixed-monster rooms.
- Optional `:layout` (vector of ASCII strings) bypasses `random-grid` + `seed-doors` for hand-authored arenas. Random procgen remains the default.
- `build-world` pre-resolves `:enemy-lives` from the catalog before `scale-cfg` so the difficulty layer's missing-field default of `1` no longer masks the catalog default.

**`src/modules/core/enemy.phel`**
- `new-enemy` gains optional `:type` keyword on the record.
- New 7-arity of `spawn-enemies` that stamps `:type` per enemy.
- New `spawn-enemies-mixed`: flattens per-type specs into one enemy vector.

**`src/modules/core/map.phel`** — new `parse-layout`
- Vector of ASCII strings → `{:grid :spawn}`. Char map: `#` wall, `.` floor, `@` spawn (floor + records cell), `D` unlocked door, `B` blue-locked, `R` red-locked. Unknown chars fall back to floor (typo-safe).

**`src/modules/io/render.phel`** — per-enemy visuals
- Drops world-level `:enemy-head-code` / `:enemy-body-glyph` / `:enemy-face` etc. (and matching frame-stats passthroughs in `play.phel`).
- New `visuals-for-type` helper: catalog lookup with fallback chain (proj `:type` → world `:enemy` → `:imp`) so an unknown type never paints a faceless enemy.
- `paint-face-overlay` + the per-enemy projection loop pull visuals from the catalog each iteration. Single-type rooms hit the same kw repeatedly (one `get` per enemy, not per frame); mixed-monster rooms branch naturally.

**Tests** — 716 pass (+166 from new test surface)
- `tests/modules/core/enemies-test.phel` (new): catalog completeness + per-type visual pins for the L1-L5 monsters + `default-lives-for` / `type-spec` lookups.
- `tests/modules/core/enemy-test.phel`: `:type` on `new-enemy`, `spawn-enemies` 7-arity stamps `:type`, `spawn-enemies-mixed` counts + per-type lives.
- `tests/modules/core/map-test.phel`: `parse-layout` happy path, locked-door chars, missing `@` → nil, unknown char → floor fallback.
- `tests/modules/core/level-test.phel`: primary `:enemy` stamped per level, every enemy carries `:type`, HP matches catalog defaults, dead world fields stay dead.

**Docs**
- `docs/level-system.md` — rewritten "Catalog" + "Adding a new room" sections.
- `docs/monsters.md` — replaced level-keyed table with the `enemy-types` catalog table; new spawning section covers mixed-spec rooms.
- `CHANGELOG.md` — `### Changed` under `## [Unreleased]`.

## 🧪 Test plan

- [x] `composer ci` — 0 warnings, 716 tests pass.
- [x] `clean-code-reviewer` — approved with one warning (faceless enemy on unknown type) which was fixed before commit.
- [ ] Smoke `/play` — L1-L5 look identical to v0.3.0; visuals come from the catalog now but the catalog values are verbatim copies of the old inline entries.

Follow-up PR will add L6-L10 (5 progressive mixed-monster rooms + L10 final boss arena).