### PR TITLE
feat(cli): --level=N to start at a specific level (dev shortcut)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 
 ### Added
 
+- `--level=N` (`-l`) CLI flag — start the run at level N (clamped to 1..num-levels). Pairs naturally with `--god` for dev testing: `make play-boss` drops straight into the L10 boss arena, `make play-level LV=8` starts at level 8. Death + retry still reset to L1; the flag only seeds the initial loop entry.
 - **5 new levels** taking the run from 5 to 10 rooms. L6-L9 mix multiple monster types per room for a chaotic late-game; L10 is a hand-authored boss arena.
   - **L6 spectres** — 4 spectres (HP 3, agile) + 2 imps. Spectres debut.
   - **L7 revenants** — 4 revenants (HP 4) + 2 demons.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install d dev t test f format fc fix b build r repl doctor clean p play play-dev
+.PHONY: help install d dev t test f format fc fix b build r repl doctor clean p play play-dev play-boss play-level
 
 help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-10s\033[0m %s\n", $$1, $$2}'
@@ -16,6 +16,12 @@ play: ## start the DOOM showcase
 
 play-dev: ## god mode: no damage, GOD badge in HUD — for testing rooms / weapons end-to-end
 	vendor/bin/phel run phel-doom.main play --god
+
+play-boss: ## god mode + drop into the L10 boss arena directly
+	vendor/bin/phel run phel-doom.main play --god --level=10
+
+play-level: ## god mode + start at level N (default 1): `make play-level LV=8`
+	vendor/bin/phel run phel-doom.main play --god --level=$(or $(LV),1)
 
 t: test
 test: ## run phel tests

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Hold space to spray with the pistol/chaingun. Shotgun needs a fresh pull per she
 CLI:
 - `--difficulty=easy|normal|hard|nightmare` (`-d`) — scales enemy speed, HP, count
 - `--god` (`-g`) or `make play-dev` — no damage, GOD badge in HUD
+- `--level=N` (`-l`) — start at level N. Pairs with `--god`: `make play-boss` jumps to L10, `make play-level LV=8` starts at L8
 
 Terminal quirks (kitty keyboard, tmux): see [docs/input.md](docs/input.md).
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -110,6 +110,7 @@ See [scores.md](scores.md).
 
 - `--difficulty=easy|normal|hard|nightmare` (`-d`) — scales enemy chase speed, per-enemy HP, per-level enemy count. HUD tag suppressed for `normal`.
 - `--god` (`-g`) or `make play-dev` — dev mode: contact damage suppressed end-to-end. HUD adds a yellow `GOD` badge after the hearts strip.
+- `--level=N` (`-l`) — start at level N (clamped to 1..num-levels). Combine with `--god` to jump straight into a boss room for testing. Shortcuts: `make play-boss` (L10), `make play-level LV=N`.
 
 ## Misc
 

--- a/src/commands/play.phel
+++ b/src/commands/play.phel
@@ -653,11 +653,11 @@
    `diff` is the difficulty keyword from --difficulty (or nil for
    :normal). `god?` (from --god / `make play-dev`) stamps :god? on
    every freshly-built world so combat/vulnerable? short-circuits
-   contact damage for the whole run. Both are threaded into every
-   build-world call so r/R retries preserve the same balance + dev
-   flags the player launched with."
-  [diff god?]
-  (loop [level       1
+   contact damage for the whole run. `start-level` (from --level / -l)
+   sets where the run begins — 1..num-levels, clamped. Death + retry
+   reset to L1 (the start-level only seeds the initial loop entry)."
+  [diff god? start-level]
+  (loop [level       (php/max 1 (php/min num-levels (or start-level 1)))
          lives       max-lives
          carry-kills 0
          carry-time  0
@@ -756,14 +756,20 @@
 
 (defn- run-play [ctx]
   (init-input!)
-  (let [diff (cli/opt ctx "difficulty")
-        god? (cli/opt ctx "god")]
+  (let [diff   (cli/opt ctx "difficulty")
+        god?   (cli/opt ctx "god")
+        lv-raw (cli/opt ctx "level")
+        ;; CLI gives strings; coerce to int. nil / empty → nil → L1.
+        lv     (cond
+                 (php/=== lv-raw nil) nil
+                 (php/=== lv-raw "")  nil
+                 :else                (php/intval lv-raw))]
     (if (php/=== (show-start-menu!) :quit)
       (do (restore!)
           (clear-screen)
           0)
       (do (clear-screen)
-          (run-levels diff god?)
+          (run-levels diff god? lv)
           (restore!)
           (clear-screen)
           (cli/success ctx "Thanks for playing.")
@@ -784,5 +790,10 @@
           {:name "god"
            :short "g"
            :mode  :none
-           :doc   "Dev god mode: contact damage suppressed; GOD badge in HUD."}]
+           :doc   "Dev god mode: contact damage suppressed; GOD badge in HUD."}
+          {:name    "level"
+           :short   "l"
+           :mode    :optional
+           :doc     "Start at level N (1..num-levels). Clamped. Pairs naturally with --god to drop straight into a boss room for testing."
+           :default ""}]
    :run  run-play})


### PR DESCRIPTION
## 📚 Description

Adds `--level=N` (`-l`) so devs can drop straight into any room — pairs naturally with `--god` for testing rooms / weapons / boss without grinding through earlier levels.

## 🔖 Changes

- `src/commands/play.phel` — new `--level` / `-l` opt registered on `play-command`; `run-play` coerces the string arg to int (nil / empty → nil → L1); `run-levels` gains a `start-level` param that seeds the initial loop entry (clamped to `[1, num-levels]`). Death + retry still reset to L1 — the flag only seeds the initial entry, avoids the player getting permanently stuck at the specified level on `r` / `R`.
- `Makefile` — two new shortcuts:
  - `make play-boss` → `play --god --level=10` (jumps straight to the L10 boss arena)
  - `make play-level LV=N` → parameterised godmode start at any level
- `README.md`, `docs/features.md`, `CHANGELOG.md` — documented.

## 🧪 Test plan

- [x] `composer ci` — 0 warnings, 731 tests pass.
- [x] `vendor/bin/phel run phel-doom.main play --help` shows the new `-l, --level[=LEVEL]` row.
- [ ] Smoke: `make play-boss` lands at L10 with GOD badge.
- [ ] Smoke: `make play-level LV=8` lands at L8.
- [ ] Smoke: invalid (`--level=999`) clamps to L10, not a crash.