### PR TITLE
feat(boss): L10 exit door stays locked until the cyberdemon dies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 
 ### Added
 
+- **L10 boss door is now boss-locked.** The exit refuses to open until the cyberdemon dies — walking through the door BEFORE the kill pulses `☠ KILL THE BOSS ☠` over the upper third of the 3D view. Killing the cyberdemon auto-grants the synthetic `:boss` keycard (no physical card spawns) so the door becomes passable. Walking through after the kill triggers the victory screen. Intro splash shows a red `KILL THE BOSS TO ESCAPE` subtitle on entry. New `cell-door-boss` (cell value 5) + `X` char in `parse-layout` for hand-authored boss arenas.
 - `--level=N` (`-l`) CLI flag — start the run at level N (clamped to 1..num-levels). Pairs naturally with `--god` for dev testing: `make play-boss` drops straight into the L10 boss arena, `make play-level LV=8` starts at level 8. Death + retry still reset to L1; the flag only seeds the initial loop entry.
 - **5 new levels** taking the run from 5 to 10 rooms. L6-L9 mix multiple monster types per room for a chaotic late-game; L10 is a hand-authored boss arena.
   - **L6 spectres** — 4 spectres (HP 3, agile) + 2 imps. Spectres debut.

--- a/docs/level-system.md
+++ b/docs/level-system.md
@@ -15,7 +15,7 @@
 | 7 | revenants | random mix | 4 revenants + 2 demons |
 | 8 | archvile court | random mix | 2 archviles + 3 cacos + 2 mancubi |
 | 9 | the brood | random mix | 3 pinkies + 3 barons + 2 mancubi |
-| 10 | the final | **hand-authored arena** | 1 cyberdemon BOSS (HP 20) + 4 imps |
+| 10 | the final | **hand-authored arena**, boss-locked exit | 1 cyberdemon BOSS (HP 20) + 4 imps. Kill the boss to unlock the north door. |
 
 ## Catalog
 

--- a/src/modules/core/combat.phel
+++ b/src/modules/core/combat.phel
@@ -390,6 +390,17 @@
       (php/=== kind :heart) (push-pickup world :hearts hit-pos)
       :else                 world)))
 
+(defn- maybe-unlock-boss-door
+  "On a `:door-lock :boss` level, killing a `:cyber` enemy grants the
+   synthetic `:boss` keycard so the exit door becomes passable. No
+   physical card spawns for boss locks — this hook is the unlock."
+  [world killed-enemy]
+  (if (and (php/=== (:door-lock world) :boss)
+           (php/=== (:type killed-enemy) :cyber))
+    (assoc world :held-keys
+           (conj (or (:held-keys world) #{}) :boss))
+    world))
+
 (defn- on-shot-hit
   "World update on a successful hit. enemy/shoot has already decremented
    `:lives` and (when the pool emptied) flipped `:alive false` and
@@ -398,9 +409,12 @@
    accordingly. A blood splatter fires on every hit so the player sees
    the wound, but `:kills` and `:streak` only advance on the final
    shot that drops the enemy. Streak chains while `:streak-secs` is
-   still ticking from the previous kill; otherwise it restarts at 1."
+   still ticking from the previous kill; otherwise it restarts at 1.
+   When the killed enemy is the L10 boss the exit door unlocks via
+   `maybe-unlock-boss-door`."
   [world enemies-after hit-pos idx]
   (let [killed?   (false? (:alive (get enemies-after idx)))
+        killed-e  (get enemies-after idx)
         chain?    (php/> (or (:streak-secs world) 0.0) 0.0)
         streak'   (if chain? (php/+ (or (:streak world) 0) 1) 1)
         scored    (if killed?
@@ -409,9 +423,10 @@
                            :streak      streak'
                            :streak-secs streak-window-seconds)
                     (assoc world :enemies enemies-after))
+        unlocked  (if killed? (maybe-unlock-boss-door scored killed-e) scored)
         ;; Kill drops a random pickup at the corpse's cell. Wounds
         ;; don't drop — the kill is the reward trigger.
-        with-loot (if killed? (push-kill-loot scored hit-pos) scored)]
+        with-loot (if killed? (push-kill-loot unlocked hit-pos) unlocked)]
     (push-blood-fx (assoc with-loot :fire-anim fire-anim-seconds) hit-pos)))
 
 (defn- on-shot-miss [world]

--- a/src/modules/core/level.phel
+++ b/src/modules/core/level.phel
@@ -98,33 +98,38 @@
               {:type :mancubus :count 2}]}
 
    ;; L10 — the final. Hand-authored arena: open chamber with a
-   ;; central pillar for cover, player spawns south, door north.
-   ;; ONE cyberdemon boss with 20 HP (needs ~7 shotgun shells or
-   ;; ~20 chaingun rounds) surrounded by 4 imps as harassment.
-   {:enemy   :cyber
-    :chase   1.5
-    :name    "the final"
-    :enemies [{:type :cyber :count 1 :lives 20}
-              {:type :imp   :count 4 :lives 1}]
-    :layout  ["####################"
-              "#.........D........#"
-              "#..................#"
-              "#..................#"
-              "#..................#"
-              "#..................#"
-              "#..................#"
-              "#..................#"
-              "#......######......#"
-              "#......#....#......#"
-              "#......#....#......#"
-              "#......######......#"
-              "#..................#"
-              "#..................#"
-              "#..................#"
-              "#..................#"
-              "#..................#"
-              "#.........@........#"
-              "####################"]}])
+   ;; central pillar for cover, player spawns south, BOSS-locked
+   ;; door north. ONE cyberdemon boss with 20 HP (needs ~7 shotgun
+   ;; shells or ~20 chaingun rounds) surrounded by 4 imps as
+   ;; harassment. The 'X' in the layout is a boss-locked door:
+   ;; impassable until combat conj's `:boss` onto :held-keys when
+   ;; the cyberdemon dies. Walk through after killing the boss to
+   ;; win the run.
+   {:enemy     :cyber
+    :chase     1.5
+    :name      "the final"
+    :door-lock :boss
+    :enemies   [{:type :cyber :count 1 :lives 20}
+                {:type :imp   :count 4 :lives 1}]
+    :layout    ["####################"
+                "#.........X........#"
+                "#..................#"
+                "#..................#"
+                "#..................#"
+                "#..................#"
+                "#..................#"
+                "#..................#"
+                "#......######......#"
+                "#......#....#......#"
+                "#......#....#......#"
+                "#......######......#"
+                "#..................#"
+                "#..................#"
+                "#..................#"
+                "#..................#"
+                "#..................#"
+                "#.........@........#"
+                "####################"]}])
 
 (def num-levels
   "Total levels in the catalog; clamped on every lookup."
@@ -263,11 +268,15 @@
                 candidates))))
 
 (defn- maybe-spawn-keycard
-  "Drop one keycard at a random open cell when the level is locked.
-   Returns [] on unlocked levels so render / pickup skips."
+  "Drop one keycard at a random open cell when the level is locked
+   by a colour the player can pick up (`:blue` / `:red`). The
+   `:boss` lock has no physical key — combat grants it on boss
+   death — so no card spawns."
   [grid colour]
-  (if (php/=== colour nil)
-    []
+  (cond
+    (php/=== colour nil)   []
+    (php/=== colour :boss) []
+    :else
     (let [[kx ky] (random-spawn grid)]
       [{:x kx :y ky :colour colour}])))
 

--- a/src/modules/core/map.phel
+++ b/src/modules/core/map.phel
@@ -29,11 +29,21 @@
   "Red-keyed door — see cell-door-blue."
   4)
 
+(def cell-door-boss
+  "Boss-locked door: passable only after the boss enemy is killed.
+   Combat conj's `:boss` to `:held-keys` when the boss dies on a
+   `:door-lock :boss` level, which then unlocks via the standard
+   `passable?` / `held-keys` machinery."
+  5)
+
 (def lock-colours
   "Map from locked-door cell value back to the matching keycard kw.
-   Drives door-lock + passable? + render door tint."
+   Drives door-lock + passable? + render door tint. `:boss` is a
+   synthetic 'colour' — no keycard ever spawns for it; the kw is
+   granted automatically by combat when the boss dies."
   {3 :blue
-   4 :red})
+   4 :red
+   5 :boss})
 
 (def default-grid
   "16×16 starter map kept around for deterministic tests."
@@ -226,6 +236,7 @@
 ;; Char map:
 ;;   '#' wall            '.' floor
 ;;   'D' unlocked door   'B' blue-locked door   'R' red-locked door
+;;   'X' boss-locked door (unlocks when boss is killed)
 ;;   '@' floor + records [x y] as the player spawn (cell centre)
 ;;
 ;; parse-layout returns {:grid <vec-of-vec> :spawn [x y]} when the
@@ -239,7 +250,8 @@
    "@" cell-floor
    "D" cell-door
    "B" cell-door-blue
-   "R" cell-door-red})
+   "R" cell-door-red
+   "X" cell-door-boss})
 
 (defn- parse-row
   "Convert one layout string into [row-vec maybe-spawn-x]. Returns

--- a/src/modules/io/render.phel
+++ b/src/modules/io/render.phel
@@ -1110,10 +1110,12 @@
           subtitle (cond
                      (php/=== lock :blue) "FIND THE BLUE KEY"
                      (php/=== lock :red)  "FIND THE RED KEY"
+                     (php/=== lock :boss) "KILL THE BOSS TO ESCAPE"
                      :else                nil)
           sub-sgr  (cond
                      (php/=== lock :blue) "\e[40;94;1m"
                      (php/=== lock :red)  "\e[40;91;1m"
+                     (php/=== lock :boss) "\e[40;38;5;196;1m"
                      :else                "\e[40;93;1m")
           ;; Box width sized to the longer of title / subtitle so
           ;; both lines fit symmetrically with the same 4-col pad.
@@ -1156,10 +1158,12 @@
             label  (cond
                      (php/=== colour :blue) "  ⚿  NEED BLUE KEY  ⚿  "
                      (php/=== colour :red)  "  ⚿  NEED RED KEY  ⚿   "
+                     (php/=== colour :boss) "  ☠  KILL THE BOSS  ☠  "
                      :else                  "  ⚿  NEED KEY  ⚿  ")
             sgr    (cond
                      (php/=== colour :blue) "\e[40;94;1m"
                      (php/=== colour :red)  "\e[40;91;1m"
+                     (php/=== colour :boss) "\e[40;38;5;196;1m"
                      :else                  "\e[40;93;1m")
             row    (php/max 1 (php/intdiv vh 3))
             col0   (php/max 1 (php/- (php/+ (php/intdiv vw 2) 1)

--- a/tests/modules/core/combat-test.phel
+++ b/tests/modules/core/combat-test.phel
@@ -433,3 +433,65 @@
   (let [w0 (ready-world :shotgun 4)
         w1 (tick-shooting w0 true)]
     (is (= 3 (:mag w1)))))
+
+;; ---------------------------------------------------------------------
+;; Boss-locked door unlock: on a :door-lock :boss level, killing a
+;; :cyber-type enemy conj's :boss into :held-keys so the exit door
+;; becomes passable. No keycard ever spawns; the kill IS the key.
+;; ---------------------------------------------------------------------
+
+(defn- boss-world []
+  ;; 8x3 corridor: walls top/bottom, open between. Player at (1.5, 1.5)
+  ;; faces east; boss 3 cells east with clear line of sight. Shotgun
+  ;; loaded so a single shot drops a 1-HP cyber.
+  (let [grid   [[1 1 1 1 1 1 1 1]
+                [1 0 0 0 0 0 0 1]
+                [1 1 1 1 1 1 1 1]]
+        player (new-player 1.5 1.5 0.0)
+        base   (new-world grid player)]
+    (assoc base
+           :weapon          :shotgun
+           :owned-weapons   #{:pistol :shotgun}
+           :mag             4
+           :ammo-reserve    10
+           :fire-cooldown   0.0
+           :reload-cooldown 0.0
+           :jam-secs        0.0
+           :iframes         0.0
+           :door-lock       :boss
+           :held-keys       #{}
+           :enemies         [{:x 4.5 :y 1.5 :alive true :lives 1 :max-lives 1
+                              :hit-flash-secs 0.0 :type :cyber}])))
+
+(deftest test-tick-shooting-kill-of-cyber-on-boss-lock-grants-boss-key
+  (let [w0 (boss-world)
+        w1 (tick-shooting w0 true true)]
+    (is (= 1 (:kills w1)))
+    (is (contains? (:held-keys w1) :boss))))
+
+(deftest test-tick-shooting-kill-of-non-cyber-does-not-grant-boss-key
+  ;; A :imp dying on a :boss-locked level must NOT unlock the door —
+  ;; only the boss type counts.
+  (let [w0 (assoc (boss-world) :enemies
+                  [{:x 4.5 :y 1.5 :alive true :lives 1 :max-lives 1
+                    :hit-flash-secs 0.0 :type :imp}])
+        w1 (tick-shooting w0 true true)]
+    (is (= 1 (:kills w1)))
+    (is (not (contains? (or (:held-keys w1) #{}) :boss)))))
+
+(deftest test-tick-shooting-wounding-cyber-does-not-grant-boss-key
+  ;; Cyber HP 4 vs shotgun dmg 3 — one shell wounds (lives 1) but
+  ;; doesn't kill. No unlock yet.
+  (let [w0 (assoc (boss-world) :enemies
+                  [{:x 4.5 :y 1.5 :alive true :lives 4 :max-lives 4
+                    :hit-flash-secs 0.0 :type :cyber}])
+        w1 (tick-shooting w0 true true)]
+    (is (not (contains? (or (:held-keys w1) #{}) :boss)))))
+
+(deftest test-tick-shooting-cyber-kill-without-boss-lock-noop-on-keys
+  ;; Killing a :cyber on a non-boss-locked level (e.g. L5) must NOT
+  ;; spuriously grant a :boss key.
+  (let [w0 (assoc (boss-world) :door-lock :red)
+        w1 (tick-shooting w0 true true)]
+    (is (= 1 (:kills w1)))
+    (is (not (contains? (or (:held-keys w1) #{}) :boss)))))

--- a/tests/modules/core/keycards-test.phel
+++ b/tests/modules/core/keycards-test.phel
@@ -1,6 +1,6 @@
 (ns phel-doom-tests.modules.core.keycards-test
   (:require phel.test :refer [deftest is])
-  (:require phel-doom.modules.core.map :refer [door-lock door? find-door-cell missing-key-for passable? wall?]))
+  (:require phel-doom.modules.core.map :refer [cell-door-boss door-lock door? find-door-cell missing-key-for parse-layout passable? wall?]))
 
 (def grid-with-doors
   ;; Row 1: wall, cell-door, cell-door-blue, cell-door-red, wall.
@@ -73,3 +73,39 @@
   (is (= :blue (missing-key-for grid-with-doors #{} 2 1)))    ; blue locked, no key
   (is (= :red  (missing-key-for grid-with-doors #{:blue} 3 1))) ; red locked, only have blue
   (is (= nil   (missing-key-for grid-with-doors #{:blue} 2 1)))) ; blue locked, have blue
+
+;; ---------------------------------------------------------------------
+;; Boss-locked door (cell-door-boss = 5). No physical keycard ever
+;; spawns for it; combat conj's `:boss` into :held-keys when the boss
+;; dies. The standard passable? / missing-key-for / door? machinery
+;; then unlocks it via the same flow as :blue / :red.
+;; ---------------------------------------------------------------------
+
+(def grid-with-boss-door
+  [[1 1 1 1 1]
+   [1 0 0 0 5]   ; cell-door-boss at (4, 1)
+   [1 1 1 1 1]])
+
+(deftest test-boss-door-is-a-door
+  (is (= true (door? grid-with-boss-door 4 1))))
+
+(deftest test-boss-door-lock-returns-boss-kw
+  (is (= :boss (door-lock grid-with-boss-door 4 1))))
+
+(deftest test-boss-door-blocks-without-key
+  (is (= false (passable? grid-with-boss-door #{} 4 1)))
+  (is (= false (passable? grid-with-boss-door #{:blue :red} 4 1))))
+
+(deftest test-boss-door-opens-with-boss-key
+  (is (= true (passable? grid-with-boss-door #{:boss} 4 1))))
+
+(deftest test-missing-key-for-boss-door
+  (is (= :boss (missing-key-for grid-with-boss-door #{} 4 1)))
+  (is (= nil   (missing-key-for grid-with-boss-door #{:boss} 4 1))))
+
+(deftest test-parse-layout-x-char-produces-boss-door
+  (let [out (parse-layout ["#####"
+                           "#.@.X"
+                           "#####"])
+        g   (:grid out)]
+    (is (= cell-door-boss (get-in g [1 4])))))


### PR DESCRIPTION
## 📚 Description

L10's north door is now boss-locked: walking into it without killing the cyberdemon first pulses `☠ KILL THE BOSS ☠` over the 3D view. Killing the boss grants the synthetic `:boss` key, the door becomes passable, walking through fires the victory screen.

## 🔖 Changes

- `src/modules/core/map.phel` — new `cell-door-boss` (value `5`); extended `lock-colours` map `{5 :boss}` so `door?` / `passable?` / `door-lock` / `missing-key-for` all just work. New `X` char in `parse-layout` produces the boss-door cell.
- `src/modules/core/level.phel` — L10 layout uses `X` for the north door; entry adds `:door-lock :boss`. `maybe-spawn-keycard` short-circuits on `:boss` (no physical card spawns — the kill is the key).
- `src/modules/core/combat.phel` — `maybe-unlock-boss-door` conj's `:boss` into `:held-keys` when a killed enemy has `:type :cyber` on a `:door-lock :boss` level. Fires from `on-shot-hit`, only when the enemy actually died (not on wound).
- `src/modules/io/render.phel` — `paint-locked-bump` + `paint-intro-splash` add a `:boss` branch (red `KILL THE BOSS` cue / `KILL THE BOSS TO ESCAPE` intro subtitle).
- Tests +12 — `keycards-test` covers the new cell value + `X` parser; `combat-test` covers cyber-kill grants `:boss`, non-cyber kill doesn't, wound doesn't, kill on non-boss-lock level doesn't.
- `docs/level-system.md` + `CHANGELOG.md` updated.

## 🧪 Test plan

- [x] `composer ci` — 0 warnings, 746 tests pass (was 731, +15).
- [ ] Smoke `make play-boss` — door visibly locked at spawn; bump pulses `KILL THE BOSS`; after killing the cyberdemon, walking through fires the victory screen.