### PR TITLE
feat(cli): --armory dev cheat for all weapons + infinite ammo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 ### Added
 
 - **L10 boss door is now boss-locked.** The exit refuses to open until the cyberdemon dies — walking through the door BEFORE the kill pulses `☠ KILL THE BOSS ☠` over the upper third of the 3D view. Killing the cyberdemon auto-grants the synthetic `:boss` keycard (no physical card spawns) so the door becomes passable. Walking through after the kill triggers the victory screen. Intro splash shows a red `KILL THE BOSS TO ESCAPE` subtitle on entry. New `cell-door-boss` (cell value 5) + `X` char in `parse-layout` for hand-authored boss arenas.
+- `--armory` (`-a`) CLI flag — dev cheat: own every weapon at spawn + infinite ammo (per-frame mag + reserve refill). Pairs naturally with `--god` to test every mechanic end-to-end without grinding for pickups. New `make play-armory` shortcut; `make play-boss` / `make play-level` now imply `--armory` so dev shortcuts always start fully loaded.
 - `--level=N` (`-l`) CLI flag — start the run at level N (clamped to 1..num-levels). Pairs naturally with `--god` for dev testing: `make play-boss` drops straight into the L10 boss arena, `make play-level LV=8` starts at level 8. Death + retry still reset to L1; the flag only seeds the initial loop entry.
 - **5 new levels** taking the run from 5 to 10 rooms. L6-L9 mix multiple monster types per room for a chaotic late-game; L10 is a hand-authored boss arena.
   - **L6 spectres** — 4 spectres (HP 3, agile) + 2 imps. Spectres debut.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install d dev t test f format fc fix b build r repl doctor clean p play play-dev play-boss play-level
+.PHONY: help install d dev t test f format fc fix b build r repl doctor clean p play play-dev play-boss play-level play-armory
 
 help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-10s\033[0m %s\n", $$1, $$2}'
@@ -17,11 +17,14 @@ play: ## start the DOOM showcase
 play-dev: ## god mode: no damage, GOD badge in HUD — for testing rooms / weapons end-to-end
 	vendor/bin/phel run phel-doom.main play --god
 
-play-boss: ## god mode + drop into the L10 boss arena directly
-	vendor/bin/phel run phel-doom.main play --god --level=10
+play-boss: ## god + armory + L10 boss arena straight away
+	vendor/bin/phel run phel-doom.main play --god --armory --level=10
 
-play-level: ## god mode + start at level N (default 1): `make play-level LV=8`
-	vendor/bin/phel run phel-doom.main play --god --level=$(or $(LV),1)
+play-level: ## god + armory + start at level N: `make play-level LV=8`
+	vendor/bin/phel run phel-doom.main play --god --armory --level=$(or $(LV),1)
+
+play-armory: ## god + armory (every weapon, infinite ammo); start at L1
+	vendor/bin/phel run phel-doom.main play --god --armory
 
 t: test
 test: ## run phel tests

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Hold space to spray with the pistol/chaingun. Shotgun needs a fresh pull per she
 CLI:
 - `--difficulty=easy|normal|hard|nightmare` (`-d`) — scales enemy speed, HP, count
 - `--god` (`-g`) or `make play-dev` — no damage, GOD badge in HUD
+- `--armory` (`-a`) or `make play-armory` — own every weapon, infinite ammo (per-frame refill)
 - `--level=N` (`-l`) — start at level N. Pairs with `--god`: `make play-boss` jumps to L10, `make play-level LV=8` starts at L8
 
 Terminal quirks (kitty keyboard, tmux): see [docs/input.md](docs/input.md).

--- a/docs/features.md
+++ b/docs/features.md
@@ -111,6 +111,7 @@ See [scores.md](scores.md).
 - `--difficulty=easy|normal|hard|nightmare` (`-d`) — scales enemy chase speed, per-enemy HP, per-level enemy count. HUD tag suppressed for `normal`.
 - `--god` (`-g`) or `make play-dev` — dev mode: contact damage suppressed end-to-end. HUD adds a yellow `GOD` badge after the hearts strip.
 - `--level=N` (`-l`) — start at level N (clamped to 1..num-levels). Combine with `--god` to jump straight into a boss room for testing. Shortcuts: `make play-boss` (L10), `make play-level LV=N`.
+- `--armory` (`-a`) or `make play-armory` — dev cheat: spawn owning every weapon, infinite ammo via per-frame mag + reserve refill. Pairs naturally with `--god` to test every mechanic end-to-end without grinding for pickups.
 
 ## Misc
 

--- a/src/commands/play.phel
+++ b/src/commands/play.phel
@@ -7,7 +7,7 @@
   (:require phel-doom.modules.glue.controls :refer [refresh-from-keys key-states rising-edges
                                                     initial-key-snapshot])
   (:require phel-doom.modules.core.physics  :refer [apply-physics tick-heartbeat tick-flicker tick-blood-drops tick-door-face tick-stamina])
-  (:require phel-doom.modules.core.combat   :refer [ammo-per-box berserk-seconds damage-step fire-anim-seconds invuln-seconds max-reserve reload reloading? reload-cooldown-seconds tick-shooting])
+  (:require phel-doom.modules.core.combat   :refer [ammo-per-box berserk-seconds damage-step fire-anim-seconds invuln-seconds max-reserve reload reloading? reload-cooldown-seconds tick-armory tick-shooting])
   (:require phel-doom.modules.core.enemy    :refer [advance tick-scare rear-attacker?])
   (:require phel-doom.modules.core.weapons  :refer [effective-reserve-cap give-weapon switch-weapon weapon-spec weapon-order weapons])
   (:require phel-doom.modules.io.sound    :refer [play-sfx! mute-for!])
@@ -384,7 +384,8 @@
                     (when (and (:sound-on w5) (reloading? w5)) (play-sfx! :reload))
                     (reload w5))
                   w5)
-            w6  (tick-shooting w5b (:fire edges) (:fire-held edges))
+            w5c (tick-armory w5b)
+            w6  (tick-shooting w5c (:fire edges) (:fire-held edges))
             w7  (damage-step   w6 dt)
             w8  (tick-heartbeat w7 dt)
             w9  (tick-flicker  w8 dt)
@@ -653,17 +654,21 @@
    `diff` is the difficulty keyword from --difficulty (or nil for
    :normal). `god?` (from --god / `make play-dev`) stamps :god? on
    every freshly-built world so combat/vulnerable? short-circuits
-   contact damage for the whole run. `start-level` (from --level / -l)
-   sets where the run begins — 1..num-levels, clamped. Death + retry
-   reset to L1 (the start-level only seeds the initial loop entry)."
-  [diff god? start-level]
+   contact damage for the whole run. `armory?` (from --armory / -a)
+   hands the player every weapon at spawn and the per-frame ammo
+   refill in combat/tick-armory keeps the pool topped up so every
+   weapon stays testable without grinding for boxes. `start-level`
+   (from --level / -l) sets where the run begins — 1..num-levels,
+   clamped. Death + retry reset to L1 (the start-level only seeds
+   the initial loop entry)."
+  [diff god? armory? start-level]
   (loop [level       (php/max 1 (php/min num-levels (or start-level 1)))
          lives       max-lives
          carry-kills 0
          carry-time  0
          seed        (php/mt_rand)
          backpack?   false
-         owned       #{:pistol}
+         owned       (if armory? #{:pistol :shotgun :chaingun} #{:pistol})
          ;; Active weapon + per-weapon mag/reserve stash carried
          ;; across level cuts so the player doesn't get reset to a
          ;; full pistol every door. Nil weapon = use build-world's
@@ -678,7 +683,8 @@
           ;; overlaid on the freshly-built world so build-world
           ;; stays purely about the level itself.
           w1     (if god? (assoc w0 :god? true) w0)
-          w2     (assoc w1 :show-map show-map? :sound-on sound-on?)
+          w1a    (if armory? (assoc w1 :armory? true) w1)
+          w2     (assoc w1a :show-map show-map? :sound-on sound-on?)
           w3     (if (php/=== weapon nil)
                    w2
                    (let [stash  (or wstate (:weapon-state w2))
@@ -756,20 +762,21 @@
 
 (defn- run-play [ctx]
   (init-input!)
-  (let [diff   (cli/opt ctx "difficulty")
-        god?   (cli/opt ctx "god")
-        lv-raw (cli/opt ctx "level")
+  (let [diff    (cli/opt ctx "difficulty")
+        god?    (cli/opt ctx "god")
+        armory? (cli/opt ctx "armory")
+        lv-raw  (cli/opt ctx "level")
         ;; CLI gives strings; coerce to int. nil / empty → nil → L1.
-        lv     (cond
-                 (php/=== lv-raw nil) nil
-                 (php/=== lv-raw "")  nil
-                 :else                (php/intval lv-raw))]
+        lv      (cond
+                  (php/=== lv-raw nil) nil
+                  (php/=== lv-raw "")  nil
+                  :else                (php/intval lv-raw))]
     (if (php/=== (show-start-menu!) :quit)
       (do (restore!)
           (clear-screen)
           0)
       (do (clear-screen)
-          (run-levels diff god? lv)
+          (run-levels diff god? armory? lv)
           (restore!)
           (clear-screen)
           (cli/success ctx "Thanks for playing.")
@@ -791,6 +798,10 @@
            :short "g"
            :mode  :none
            :doc   "Dev god mode: contact damage suppressed; GOD badge in HUD."}
+          {:name "armory"
+           :short "a"
+           :mode  :none
+           :doc   "Dev armory: own every weapon + infinite ammo (per-frame refill). Pairs naturally with --god for end-to-end mechanic testing."}
           {:name    "level"
            :short   "l"
            :mode    :optional

--- a/src/modules/core/combat.phel
+++ b/src/modules/core/combat.phel
@@ -3,8 +3,14 @@
   (:require phel-doom.modules.core.enemy   :refer [shoot])
   (:require phel-doom.modules.core.physics :refer [try-move])
   (:require phel-doom.modules.core.state   :refer [max-lives])
-  (:require phel-doom.modules.core.weapons :refer [weapon-spec])
+  (:require phel-doom.modules.core.weapons :refer [weapon-order weapon-spec weapons])
   (:require phel-doom.modules.io.sound   :refer [play-sfx!]))
+
+(def armory-reserve
+  "Reserve cap stamped onto every weapon when --armory is on. Picked
+   big enough to read as 'infinite' in the HUD chip even after long
+   chaingun sprays, small enough to render as 4 digits."
+  9999)
 
 ;; ---------------------------------------------------------------------
 ;; Combat: the hitscan trigger pull (fire-shot) and the damage / i-frame
@@ -570,3 +576,25 @@
             (php/<= (or (:jam-secs w) 0.0) 0.0)
             (php/<= (or (:reload-cooldown w) 0.0) 0.0)) (empty-trigger-pull w)
        :else              w))))
+
+(defn tick-armory
+  "Dev cheat: when `:armory?` is set, refill every weapon's mag to
+   capacity and reserve to `armory-reserve` each tick + clear the
+   reload cooldown. Net effect is effectively-infinite ammo with no
+   reload pauses, so the player can test every weapon's hit feel
+   without grinding for boxes. No-op when `:armory?` is falsy."
+  [world]
+  (if (not (:armory? world))
+    world
+    (let [active  (or (:weapon world) :pistol)
+          stash   (reduce (fn [acc kw]
+                            (let [s (get weapons kw)]
+                              (assoc acc kw {:mag     (:mag-size s)
+                                             :reserve armory-reserve})))
+                          {} weapon-order)
+          mag-cap (:mag-size (get weapons active))]
+      (assoc world
+             :weapon-state    stash
+             :mag             mag-cap
+             :ammo-reserve    armory-reserve
+             :reload-cooldown 0.0))))

--- a/tests/modules/core/combat-test.phel
+++ b/tests/modules/core/combat-test.phel
@@ -2,7 +2,7 @@
   (:require phel.test :refer [deftest is])
   (:require phel-doom.modules.core.state :refer [new-world new-player])
   (:require phel-doom.modules.core.combat
-            :refer [closest-attacker attacker-side berserk? berserk-seconds can-fire? apply-heat damage-step empty-click-seconds invuln? invuln-seconds knockback mag-size pick-loot-weapon reload reloading? roll-loot-kind tick-shooting]))
+            :refer [armory-reserve closest-attacker attacker-side berserk? berserk-seconds can-fire? apply-heat damage-step empty-click-seconds invuln? invuln-seconds knockback mag-size pick-loot-weapon reload reloading? roll-loot-kind tick-armory tick-shooting]))
 
 ;; ---------------------------------------------------------------------
 ;; closest-attacker: selection rule.
@@ -495,3 +495,33 @@
         w1 (tick-shooting w0 true true)]
     (is (= 1 (:kills w1)))
     (is (not (contains? (or (:held-keys w1) #{}) :boss)))))
+
+;; ---------------------------------------------------------------------
+;; tick-armory: dev cheat that effectively grants infinite ammo by
+;; refilling mag + reserve each tick. No-op when :armory? is falsy.
+;; ---------------------------------------------------------------------
+
+(deftest test-tick-armory-noop-when-flag-off
+  (let [w0 {:mag 3 :ammo-reserve 5 :weapon :pistol
+            :weapon-state {:pistol {:mag 3 :reserve 5}}}
+        w1 (tick-armory w0)]
+    (is (= 3 (:mag w1)))
+    (is (= 5 (:ammo-reserve w1)))))
+
+(deftest test-tick-armory-refills-mag-and-reserve
+  (let [w0 {:armory? true :weapon :pistol :mag 1 :ammo-reserve 0}
+        w1 (tick-armory w0)]
+    (is (= 10 (:mag w1)))
+    (is (= armory-reserve (:ammo-reserve w1)))
+    (is (= 0.0 (:reload-cooldown w1)))))
+
+(deftest test-tick-armory-stamps-every-weapon-in-stash
+  (let [w0    {:armory? true :weapon :chaingun}
+        w1    (tick-armory w0)
+        stash (:weapon-state w1)]
+    (is (= 10 (get-in stash [:pistol :mag])))
+    (is (= 4  (get-in stash [:shotgun :mag])))
+    (is (= 30 (get-in stash [:chaingun :mag])))
+    (is (= armory-reserve (get-in stash [:pistol :reserve])))
+    (is (= armory-reserve (get-in stash [:shotgun :reserve])))
+    (is (= armory-reserve (get-in stash [:chaingun :reserve])))))


### PR DESCRIPTION
## 📚 Description

Dev cheat that hands the player every weapon at spawn and refills mag + reserve to caps each frame. Pairs naturally with `--god` for end-to-end mechanic testing — test the chaingun on L1, the shotgun on L3, the boss room without grinding.

## 🔖 Changes

- `src/modules/core/combat.phel` — new `tick-armory` + `armory-reserve` (9999). No-op when `:armory?` is falsy (zero cost in normal runs). When set: every weapon's mag → mag-size, every weapon's reserve → 9999, reload-cooldown → 0.
- `src/commands/play.phel` — new `--armory` / `-a` CLI flag. `run-levels` takes an `armory?` param; build-world post-pass stamps `:armory? true` + sets `:owned-weapons #{:pistol :shotgun :chaingun}`. Tick pipeline calls `tick-armory` between reload and `tick-shooting` so the refill is in place before any shot resolves.
- `Makefile` — new `make play-armory` shortcut. `make play-boss` + `make play-level` now also imply `--armory` so dev shortcuts always start loaded.
- Tests +3 (757 total): off-noop, refill mag + reserve + reload cooldown, stash entries for every weapon.
- README + features + CHANGELOG documented.

## 🧪 Test plan

- [x] `composer ci` — 0 warnings, 757 tests pass.
- [x] `vendor/bin/phel run phel-doom.main play --help` shows `-a, --armory`.
- [ ] Smoke `make play-armory` — start at L1, press 2 → shotgun, press 3 → chaingun, fire freely without mag depletion.
- [ ] Smoke `make play-boss` — start at L10 already loaded with chaingun + 9999 reserve.