### PR TITLE
docs: sync to last 4 PRs (CLI flags + boss door + retune + knockback)

### DIFF
--- a/docs/combat.md
+++ b/docs/combat.md
@@ -7,6 +7,7 @@ Hitscan + damage timing + i-frames. `src/modules/core/combat.phel`. Only side ef
 ```phel
 (def shot-hit-radius   0.5)   ; off-axis tolerance for a ray-hit
 (def shot-max-range   12.0)   ; hitscan range, world units
+(def shot-knockback-distance 1.0) ; world units pushed back per wounding hit
 (def touch-damage-dist 0.7)   ; enemy this close = take-damage
 (def iframe-seconds    1.0)   ; post-hit invulnerability window
 (def fire-anim-seconds 0.09)  ; muzzle flash visibility
@@ -20,6 +21,7 @@ Hitscan + damage timing + i-frames. `src/modules/core/combat.phel`. Only side ef
 (def mag-size 10)
 (def max-reserve 50)
 (def reload-cooldown-seconds 1.2)
+(def armory-reserve 999) ; per-weapon reserve cap under --armory
 ```
 
 ## Magazine + reload
@@ -102,7 +104,7 @@ Dead enemy stays in vector with respawn timer. `tick-enemies` counts down + revi
 
 Pushed into `(:fx world)`. `decay-fx` ticks each `:ttl` by dt, drops expired. `io/render.phel` paints them as bright-pink, mid-red, dim-red blocks via projection math.
 
-## Damage
+## Damage + knockback
 
 ```phel
 (defn damage-step [world dt]
@@ -125,13 +127,17 @@ Decrements `:iframes`, `:fire-anim`, `:intro-secs`, `:flash-secs` by `dt`. Also 
 
 Four gates: i-frame window, invulnerability sphere timer, dev god mode, AND at least one alive enemy within `touch-damage-dist`. Squared-distance comparison, no sqrt.
 
-### take-damage
+### take-damage (player contact)
 
 - Armor absorbs the hit first if `:armor > 0` (drops the counter, no life loss).
 - Otherwise loses one life (clamped at 0).
 - 1.0s i-frame: `vulnerable?` returns false, single touch can't drain multiple lives.
 - 0.05s flash: `render!` paints viewport white. One-frame jolt before the red i-frame wash.
-- Knockback shove away from the attacker; arms `:hurt-side` so the directional red band paints on the correct edge.
+- Player knockback shove away from the attacker; arms `:hurt-side` so the directional red band paints on the correct edge.
+
+### Shot knockback (enemy-only)
+
+Every wounding enemy hit (`:lives > 0` after damage) pushes the enemy ~1 cell back along the shot direction. Movement respects walls (half-step or quarter-step fallback if full step hits a wall). Killing blows skip knockback so the corpse lands on the death cell and loot drops cleanly. See `enemy/push-back-enemy`.
 
 ## i-frame visualization
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -20,10 +20,10 @@ See [rendering.md](rendering.md), [raycaster.md](raycaster.md),
 
 ## Levels + map
 
-- 10 levels: 5 procedurally-generated escalating rooms (L1-L5), 4 mixed-monster rooms (L6-L9), and L10 a hand-authored boss arena (cyberdemon HP 20 + 4 imp minions)
+- 10 levels: 5 procedurally-generated escalating rooms (L1-L5), 4 mixed-monster rooms (L6-L9), and L10 a hand-authored boss arena (cyberdemon HP 50 + 2 imp minions, cap 1 alive)
 - Per-level wall + sky + floor palette
 - Pickups: hearts (cap 5), armor (cap 3, absorbs one hit each), ammo boxes (per-weapon `:ammo-per-box`), berserk (20s ×2 dmg), invuln (10s immune), backpack (1-shot, doubles every weapon's reserve cap)
-- Keycards + locked exits on L4 (blue) / L5 (red). Intro splash adds a `FIND THE <COLOUR> KEY` subtitle on locked levels; compass top-centre tints the E/S/W/N letter pointing at the un-picked card in the lock colour; bumping the door without the matching key pulses `⚿ NEED <COLOUR> KEY ⚿` for 1.5s
+- Keycards + locked exits on L4 (blue) / L5 (red). Intro splash adds a `FIND THE <COLOUR> KEY` subtitle on locked levels; compass top-centre tints the E/S/W/N letter pointing at the un-picked card in the lock colour; bumping the door without the matching key pulses `⚿ NEED <COLOUR> KEY ⚿` for 1.5s. L10 boss door unlocks via synthetic `:boss` keycard granted on cyberdemon kill (no physical pickup); intro splash: `KILL THE BOSS TO ESCAPE`, door pulse: `☠ KILL THE BOSS ☠`
 - Walk-into-door auto-advance; pulsing minimap door + bright 3D door glyph
 - Cross-level carry: lives, kills, time, owned-weapons, **active weapon**, **per-weapon mag/reserve**, backpack, minimap + sound toggles. Retry/restart resets to fresh defaults.
 
@@ -35,8 +35,9 @@ See [level-system.md](level-system.md), [map.md](map.md).
   each with distinct color, body texture, animated face glyph, aggro
   pulse at close range
 - Per-level HP (L1 imp 1, L2 demon 2, L3 caco 3, L4 baron 4, L5
-  cyber 5). Wounded body shades darker as HP drops; a yellow HP
+  cyber 5; L10 boss cyber 50). Wounded body shades darker as HP drops; a yellow HP
   digit floats above the head for 1.2s after each hit
+- Shot knockback: every wounding hit shoves the enemy ~1 cell back along the shot direction (wall-clamped; killing blow skips push so corpse lands on death cell)
 - Attack telegraph: face swaps to `:face-attack` glyph within
   aggro-distance (1.8 units)
 - Hitscan combat: blood splatter, muzzle flash, 5-stage death anim,
@@ -51,7 +52,7 @@ See [level-system.md](level-system.md), [map.md](map.md).
 
   Pistol + chaingun spray while space is held; shotgun needs a fresh pull per shell. Pistol is the only weapon that overheats / jams. Distinct silhouette + palette per slot. Per-weapon mag/reserve persists across switches. First-time pickup auto-switches. Drop/refill/raise reload anim; sprite recoils 2 rows per shot.
 - Kill-loot ammo skips the pistol when other weapons are owned — biases toward the scarce shotgun + chaingun the player had to hunt for. Level-spawn boxes still refill the active weapon.
-- 5 lives, 1s i-frame, directional red hurt-side band, knockback shove.
+- 5 lives, 1s i-frame, directional red hurt-side band, knockback shove on contact damage.
 
 See [monsters.md](monsters.md), [combat.md](combat.md).
 
@@ -110,8 +111,8 @@ See [scores.md](scores.md).
 
 - `--difficulty=easy|normal|hard|nightmare` (`-d`) — scales enemy chase speed, per-enemy HP, per-level enemy count. HUD tag suppressed for `normal`.
 - `--god` (`-g`) or `make play-dev` — dev mode: contact damage suppressed end-to-end. HUD adds a yellow `GOD` badge after the hearts strip.
-- `--level=N` (`-l`) — start at level N (clamped to 1..num-levels). Combine with `--god` to jump straight into a boss room for testing. Shortcuts: `make play-boss` (L10), `make play-level LV=N`.
-- `--armory` (`-a`) or `make play-armory` — dev cheat: spawn owning every weapon, infinite ammo via per-frame mag + reserve refill. Pairs naturally with `--god` to test every mechanic end-to-end without grinding for pickups.
+- `--level=N` (`-l`) — start at level N (clamped to 1..num-levels). Pairs with `--god` to jump straight into a test level. Shortcuts: `make play-boss` (L10), `make play-level LV=N`.
+- `--armory` (`-a`) or `make play-armory` — dev cheat: spawn owning every weapon, infinite ammo via per-frame mag + reserve refill. Pairs with `--god` to test every mechanic end-to-end without grinding for pickups.
 
 ## Misc
 

--- a/docs/level-system.md
+++ b/docs/level-system.md
@@ -15,7 +15,7 @@
 | 7 | revenants | random mix | 4 revenants + 2 demons |
 | 8 | archvile court | random mix | 2 archviles + 3 cacos + 2 mancubi |
 | 9 | the brood | random mix | 3 pinkies + 3 barons + 2 mancubi |
-| 10 | the final | **hand-authored arena**, boss-locked exit | 1 cyberdemon BOSS (HP 20) + 4 imps. Kill the boss to unlock the north door. |
+| 10 | the final | **hand-authored arena**, boss-locked north door | 1 cyberdemon BOSS (HP 50) + 2 imps (cap 1 alive). Intro: "KILL THE BOSS TO ESCAPE". Bumping north door without kill: "☠ KILL THE BOSS ☠". Kill triggers victory. |
 
 ## Catalog
 
@@ -70,6 +70,7 @@ When `:enemies` is a vector, each spec spawns its own count + HP and the enemy c
 | `D` | unlocked door |
 | `B` | blue-locked door |
 | `R` | red-locked door |
+| `X` | boss-locked door (synthetic keycard, no pickup) |
 
 `:layout` skips `random-grid`, `seed-doors`, and `lock-the-door` — the author placed everything explicitly. Enemy spawn (random / mixed-spec) still applies on top.
 

--- a/docs/map.md
+++ b/docs/map.md
@@ -5,12 +5,22 @@
 ## Cells
 
 ```phel
-(def cell-floor   0)  ; walkable empty
-(def cell-wall    1)  ; solid wall, blocks rays and player
-(def cell-door    2)  ; passable trigger, blocks rays only
+(def cell-floor     0)  ; walkable empty
+(def cell-wall      1)  ; solid wall, blocks rays and player
+(def cell-door      2)  ; unlocked door: passable trigger, blocks rays only
+(def cell-door-blue 3)  ; blue-keyed door: blocks until player holds :blue keycard
+(def cell-door-red  4)  ; red-keyed door: blocks until player holds :red keycard
+(def cell-door-boss 5)  ; boss-locked door: blocks until player kills the boss (grants synthetic :boss keycard)
 ```
 
-Every cell is one of these ints. Constants exported so no module uses raw `0/1/2` literals. `(= cell-door (cell g x y))` reads as purpose.
+Every cell is one of these ints. Constants exported so no module uses raw `0/1/2/3/4/5` literals. `(= cell-door (cell g x y))` reads as purpose.
+
+`lock-colours` maps locked-door cell values to keycard keywords:
+```phel
+{3 :blue   4 :red   5 :boss}
+```
+
+`:boss` is a synthetic "colour" — no physical keycard item ever spawns for it; the kw is granted automatically by `combat/maybe-unlock-boss-door` when the boss is killed on a `:door-lock :boss` level.
 
 ## Lookup helpers
 

--- a/docs/monsters.md
+++ b/docs/monsters.md
@@ -28,7 +28,7 @@ Each enemy carries `:lives` / `:max-lives` / `:type`. `enemy/shoot` drops `:live
 ## Spawning
 
 - `spawn-enemies grid n min-dist px py [max-lives [type-kw]]` — single-type rooms.
-- `spawn-enemies-mixed grid specs min-dist px py` — multi-type. Spec shape: `{:type :count [:lives N]}`. Each enemy carries `:type` for render lookup. Used by `build-world` whenever a level's `:enemies` field is a vector (and for the L10 boss arena where `{:type :cyber :count 1 :lives 20}` + `{:type :imp :count 4}` paints one boss surrounded by minions).
+- `spawn-enemies-mixed grid specs min-dist px py` — multi-type. Spec shape: `{:type :count [:lives N] [:max-concurrent K]}`. Each enemy carries `:type` for render lookup and optional `:max-concurrent` cap. Used by `build-world` whenever a level's `:enemies` field is a vector (and for the L10 boss arena where `{:type :cyber :count 1 :lives 50}` + `{:type :imp :count 2 :max-concurrent 1}` paints one boss with 2 minions but only 1 alive at a time).
 
 ## Chase AI
 
@@ -40,7 +40,7 @@ Each enemy carries `:lives` / `:max-lives` / `:type`. `enemy/shoot` drops `:live
 
 Stop distance: enemies don't close past `stop-dist = 0.6` to avoid piling up inside the player's cell.
 
-## Respawn cooldown
+## Respawn cooldown + max-concurrent cap
 
 Killed enemies stay in the vector with `:alive false` and `:respawn-after` set to a random 3-6s.
 
@@ -61,6 +61,8 @@ Killed enemies stay in the vector with `:alive false` and `:respawn-after` set t
 ```
 
 `respawn-min-dist = 3.0` keeps revivals away from the player. No valid cell = bump 0.5s, try next frame instead of forcing an ambush spawn.
+
+Optional `:max-concurrent` cap on a spawned enemy type enforces a max-alive count. Revival checks the count of `:alive` enemies of the same `:type`; respawn is delayed until a sibling dies (up to respawn cap). `:type` is now preserved across respawn (bug fix: revived enemies previously dropped `:type`).
 
 ## Rendering: 3 zones + face overlay
 

--- a/docs/rendering.md
+++ b/docs/rendering.md
@@ -70,7 +70,7 @@ idx = clamp(0, 23,
 
 Indexes `shade-table[0..23]`: pre-baked ANSI strings for the 256-color grayscale palette (232..255). One PHP-array lookup per column.
 
-Door columns get solid `door-shade` (orange) in `shades-normal` and a half-block edge mix in `shades-top-edge`/`shades-bot-edge`.
+Door columns get solid `door-shade` (orange for unlocked, blue/red for locked keycards, bright red for boss-lock) in `shades-normal` and a half-block edge mix in `shades-top-edge`/`shades-bot-edge`. Paint function `paint-locked-bump` handles door-locked state messaging (e.g. "NEED BLUE KEY" or "KILL THE BOSS").
 
 ## Half-block edge anti-aliasing
 

--- a/docs/state.md
+++ b/docs/state.md
@@ -15,21 +15,23 @@ Pure data shapes that every other module operates on. `src/modules/core/state.ph
  :show-map   <bool>     ; minimap toggle
  :paused     <bool>     ; P toggle
  :sound-on   <bool>     ; N toggle
- :enemies    <vector of {:x :y :alive :lives :max-lives :hit-flash-secs [:respawn-after]}>
+ :enemies    <vector of {:x :y :alive :lives :max-lives :type :hit-flash-secs [:respawn-after] [:max-concurrent]}>
  :hearts     <vector of {:x :y}>
  :armors     <vector of {:x :y}>
  :ammo-boxes <vector of {:x :y}>
  :berserks   <vector of {:x :y}>           ; rage spheres (20s ×2 damage)
  :invulns    <vector of {:x :y}>           ; immunity spheres (10s invincible)
  :backpacks  <vector of {:x :y}>           ; one-shot reserve doubler
- :keycards   <vector of {:x :y :colour}>   ; :blue / :red keycards for locked exits
- :held-keys  <set of colour kws>           ; #{:blue :red} collected so far
+ :keycards   <vector of {:x :y :colour}>   ; :blue / :red / :boss keycards for locked exits (boss = synthetic, no pickup)
+ :held-keys  <set of colour kws>           ; #{:blue :red :boss} collected so far
  :armor      <int 0..max-armor, hits absorbed before lives drop>
  :backpack?  <bool, persists across level cuts>
+ :armory?    <bool, --armory flag; infinite ammo per-frame refill>
  :berserk-secs <float seconds>             ; while > 0: 2x weapon damage
  :invuln-secs  <float seconds>             ; while > 0: contact hits skipped
  :difficulty <kw :easy|:normal|:hard|:nightmare>
- :door-lock  <kw :blue|:red|nil>           ; lock colour on this level's exit
+ :god?       <bool, --god flag; no damage>
+ :door-lock  <kw :blue|:red|:boss|nil>     ; lock colour on this level's exit (:boss = synthetic, no keycard pickup)
  :weapon     <kw :pistol|:shotgun|:chaingun>  ; active weapon
  :owned-weapons <set of kw>                ; pistol owned by default; others must be picked up
  :weapon-pickups <vector of {:x :y :weapon}>


### PR DESCRIPTION
## 📚 Description

Doc-only PR. Brings docs/ back in sync with the 4 most-recently-merged feature PRs (#39 --level, #40 boss door, #41 --armory, #42 L10 retune, #43 shot knockback).

## 🔖 Changes

- `features.md` — shot knockback + L10 retune + `--armory` CLI bullets
- `combat.md` — split player vs enemy knockback; new tunables (`shot-knockback-distance`, `armory-reserve`)
- `monsters.md` — spec shape gains `:max-concurrent`; respawn now carries `:type` forward (bugfix note)
- `level-system.md` — L10 row updated (boss HP 50, 2 imps cap 1, boss lock); layout char map gains `X` for boss door
- `state.md` — world + enemy field shape updated (`:type` / `:max-concurrent` / `:armory?` / `:god?` / `:held-keys :boss` / `:door-lock :boss`)
- `map.md` — `cell-door-blue/red/boss` constants + `lock-colours` table
- `rendering.md` — `paint-locked-bump :boss` branch noted

## 🧪 Test plan

- [x] `composer ci` — 0 warnings, 772 tests pass.
- [x] All doc cross-links verified.