### PR TITLE
feat(enemy): LOS-gated wake state machine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 ### Added
 
 - Responsive help panel (`H` / `ESC`) — adapts width + drops optional sections on small terminals.
+- Enemy AI state machine. Real-game spawns start `:dormant` — they hold position + deal no contact damage until they get line-of-sight to the player OR take a hit. Once aware, sticky (DOOM "wake once, stay awake"). Bosses + minions can be peeked / planned around instead of homing through walls.
 
 ### Performance
 

--- a/docs/monsters.md
+++ b/docs/monsters.md
@@ -1,7 +1,8 @@
 # Monsters
 
 - `src/modules/core/enemies.phel` — type catalog (visuals + default HP)
-- `src/modules/core/enemy.phel` — record + spawn + chase AI
+- `src/modules/core/enemy.phel` — record + spawn + chase step
+- `src/modules/core/enemy_ai.phel` — AI state machine (LOS-gated wake)
 - Visual rendering in `io/render.phel` (per-enemy `:type` lookup).
 
 ## Catalog (`enemy-types`)
@@ -30,15 +31,33 @@ Each enemy carries `:lives` / `:max-lives` / `:type`. `enemy/shoot` drops `:live
 - `spawn-enemies grid n min-dist px py [max-lives [type-kw]]` — single-type rooms.
 - `spawn-enemies-mixed grid specs min-dist px py` — multi-type. Spec shape: `{:type :count [:lives N] [:max-concurrent K]}`. Each enemy carries `:type` for render lookup and optional `:max-concurrent` cap. Used by `build-world` whenever a level's `:enemies` field is a vector (and for the L10 boss arena where `{:type :cyber :count 1 :lives 50}` + `{:type :imp :count 2 :max-concurrent 1}` paints one boss with 2 minions but only 1 alive at a time).
 
-## Chase AI
+## AI state machine
 
-`advance enemies grid player-x player-y dt speed` walks every alive enemy one frame toward the player. Per enemy, `step-toward`:
+Each enemy carries a `:state` keyword that decides whether it moves + deals contact damage this tick. Spec lives in `enemy_ai.phel`:
+
+```phel
+{:dormant {:moves? false :attacks? false}
+ :aware   {:moves? true  :attacks? true}}
+```
+
+`new-enemy` defaults to `:aware` (legacy test fixtures keep chasing). Real-game spawns (`spawn-enemies`, `spawn-enemies-mixed`) stamp `:state :dormant`, so the player can sneak / peek / plan until the room reacts.
+
+### Wake triggers
+
+- **Line-of-sight (LOS)** — every tick, `enemy-ai/observe` casts one ray from each alive enemy to the player. Ray hits a wall before reaching the player cell → no LOS, stays dormant. Reaches the player → flips to `:aware`. Reuses `engine/cast-ray`; capped at `max-depth` (12 units), so very long sectors read as "too far to see" — matches DOOM's sight cutoff.
+- **Pain (being shot)** — `enemy/shoot` stamps `:state :aware` on the hit target unconditionally. A dormant enemy that took a bullet without reacting would read as broken AI.
+
+Once aware the state is sticky (DOOM "wake once, stay awake"). Future state transitions (`:hunting` for LOS-lost-then-chase-to-LKP, `:pain` for stagger, `:attacking` for ranged windup) slot into the same `state-spec` map + `next-state` cond — call sites don't change.
+
+### Chase step
+
+Aware enemies route through `step-toward`:
 
 1. Desired heading (atan2 enemy → player).
 2. Try stepping `speed * dt` units along that heading.
 3. If destination is inside a wall, try angle offsets ±45°, ±90°, ±135°. Slides around corners, walks out of dead ends.
 
-Stop distance: enemies don't close past `stop-dist = 0.6` to avoid piling up inside the player's cell.
+Stop distance: enemies don't close past `stop-dist = 0.6` to avoid piling up inside the player's cell. Dormant enemies skip the chase step entirely.
 
 ## Respawn cooldown + max-concurrent cap
 

--- a/src/commands/play.phel
+++ b/src/commands/play.phel
@@ -109,11 +109,14 @@
 
 (defn- tick-enemies
   "Step every alive enemy one dt-scaled frame toward the player, using
-   the world's per-level chase speed. Suspends respawns once the boss
-   is down on L10 (see boss-down?)."
+   the world's per-level chase speed. `:pgrid` is forwarded so the
+   AI observation pass (enemy-ai) can cast LOS rays from each enemy
+   to the player; without it the AI falls through to the legacy
+   'always chase' behaviour. Suspends respawns once the boss is down
+   on L10 (see boss-down?)."
   [world ^float dt]
   (let [p (:player world)]
-    (update world :enemies advance (:grid world) (:x p) (:y p) dt
+    (update world :enemies advance (:grid world) (:pgrid world) (:x p) (:y p) dt
             (or (:chase-speed world) 0.75)
             (not (boss-down? world)))))
 

--- a/src/modules/core/combat.phel
+++ b/src/modules/core/combat.phel
@@ -1,10 +1,11 @@
 (ns phel-doom.modules.core.combat
-  (:require phel-doom.modules.core.engine  :refer [cast-ray])
-  (:require phel-doom.modules.core.enemy   :refer [push-back-enemy shoot])
-  (:require phel-doom.modules.core.physics :refer [try-move])
-  (:require phel-doom.modules.core.state   :refer [max-lives])
-  (:require phel-doom.modules.core.weapons :refer [weapon-order weapon-spec weapons])
-  (:require phel-doom.modules.io.sound   :refer [play-sfx!]))
+  (:require phel-doom.modules.core.engine   :refer [cast-ray])
+  (:require phel-doom.modules.core.enemy    :refer [push-back-enemy shoot])
+  (:require phel-doom.modules.core.enemy-ai :refer [attacks?])
+  (:require phel-doom.modules.core.physics  :refer [try-move])
+  (:require phel-doom.modules.core.state    :refer [max-lives])
+  (:require phel-doom.modules.core.weapons  :refer [weapon-order weapon-spec weapons])
+  (:require phel-doom.modules.io.sound      :refer [play-sfx!]))
 
 (def shot-knockback-distance
   "World units an enemy is shoved AWAY from the player on every shot
@@ -180,7 +181,13 @@
         (nil? es) false
         :else
         (let [e (first es)]
-          (if (and e (:alive e) (php/<= (enemy-distance-sq e px py) threshold-sq))
+          ;; Dormant enemies don't deal contact damage — they're
+          ;; passive until something wakes them. enemy-ai/attacks?
+          ;; reads `:state` and falls back to the default-state
+          ;; (:aware) for legacy fixtures that don't carry one,
+          ;; so existing tests stay green.
+          (if (and e (:alive e) (attacks? e)
+                   (php/<= (enemy-distance-sq e px py) threshold-sq))
             true
             (recur (next es))))))))
 

--- a/src/modules/core/enemy.phel
+++ b/src/modules/core/enemy.phel
@@ -1,5 +1,6 @@
 (ns phel-doom.modules.core.enemy
-  (:require phel-doom.modules.core.map :refer [random-spawn wall?]))
+  (:require phel-doom.modules.core.map      :refer [random-spawn wall?])
+  (:require phel-doom.modules.core.enemy-ai :refer [observe moves?]))
 
 (def default-chase-speed
   "Fallback chase speed (units/sec) used by the single-arity advance
@@ -144,7 +145,13 @@
                prev-lives (or (:lives hit-enemy) 1)
                new-lives  (php/max 0 (php/- prev-lives damage))
                hit-vec    (apply vector es')
-               wounded    (assoc-in hit-vec [best :lives] new-lives)]
+               ;; Any hit wakes the target — being shot is the
+               ;; loudest possible "I see you" signal, and a dormant
+               ;; enemy that takes a bullet without reacting would
+               ;; read as broken AI. Mirrors DOOM where damage forces
+               ;; the target into chase regardless of prior state.
+               woken      (assoc-in hit-vec [best :state] :aware)
+               wounded    (assoc-in woken [best :lives] new-lives)]
            (if (php/<= new-lives 0)
              (let [delay   (php/+ respawn-delay-min
                                   (php/* (php// (php/mt_rand) (php/mt_getrandmax))
@@ -212,23 +219,36 @@
                  total))))))
 
 (defn- tick-one
-  "One frame of update for a single enemy. Alive → walk toward the
-   player. Dead WITH a respawn timer → decrement; on expiry revive at
-   a random open cell at least respawn-min-dist away. Dead WITHOUT a
-   timer (e.g. spawned that way in a test) stays untouched.
+  "One frame of update for a single enemy. Alive → run the AI
+   observation pass (state machine in enemy-ai) then walk toward the
+   player if the resulting state allows it. Dormant enemies hold
+   position; aware enemies chase. Dead WITH a respawn timer →
+   decrement; on expiry revive at a random open cell at least
+   respawn-min-dist away. Dead WITHOUT a timer (e.g. spawned that way
+   in a test) stays untouched.
 
    Revival respects `:max-concurrent` when set on the enemy spec — if
    the live count of the same `:type` is already at the cap, the
    timer is bumped back so the next attempt fires in 0.5s. Lets the
    L10 boss room cap minion pressure at 1 alive at a time.
 
+   `pgrid` is the PHP-array grid mirror the AI needs for line-of-sight
+   raycasts. nil pgrid skips the observation pass — tests that don't
+   carry a pgrid fall through with the enemy's existing :state, which
+   defaults to :aware (`enemy-ai/default-state`) so their existing
+   chase expectations still hold.
+
    `revive?` false suspends every dead enemy's timer (boss dead on L10
    → no more respawns of boss OR minions, the run is winding down)."
-  [e grid player-x player-y ^float dt ^float speed all-enemies revive?]
+  [e grid pgrid ^float player-x ^float player-y ^float dt ^float speed all-enemies revive?]
   (cond
-    (:alive e)                (let [mul     (or (get type-speed-mul (:type e)) 1.0)
-                                    stepped (step-toward e grid player-x player-y dt (php/* speed mul))
-                                    flash'  (php/max 0.0 (php/- (or (:hit-flash-secs e) 0.0) dt))]
+    (:alive e)                (let [observed (if pgrid (observe e pgrid player-x player-y) e)
+                                    chase?   (moves? observed)
+                                    mul      (or (get type-speed-mul (:type observed)) 1.0)
+                                    stepped  (if chase?
+                                               (step-toward observed grid player-x player-y dt (php/* speed mul))
+                                               observed)
+                                    flash'   (php/max 0.0 (php/- (or (:hit-flash-secs observed) 0.0) dt))]
                                 (assoc stepped :hit-flash-secs flash'))
     (nil? (:respawn-after e)) e
     (not revive?)             e
@@ -257,19 +277,29 @@
             (assoc e :respawn-after 0.5)))))))
 
 (defn advance
-  "Per-frame update for every enemy: alive enemies chase the player at
-   `speed` units/sec; dead enemies tick their respawn timer and rejoin
-   the fight once it expires (unless their `:max-concurrent` cap is
-   already met — see tick-one).
+  "Per-frame update for every enemy: alive enemies run the AI
+   state machine (LOS-gated wake; see enemy-ai) then chase the
+   player at `speed` units/sec if their state allows it; dead enemies
+   tick their respawn timer and rejoin the fight once it expires
+   (unless their `:max-concurrent` cap is already met — see tick-one).
+
+   The optional `pgrid` slot is the PHP-array grid mirror the AI
+   uses for line-of-sight raycasts. Real game callers pass it from
+   the world (`:pgrid`); test callers may omit it (legacy 6/7-arity
+   forms below), in which case the AI observation pass is skipped
+   and enemies behave per their existing :state — default :aware →
+   they chase as before, so old tests don't churn.
 
    The 7-arity opt-in `revive?` flag, when false, freezes every dead
    enemy in place — used on L10 once the boss is down so neither the
    cyberdemon nor its capped minions ever come back."
   ([enemies grid player-x player-y dt speed]
-   (advance enemies grid player-x player-y dt speed true))
-  ([es g x y delta sp revive?]
+   (advance enemies grid nil player-x player-y dt speed true))
+  ([enemies grid player-x player-y dt speed revive?]
+   (advance enemies grid nil player-x player-y dt speed revive?))
+  ([es g pg x y delta sp revive?]
    (apply vector
-          (map (fn [e] (tick-one e g x y delta sp es revive?))
+          (map (fn [e] (tick-one e g pg x y delta sp es revive?))
                es))))
 
 (def scare-trigger-dist
@@ -393,7 +423,11 @@
                        (php/+ (php/* dx dx) (php/* dy dy)))]
          (if (php/< d2 (php/* min-d min-d))
            (recur acc (php/+ attempts 1) remaining)
-           (recur (conj acc (new-enemy ex ey max-lives type-kw))
+           ;; Real-game spawns start :dormant so the player can sneak
+           ;; / peek / plan; LOS or being shot wakes them. `new-enemy`
+           ;; itself stays :aware-default so unit tests built directly
+           ;; via the constructor don't need to be migrated.
+           (recur (conj acc (assoc (new-enemy ex ey max-lives type-kw) :state :dormant))
                   (php/+ attempts 1)
                   (php/- remaining 1))))))))
 

--- a/src/modules/core/enemy_ai.phel
+++ b/src/modules/core/enemy_ai.phel
@@ -1,0 +1,110 @@
+(ns phel-doom.modules.core.enemy-ai
+  (:require phel-doom.modules.core.engine :refer [cast-ray max-depth]))
+
+;; ---------------------------------------------------------------------
+;; Enemy AI state machine.
+;;
+;; Each enemy carries a `:state` keyword describing what it's currently
+;; doing. The state controls two orthogonal questions: does the enemy
+;; move this tick, and does it deal contact damage this tick. Both are
+;; data-driven via `state-spec` so adding a new state means appending
+;; one entry — call sites (`tick-one`, `enemies-touching?`) stay
+;; unchanged.
+;;
+;; Current states:
+;;   :dormant   passive, doesn't move or hurt. Wakes on LOS to player
+;;              or when shot (any hit auto-wakes the target enemy in
+;;              combat/shoot).
+;;   :aware     full chase + contact damage. Sticky in v1 — once an
+;;              enemy is aware it stays aware for the rest of the
+;;              level (matches DOOM's "wake once, stay awake" feel).
+;;
+;; Reserved slots (commented out) so future state additions slot in
+;; without renaming or restructuring:
+;;   :hunting   LOS lost, walking toward last-known-position
+;;   :pain      hit-staggered, frozen briefly, won't attack
+;;   :attacking inside attack window (projectile / hitscan windup)
+;; ---------------------------------------------------------------------
+
+(def state-spec
+  "Per-state behaviour flags. `tick-one` reads `:moves?` to gate the
+   chase step; `combat/enemies-touching?` reads `:attacks?` to gate
+   contact damage. Add a new entry here + add a transition clause in
+   `next-state` to introduce a new behavioural mode."
+  {:dormant   {:moves? false :attacks? false}
+   :aware     {:moves? true  :attacks? true}
+   ;; :hunting   {:moves? true  :attacks? false}
+   ;; :pain      {:moves? false :attacks? false}
+   ;; :attacking {:moves? false :attacks? true}
+})
+
+(def default-state
+  "Fallback when an enemy carries no `:state` key (legacy test
+   fixtures, ad-hoc constructions). Picking `:aware` keeps the old
+   'enemy always chases' behaviour for unit tests that haven't been
+   migrated to the new state machine."
+  :aware)
+
+(defn- state-of [enemy]
+  (or (:state enemy) default-state))
+
+(defn moves?
+  "True when the enemy's state allows it to chase / pathfind this
+   tick. Pure data lookup — no behaviour fork in the caller."
+  [enemy]
+  (boolean (get-in state-spec [(state-of enemy) :moves?])))
+
+(defn attacks?
+  "True when the enemy's state allows it to deal contact damage this
+   tick. Pure data lookup — same shape as `moves?`."
+  [enemy]
+  (boolean (get-in state-spec [(state-of enemy) :attacks?])))
+
+(defn sees-player?
+  "Line-of-sight test from enemy (ex, ey) to player (px, py) over
+   `pgrid`. Casts one ray at the enemy→player angle and compares the
+   ray's first-wall distance to the actual player distance. Player
+   closer than the wall hit → LOS clear.
+
+   Player beyond `max-depth` reads as no LOS (engine caps the cast
+   distance there anyway — outside that range we can't tell whether
+   a wall blocks, so treat as 'too far to see' which matches DOOM's
+   sight cutoff for very long sectors)."
+  [pgrid ^float ex ^float ey ^float px ^float py]
+  (let [dx       (php/- px ex)
+        dy       (php/- py ey)
+        player-d (php/sqrt (php/+ (php/* dx dx) (php/* dy dy)))]
+    (if (php/>= player-d max-depth)
+      false
+      (let [angle  (php/atan2 dy dx)
+            wall-d (cast-ray pgrid ex ey angle)]
+        (php/< player-d wall-d)))))
+
+(defn next-state
+  "Pure state-machine transition for one enemy on one tick. Inputs
+   are the current enemy and the observations gathered this frame
+   (currently just `sees-player?`; future params will land here:
+   `heard-noise?` for sound-wake, `taking-pain?` for stagger, etc).
+   Returns the new `:state` keyword.
+
+   v1 transitions:
+     :dormant + sees-player? → :aware
+     :dormant + !sees        → :dormant
+     :aware                  → :aware (sticky — wake once, stay awake)
+
+   Future clauses for :hunting / :pain / :attacking slot in alongside
+   these without disturbing existing behaviour."
+  [enemy sees?]
+  (case (state-of enemy)
+    :dormant (if sees? :aware :dormant)
+    :aware   :aware
+    (state-of enemy)))
+
+(defn observe
+  "One-shot transition wrapper: given an alive enemy, world grid,
+   and player position, compute LOS and return the enemy with its
+   `:state` updated. Pure — caller threads the result back into the
+   enemies vector."
+  [enemy pgrid ^float px ^float py]
+  (let [sees? (sees-player? pgrid (:x enemy) (:y enemy) px py)]
+    (assoc enemy :state (next-state enemy sees?))))

--- a/tests/modules/core/combat-test.phel
+++ b/tests/modules/core/combat-test.phel
@@ -338,6 +338,16 @@
         w1 (damage-step w0 0.016)]
     (is (= 5 (:lives w1)))))
 
+(deftest test-damage-step-spares-life-against-dormant-enemy
+  ;; LOS-gated AI: a dormant enemy (hasn't seen the player yet) deals
+  ;; no contact damage even sitting on top of the player. Walking
+  ;; through a sleeping monster is allowed; touching them as a way to
+  ;; wake them up would be a future extension (see enemy-ai docstring).
+  (let [w0 (assoc-in (world-with-enemy-on-player 5 false)
+                     [:enemies 0 :state] :dormant)
+        w1 (damage-step w0 0.016)]
+    (is (= 5 (:lives w1)))))
+
 ;; ---------------------------------------------------------------------
 ;; Kill-loot ammo drop picks uniformly from :owned-weapons so each
 ;; kill seeds ammo for some gun the player can actually use. Roll is

--- a/tests/modules/core/enemy-test.phel
+++ b/tests/modules/core/enemy-test.phel
@@ -167,6 +167,86 @@
     (is (> (:x e) 5.0))))
 
 ;; ---------------------------------------------------------------------
+;; AI state integration: LOS-gated wake. The 8-arity advance with pgrid
+;; routes each alive enemy through enemy-ai/observe. Dormant enemies
+;; with LOS to the player flip to :aware and start chasing this frame;
+;; dormant enemies WITHOUT LOS hold position. Enemies without a :state
+;; (legacy fixtures, default :aware) chase regardless.
+;; ---------------------------------------------------------------------
+
+(def open-pgrid
+  (php/array
+   (php/array 1 1 1 1 1 1 1 1 1 1)
+   (php/array 1 0 0 0 0 0 0 0 0 1)
+   (php/array 1 0 0 0 0 0 0 0 0 1)
+   (php/array 1 0 0 0 0 0 0 0 0 1)
+   (php/array 1 0 0 0 0 0 0 0 0 1)
+   (php/array 1 0 0 0 0 0 0 0 0 1)
+   (php/array 1 0 0 0 0 0 0 0 0 1)
+   (php/array 1 0 0 0 0 0 0 0 0 1)
+   (php/array 1 0 0 0 0 0 0 0 0 1)
+   (php/array 1 1 1 1 1 1 1 1 1 1)))
+
+(def wall-between-pgrid
+  ;; x=4 wall column splits the chamber. Enemy on the left, player on
+  ;; the right — no LOS.
+  (php/array
+   (php/array 1 1 1 1 1 1 1 1 1 1)
+   (php/array 1 0 0 0 1 0 0 0 0 1)
+   (php/array 1 0 0 0 1 0 0 0 0 1)
+   (php/array 1 0 0 0 1 0 0 0 0 1)
+   (php/array 1 0 0 0 1 0 0 0 0 1)
+   (php/array 1 0 0 0 1 0 0 0 0 1)
+   (php/array 1 0 0 0 1 0 0 0 0 1)
+   (php/array 1 0 0 0 1 0 0 0 0 1)
+   (php/array 1 0 0 0 1 0 0 0 0 1)
+   (php/array 1 1 1 1 1 1 1 1 1 1)))
+
+(deftest test-advance-with-pgrid-wakes-dormant-on-los
+  ;; Dormant enemy at (2.5, 2.5), player at (5.5, 2.5), open chamber.
+  ;; LOS clear → observe flips state to :aware AND the chase step runs
+  ;; this same frame, so the enemy both wakes and moves.
+  (let [start (assoc (new-enemy 2.5 2.5) :state :dormant)
+        es'   (advance [start] open-grid open-pgrid 5.5 2.5 0.5 0.75 true)
+        e     (first es')]
+    (is (= :aware (:state e)))
+    (is (> (:x e) 2.5))))
+
+(deftest test-advance-with-pgrid-keeps-dormant-behind-wall
+  ;; Same setup but with a wall column between enemy and player.
+  ;; observe sees no LOS → state stays :dormant → no chase step.
+  (let [start (assoc (new-enemy 2.5 4.5) :state :dormant)
+        es'   (advance [start] open-grid wall-between-pgrid 6.5 4.5 0.5 0.75 true)
+        e     (first es')]
+    (is (= :dormant (:state e)))
+    (is (= 2.5 (:x e)))
+    (is (= 4.5 (:y e)))))
+
+(deftest test-advance-without-pgrid-skips-observation
+  ;; 6-arity legacy form (no pgrid) doesn't run observe. Enemies keep
+  ;; whatever state they have; default :aware → they chase as before.
+  ;; This pins backward-compat for unit tests that build enemies via
+  ;; new-enemy without going through spawn-enemies.
+  (let [es' (advance [(new-enemy 5.0 5.0)] open-grid 8.0 5.0 0.5 0.75)
+        e   (first es')]
+    (is (> (:x e) 5.0))))
+
+(deftest test-shoot-wakes-target
+  ;; Dormant imp gets hit by a pistol round → state forced to :aware
+  ;; so they react to being shot regardless of prior dormancy.
+  (let [start      [(assoc (new-enemy 3.5 1.5 3) :state :dormant)]
+        [es' hit?] (shoot start 1.5 1.5 0.0 10.0 0.5 12.0)]
+    (is (= true hit?))
+    (is (= :aware (:state (first es'))))))
+
+(deftest test-spawn-enemies-stamps-dormant
+  ;; Real-game spawns start :dormant — player can sneak through a
+  ;; room until they're seen / shot. Pin so a refactor doesn't
+  ;; silently swap the default and undo the LOS-gate behaviour.
+  (let [es (spawn-enemies open-grid 3 0.0 5.0 5.0 1)]
+    (is (every? (fn [e] (= :dormant (:state e))) es))))
+
+;; ---------------------------------------------------------------------
 ;; tick-scare: fires the wide-eyed beat ONLY on the inbound crossing
 ;; past scare-trigger-dist (3.5). Tracks last frame's nearest enemy so
 ;; sitting inside the band doesn't keep refiring.

--- a/tests/modules/core/enemy_ai_test.phel
+++ b/tests/modules/core/enemy_ai_test.phel
@@ -1,0 +1,111 @@
+(ns phel-doom-tests.modules.core.enemy-ai-test
+  (:require phel.test :refer [deftest is])
+  (:require phel-doom.modules.core.enemy-ai :refer [moves? attacks? sees-player? next-state observe
+                                                    state-spec default-state]))
+
+;; Open chamber grid mirroring engine-test fixtures: 1 = wall, 0 = floor.
+;; PHP-array form so cast-ray (which expects :pgrid) can read it.
+(def open-pgrid
+  (php/array
+   (php/array 1 1 1 1 1 1 1)
+   (php/array 1 0 0 0 0 0 1)
+   (php/array 1 0 0 0 0 0 1)
+   (php/array 1 0 0 0 0 0 1)
+   (php/array 1 0 0 0 0 0 1)
+   (php/array 1 0 0 0 0 0 1)
+   (php/array 1 1 1 1 1 1 1)))
+
+;; Same chamber with a solid wall column at x=3 splitting it in half.
+(def wall-between-pgrid
+  (php/array
+   (php/array 1 1 1 1 1 1 1)
+   (php/array 1 0 0 1 0 0 1)
+   (php/array 1 0 0 1 0 0 1)
+   (php/array 1 0 0 1 0 0 1)
+   (php/array 1 0 0 1 0 0 1)
+   (php/array 1 0 0 1 0 0 1)
+   (php/array 1 1 1 1 1 1 1)))
+
+(deftest test-state-spec-has-dormant-and-aware
+  (is (= false (get-in state-spec [:dormant :moves?])))
+  (is (= false (get-in state-spec [:dormant :attacks?])))
+  (is (= true  (get-in state-spec [:aware :moves?])))
+  (is (= true  (get-in state-spec [:aware :attacks?]))))
+
+(deftest test-default-state-is-aware
+  ;; Legacy enemies built via new-enemy carry no :state. Default
+  ;; falls through to :aware so prior 'always chase' tests stay green.
+  (is (= :aware default-state)))
+
+(deftest test-moves-on-aware
+  (is (= true (moves? {:state :aware}))))
+
+(deftest test-moves-on-dormant
+  (is (= false (moves? {:state :dormant}))))
+
+(deftest test-moves-on-missing-state
+  ;; Missing :state → default-state (:aware) → moves.
+  (is (= true (moves? {}))))
+
+(deftest test-attacks-on-aware
+  (is (= true (attacks? {:state :aware}))))
+
+(deftest test-attacks-on-dormant
+  (is (= false (attacks? {:state :dormant}))))
+
+(deftest test-sees-player-open-chamber
+  ;; Enemy at (1.5, 1.5), player at (5.5, 5.5). Straight diagonal
+  ;; through open floor — clear LOS.
+  (is (= true (sees-player? open-pgrid 1.5 1.5 5.5 5.5))))
+
+(deftest test-sees-player-wall-blocks
+  ;; Enemy at (1.5, 3.5) on the left half, player at (5.5, 3.5) on
+  ;; the right half. The x=3 wall column sits between them — no LOS.
+  (is (= false (sees-player? wall-between-pgrid 1.5 3.5 5.5 3.5))))
+
+(deftest test-sees-player-far-distance-no-los
+  ;; Beyond max-depth (12 units) returns false even with no wall in
+  ;; the way — matches the engine's sight cap. Place enemy + player
+  ;; on a grid that's effectively unbounded for the assertion.
+  (let [huge-pgrid (php/array (php/array 0 0 0 0 0)
+                              (php/array 0 0 0 0 0)
+                              (php/array 0 0 0 0 0))]
+    (is (= false (sees-player? huge-pgrid 0.5 0.5 100.5 100.5)))))
+
+(deftest test-next-state-dormant-stays-dormant-without-los
+  (is (= :dormant (next-state {:state :dormant} false))))
+
+(deftest test-next-state-dormant-flips-aware-on-los
+  (is (= :aware (next-state {:state :dormant} true))))
+
+(deftest test-next-state-aware-is-sticky
+  ;; Once aware, no LOS check loses it. Matches DOOM's wake-once
+  ;; behaviour for most monsters.
+  (is (= :aware (next-state {:state :aware} false)))
+  (is (= :aware (next-state {:state :aware} true))))
+
+(deftest test-next-state-missing-defaults-to-aware
+  ;; Enemies without an explicit state observe in as :aware so
+  ;; legacy code paths stay backward compatible.
+  (is (= :aware (next-state {} false)))
+  (is (= :aware (next-state {} true))))
+
+(deftest test-observe-wakes-dormant-on-los
+  ;; Dormant enemy at (1.5, 1.5), player at (5.5, 5.5), open chamber.
+  ;; observe should flip the state to :aware.
+  (let [e  {:x 1.5 :y 1.5 :state :dormant}
+        e' (observe e open-pgrid 5.5 5.5)]
+    (is (= :aware (:state e')))))
+
+(deftest test-observe-keeps-dormant-behind-wall
+  ;; Enemy at (1.5, 3.5), player at (5.5, 3.5), wall column between.
+  ;; observe should leave state at :dormant.
+  (let [e  {:x 1.5 :y 3.5 :state :dormant}
+        e' (observe e wall-between-pgrid 5.5 3.5)]
+    (is (= :dormant (:state e')))))
+
+(deftest test-observe-aware-stays-aware-everywhere
+  ;; Sticky aware: even with no LOS the state holds.
+  (let [e  {:x 1.5 :y 3.5 :state :aware}
+        e' (observe e wall-between-pgrid 5.5 3.5)]
+    (is (= :aware (:state e')))))


### PR DESCRIPTION
## 📚 Description

Today every alive enemy chases the player every frame — through walls, closed doors, pillars, across the entire map. There's no tactical play; spawns read as omniscient. This PR is the smallest concrete fix for that complaint: a line-of-sight (LOS) gate on the chase, plus a small state machine so further AI behaviours have somewhere clean to land.

Mirrors DOOM's monster wake-up rule:
- Monsters spawn passive (`:dormant`).
- Wake on LOS to the player OR on taking a hit.
- Once awake, stay awake (DOOM "wake once, stay awake" feel).

Player can now peek / retreat / plan corners. Walls and pillars actually shield you.

## 🔖 Changes

- **New module `src/modules/core/enemy_ai.phel`** — data-driven `state-spec` (`:dormant` / `:aware`), `moves?` / `attacks?` predicates, `sees-player?` LOS cast, `next-state` transition, `observe` one-shot wrapper.
- **`enemy.phel`**:
  - `new-enemy` keeps `:state :aware` default so unit-test fixtures don't churn.
  - `spawn-enemies` / `spawn-enemies-mixed` stamp `:state :dormant` for real-game spawns.
  - `advance` grows an 8-arity that forwards `pgrid` for the AI observation pass; legacy 6/7-arity stays as a thin wrapper passing `nil` pgrid (skips observation).
  - `tick-one` runs `observe` first on alive enemies, then gates `step-toward` on `moves?`.
  - `shoot` stamps `:state :aware` on the hit target.
- **`combat.phel`** — `enemies-touching?` filters by `attacks?` so dormant enemies don't deal contact damage.
- **`play.phel`** — `tick-enemies` forwards `(:pgrid world)` into the new 8-arity `advance`.
- **`docs/monsters.md`** — new "AI state machine" section documenting states, wake triggers, sticky-aware behaviour, and the chase step.

## 🏗️ Architecture for follow-ups

The state machine is deliberately small + extendable. Reserved slots in `state-spec` (commented out) for `:hunting`, `:pain`, `:attacking`. `next-state` takes the enemy + observation inputs; new transition clauses + new params (`heard-noise?`, `taking-pain?`) slot in without touching the call sites.

### Follow-up ideas (deferred)

- **Sound-wake** — when the player fires, BFS flood-fill through the grid (closed doors opaque, open doors transparent) up to N cells; mark touched enemies `:state :aware`. Adds the classic "one shot wakes the next room" moment. ~30 min on top of this PR.
- **Hunting + LKP** — when an aware enemy loses LOS for >N seconds, walk toward last-known position; revert if still no LOS after arrival.
- **Pain stagger** — hit-chance roll on damage flips state to `:pain` for ~0.3s, freezing chase + attack briefly.
- **Per-type attack profiles** — projectile imp, hitscan zombieman, rocket cyberdemon. Needs new fx + collision; biggest surface area, leave for a separate epic.

## 🧪 Test plan

- [x] `composer ci` — format, lint, 856 tests (31 new), build (all green)
- [x] New `tests/modules/core/enemy_ai_test.phel` — spec shape, predicates, LOS open / wall-blocked / max-depth cap, all transitions, `observe` wrapper
- [x] New cases in `enemy-test.phel` — 8-arity `advance` wakes dormant on LOS + chases same frame, wall-blocked dormant holds, 6-arity legacy skips observation, `shoot` wakes target, `spawn-enemies` stamps dormant
- [x] New case in `combat-test.phel` — dormant enemy on top of player deals no damage
- [ ] Manual smoke: load a level, walk near a room. Confirm enemies hold position until you peek the corner / fire a shot.
- [ ] Manual smoke: L10 boss room — cyberdemon dormant until LOS / shot.