### PR TITLE
feat(enemy): hunting state — lose LOS, walk to LKP, give up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,9 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 ### Added
 
 - Responsive help panel (`H` / `ESC`) — adapts width + drops optional sections on small terminals.
-- Enemy AI state machine. Real-game spawns start `:dormant` — they hold position + deal no contact damage until they get line-of-sight to the player OR take a hit. Once aware, sticky (DOOM "wake once, stay awake"). Bosses + minions can be peeked / planned around instead of homing through walls.
-- Sound-wake. Pulling the trigger flood-fills sound from the player's cell up to 6 floor cells; every alive enemy in the same sector wakes. Walls + all door variants block the BFS so the wake stays in your room — matches DOOM's per-sector noise rule. One shot wakes the room, not the level.
+- Enemy AI state machine. Real-game spawns start `:dormant` — they hold position + deal no contact damage until they get line-of-sight to the player OR take a hit. Bosses + minions can be peeked / planned around instead of homing through walls.
+- `:hunting` state. Aware enemies that lose line-of-sight stop chasing the player's live position; they walk to the last-known cell instead, doing no contact damage along the way. Arrive at the breadcrumb without re-acquiring LOS → drop back to `:dormant`. Player can break contact by ducking around a corner / behind a door.
+- Sound-wake. Pulling the trigger flood-fills sound from the player's cell up to 3 floor cells; alive enemies in the close-by area go into `:hunting` with the fire origin as their `:lkp`. Walls + all door variants block the BFS so the wake stays nearby — matches DOOM's per-sector noise rule, just tighter than the original 6-cell radius (less "the whole room aggros every shot").
 
 ### Performance
 

--- a/docs/monsters.md
+++ b/docs/monsters.md
@@ -33,32 +33,65 @@ Each enemy carries `:lives` / `:max-lives` / `:type`. `enemy/shoot` drops `:live
 
 ## AI state machine
 
-Each enemy carries a `:state` keyword that decides whether it moves + deals contact damage this tick. Spec lives in `enemy_ai.phel`:
+Each enemy carries a `:state` keyword + an optional `:lkp` (last-known player position). State decides whether it moves + deals contact damage this tick. Spec lives in `enemy_ai.phel`:
 
 ```phel
 {:dormant {:moves? false :attacks? false}
- :aware   {:moves? true  :attacks? true}}
+ :aware   {:moves? true  :attacks? true}
+ :hunting {:moves? true  :attacks? false}}
 ```
 
 `new-enemy` defaults to `:aware` (legacy test fixtures keep chasing). Real-game spawns (`spawn-enemies`, `spawn-enemies-mixed`) stamp `:state :dormant`, so the player can sneak / peek / plan until the room reacts.
 
-### Wake triggers
+### State meanings
 
-- **Line-of-sight (LOS)** — every tick, `enemy-ai/observe` casts one ray from each alive enemy to the player. Ray hits a wall before reaching the player cell → no LOS, stays dormant. Reaches the player → flips to `:aware`. Reuses `engine/cast-ray`; capped at `max-depth` (12 units), so very long sectors read as "too far to see" — matches DOOM's sight cutoff.
-- **Pain (being shot)** — `enemy/shoot` stamps `:state :aware` on the hit target unconditionally. A dormant enemy that took a bullet without reacting would read as broken AI.
-- **Noise (player fire)** — `combat/fire-shot` runs a flood-fill BFS from the player's cell up to `noise-wake-radius` (6 cells) through `cell-floor` neighbours only. Walls and ALL door variants block, so sound dies at the room boundary — matches DOOM's per-sector noise rule. Every alive enemy whose integer cell sits inside the visited set flips to `:aware`, including those without LOS. One shot wakes the room you're in, not the level.
+- **`:dormant`** — passive. Won't move, won't damage. Waiting for LOS or a close-by noise.
+- **`:aware`** — has LOS to the player right now. Full chase + contact damage. `:lkp` refreshes to the player's current cell every tick.
+- **`:hunting`** — lost LOS. Walks toward the frozen `:lkp` (whatever cell the player was in at the last LOS frame), but does NOT deal contact damage — searching, not engaged. Re-acquiring LOS → `:aware`. Arriving at `:lkp` without LOS → `:dormant` ("lost the scent", give up).
 
-Once aware the state is sticky (DOOM "wake once, stay awake"). Future state transitions (`:hunting` for LOS-lost-then-chase-to-LKP, `:pain` for stagger, `:attacking` for ranged windup) slot into the same `state-spec` map + `next-state` cond — call sites don't change.
+### Wake / transition triggers
 
-### Chase step
+- **LOS** — every tick, `enemy-ai/observe` casts one ray from each alive enemy to the player via `engine/cast-ray`. Ray hits a wall before reaching the player cell → no LOS. Player closer than the wall → LOS clear. Capped at `max-depth` (12 units) — long sectors read as "too far to see" (DOOM sight cutoff).
+- **Pain (being shot)** — `enemy/shoot` stamps `:state :aware` on the hit target unconditionally.
+- **Noise (player fire)** — `combat/fire-shot` runs a 4-connected flood-fill from the player's cell up to `noise-wake-radius` (3 cells) through `cell-floor` neighbours only. Walls + all door variants block. Alive enemies inside the visited set go into the hunt: dormant → `:hunting` with `:lkp` stamped at the fire origin; existing hunters get their `:lkp` refreshed to the fresher noise. Already-aware enemies are unchanged (they're tracking visually, sound adds nothing).
 
-Aware enemies route through `step-toward`:
+### Transition table
 
-1. Desired heading (atan2 enemy → player).
+| From      | Trigger                       | To         |
+|-----------|-------------------------------|------------|
+| `:dormant` | LOS to player                 | `:aware`   |
+| `:dormant` | Noise within radius           | `:hunting` (lkp = fire origin) |
+| `:dormant` | Hit                           | `:aware`   |
+| `:aware`   | LOS                           | `:aware` (lkp refreshes) |
+| `:aware`   | No LOS                        | `:hunting` (lkp frozen) |
+| `:hunting` | LOS regained                  | `:aware`   |
+| `:hunting` | Reached `:lkp`, still no LOS  | `:dormant` |
+| `:hunting` | Still moving, no LOS          | `:hunting` |
+
+### Chase step + target selection
+
+`tick-one` calls `enemy-ai/target-pos` per alive enemy to pick where to walk:
+- `:aware` → live player position
+- `:hunting` → frozen `:lkp` (falls back to player position if somehow missing)
+- `:dormant` → `nil` (skip the step entirely)
+
+`step-toward` then runs the standard chase:
+
+1. Desired heading (atan2 enemy → target).
 2. Try stepping `speed * dt` units along that heading.
 3. If destination is inside a wall, try angle offsets ±45°, ±90°, ±135°. Slides around corners, walks out of dead ends.
 
-Stop distance: enemies don't close past `stop-dist = 0.6` to avoid piling up inside the player's cell. Dormant enemies skip the chase step entirely.
+Stop distance: `stop-dist = 0.6` so enemies don't pile up inside the target cell. `lkp-arrival-dist = 0.9` (slightly above `stop-dist`) is the "I've arrived at the lkp" threshold the state machine uses to flip `:hunting → :dormant`.
+
+### Hiding from enemies
+
+Player can break contact by ducking around a corner / behind a door while an aware enemy chases. Sequence:
+1. Aware enemy chases, `:lkp` refreshing every frame.
+2. Player ducks behind a wall. LOS drops → state flips to `:hunting`, `:lkp` freezes at the player's last-seen cell.
+3. Hunter walks to the frozen `:lkp`. Player keeps running.
+4. Hunter arrives at `:lkp`. Still no LOS → `:dormant`. Player got away.
+
+Future improvements left as `next-state` clause extensions (no call-site churn): `:pain` (hit stagger), `:attacking` (ranged windup), `:wander` (random patrol while dormant).
 
 ## Respawn cooldown + max-concurrent cap
 

--- a/src/modules/core/enemy.phel
+++ b/src/modules/core/enemy.phel
@@ -1,6 +1,6 @@
 (ns phel-doom.modules.core.enemy
   (:require phel-doom.modules.core.map      :refer [random-spawn wall?])
-  (:require phel-doom.modules.core.enemy-ai :refer [observe moves?]))
+  (:require phel-doom.modules.core.enemy-ai :refer [observe moves? target-pos]))
 
 (def default-chase-speed
   "Fallback chase speed (units/sec) used by the single-arity advance
@@ -244,9 +244,15 @@
   (cond
     (:alive e)                (let [observed (if pgrid (observe e pgrid player-x player-y) e)
                                     chase?   (moves? observed)
+                                    target   (target-pos observed player-x player-y)
                                     mul      (or (get type-speed-mul (:type observed)) 1.0)
-                                    stepped  (if chase?
-                                               (step-toward observed grid player-x player-y dt (php/* speed mul))
+                                    ;; target may be nil for states that don't move
+                                    ;; (:dormant); the `chase?` gate already covers
+                                    ;; that case, but keep a defensive guard for
+                                    ;; future states that move but don't pick a
+                                    ;; target.
+                                    stepped  (if (and chase? target)
+                                               (step-toward observed grid (:x target) (:y target) dt (php/* speed mul))
                                                observed)
                                     flash'   (php/max 0.0 (php/- (or (:hit-flash-secs observed) 0.0) dt))]
                                 (assoc stepped :hit-flash-secs flash'))

--- a/src/modules/core/enemy.phel
+++ b/src/modules/core/enemy.phel
@@ -243,16 +243,15 @@
   [e grid pgrid ^float player-x ^float player-y ^float dt ^float speed all-enemies revive?]
   (cond
     (:alive e)                (let [observed (if pgrid (observe e pgrid player-x player-y) e)
-                                    chase?   (moves? observed)
-                                    target   (target-pos observed player-x player-y)
-                                    mul      (or (get type-speed-mul (:type observed)) 1.0)
-                                    ;; target may be nil for states that don't move
-                                    ;; (:dormant); the `chase?` gate already covers
-                                    ;; that case, but keep a defensive guard for
-                                    ;; future states that move but don't pick a
-                                    ;; target.
-                                    stepped  (if (and chase? target)
-                                               (step-toward observed grid (:x target) (:y target) dt (php/* speed mul))
+                                    ;; Only compute the step target when the state
+                                    ;; actually moves — `:dormant` skips both the
+                                    ;; target-pos call and the chase step entirely.
+                                    stepped  (if (moves? observed)
+                                               (let [target (target-pos observed player-x player-y)
+                                                     mul    (or (get type-speed-mul (:type observed)) 1.0)]
+                                                 (if target
+                                                   (step-toward observed grid (:x target) (:y target) dt (php/* speed mul))
+                                                   observed))
                                                observed)
                                     flash'   (php/max 0.0 (php/- (or (:hit-flash-secs observed) 0.0) dt))]
                                 (assoc stepped :hit-flash-secs flash'))

--- a/src/modules/core/enemy_ai.phel
+++ b/src/modules/core/enemy_ai.phel
@@ -5,26 +5,31 @@
 ;; ---------------------------------------------------------------------
 ;; Enemy AI state machine.
 ;;
-;; Each enemy carries a `:state` keyword describing what it's currently
-;; doing. The state controls two orthogonal questions: does the enemy
-;; move this tick, and does it deal contact damage this tick. Both are
-;; data-driven via `state-spec` so adding a new state means appending
-;; one entry — call sites (`tick-one`, `enemies-touching?`) stay
-;; unchanged.
+;; Each enemy carries a `:state` keyword + an optional `:lkp` slot
+;; (last-known player position). State controls two orthogonal
+;; questions: does the enemy move this tick, and does it deal contact
+;; damage. Both are data-driven via `state-spec` so adding a new state
+;; means appending one entry — call sites (`tick-one`,
+;; `enemies-touching?`) stay unchanged.
 ;;
-;; Current states:
-;;   :dormant   passive, doesn't move or hurt. Wakes on LOS to player
-;;              or when shot (any hit auto-wakes the target enemy in
-;;              combat/shoot).
-;;   :aware     full chase + contact damage. Sticky in v1 — once an
-;;              enemy is aware it stays aware for the rest of the
-;;              level (matches DOOM's "wake once, stay awake" feel).
+;; States:
+;;   :dormant   passive. No move, no damage. Waits for LOS or noise.
+;;   :aware     full chase + contact damage. LOS to the player right
+;;              now; lkp is being refreshed every frame.
+;;   :hunting   lost LOS while aware. Walks toward the last refreshed
+;;              `:lkp` but does NOT deal contact damage — they're
+;;              searching, not engaged. Re-acquiring LOS → :aware.
+;;              Arriving at lkp without LOS → :dormant (give up,
+;;              "lost the scent"). Lets the player break contact by
+;;              ducking around a corner / behind a door.
 ;;
-;; Reserved slots (commented out) so future state additions slot in
-;; without renaming or restructuring:
-;;   :hunting   LOS lost, walking toward last-known-position
+;; Reserved slots for future state additions:
 ;;   :pain      hit-staggered, frozen briefly, won't attack
 ;;   :attacking inside attack window (projectile / hitscan windup)
+;;
+;; LKP discipline: `observe` refreshes `:lkp` to the player's CURRENT
+;; position only while LOS is clear. Once LOS drops, lkp freezes at
+;; whatever it was last frame — that's the cell the hunter walks to.
 ;; ---------------------------------------------------------------------
 
 (def state-spec
@@ -32,9 +37,9 @@
    chase step; `combat/enemies-touching?` reads `:attacks?` to gate
    contact damage. Add a new entry here + add a transition clause in
    `next-state` to introduce a new behavioural mode."
-  {:dormant   {:moves? false :attacks? false}
-   :aware     {:moves? true  :attacks? true}
-   ;; :hunting   {:moves? true  :attacks? false}
+  {:dormant {:moves? false :attacks? false}
+   :aware   {:moves? true  :attacks? true}
+   :hunting {:moves? true  :attacks? false}
    ;; :pain      {:moves? false :attacks? false}
    ;; :attacking {:moves? false :attacks? true}
 })
@@ -45,6 +50,22 @@
    'enemy always chases' behaviour for unit tests that haven't been
    migrated to the new state machine."
   :aware)
+
+(def lkp-arrival-dist
+  "World-units threshold for 'arrived at last-known-position'. Once
+   the hunter is this close to its `:lkp` cell and LOS is still
+   blank, it gives up and reverts to :dormant. Slightly above
+   `stop-dist` so a hunter never gets stuck oscillating between
+   'arrived' and 'one step short'."
+  0.9)
+
+(def noise-wake-radius
+  "BFS cell radius around the player's fire origin. 3 cells matches
+   the 'close-by' feel: shooting only wakes enemies in the immediate
+   surroundings (same small room), not the whole sector. Walls and
+   every door variant block propagation, so the BFS often dies sooner
+   than the radius itself."
+  3)
 
 (defn- state-of [enemy]
   (or (:state enemy) default-state))
@@ -81,42 +102,82 @@
             wall-d (cast-ray pgrid ex ey angle)]
         (php/< player-d wall-d)))))
 
+(defn- at-lkp?
+  "True when the enemy is within `lkp-arrival-dist` of its `:lkp`.
+   Missing lkp counts as arrived — a state machine that lands in
+   :hunting without one would otherwise wander forever; instead the
+   next transition tips it straight back to :dormant."
+  [enemy]
+  (let [lkp (:lkp enemy)]
+    (if (nil? lkp)
+      true
+      (let [dx (php/- (:x lkp) (:x enemy))
+            dy (php/- (:y lkp) (:y enemy))]
+        (php/<= (php/+ (php/* dx dx) (php/* dy dy))
+                (php/* lkp-arrival-dist lkp-arrival-dist))))))
+
+(defn target-pos
+  "Where this enemy is walking toward THIS tick. Pure data lookup —
+   `tick-one` reads this to pick the step-toward target without
+   forking on state. :aware → the live player position; :hunting →
+   the frozen `:lkp` (falls back to the player position if somehow
+   missing); anything else → nil (caller should not step)."
+  [enemy ^float px ^float py]
+  (case (state-of enemy)
+    :aware   {:x px :y py}
+    :hunting (or (:lkp enemy) {:x px :y py})
+    nil))
+
 (defn next-state
-  "Pure state-machine transition for one enemy on one tick. Inputs
-   are the current enemy and the observations gathered this frame
-   (currently just `sees-player?`; future params will land here:
-   `heard-noise?` for sound-wake, `taking-pain?` for stagger, etc).
+  "Pure state-machine transition for one enemy on one tick. `obs` is
+   a map of this frame's observations:
+     :sees?   true when LOS to the player is clear right now
+     :at-lkp? true when the enemy has arrived at its `:lkp`
    Returns the new `:state` keyword.
 
-   v1 transitions:
-     :dormant + sees-player? → :aware
-     :dormant + !sees        → :dormant
-     :aware                  → :aware (sticky — wake once, stay awake)
+   Transitions:
+     :dormant + sees?            → :aware
+     :dormant + !sees?           → :dormant
+     :aware   + sees?            → :aware  (lkp refreshes in observe)
+     :aware   + !sees?           → :hunting (start tracking lkp)
+     :hunting + sees?            → :aware   (re-acquired)
+     :hunting + at-lkp? + !sees? → :dormant (lost the scent)
+     :hunting + else             → :hunting (still walking to lkp)
 
-   Future clauses for :hunting / :pain / :attacking slot in alongside
-   these without disturbing existing behaviour."
-  [enemy sees?]
-  (case (state-of enemy)
-    :dormant (if sees? :aware :dormant)
-    :aware   :aware
-    (state-of enemy)))
+   Adding a new state means one extra `case` clause; existing call
+   sites don't change."
+  [enemy obs]
+  (let [sees?   (:sees? obs)
+        at-lkp? (:at-lkp? obs)]
+    (case (state-of enemy)
+      :dormant (if sees? :aware :dormant)
+      :aware   (if sees? :aware :hunting)
+      :hunting (cond
+                 sees?   :aware
+                 at-lkp? :dormant
+                 :else   :hunting)
+      (state-of enemy))))
 
 (defn observe
-  "One-shot transition wrapper: given an alive enemy, world grid,
-   and player position, compute LOS and return the enemy with its
-   `:state` updated. Pure — caller threads the result back into the
-   enemies vector."
-  [enemy pgrid ^float px ^float py]
-  (let [sees? (sees-player? pgrid (:x enemy) (:y enemy) px py)]
-    (assoc enemy :state (next-state enemy sees?))))
+  "One-shot AI tick for a single alive enemy. Computes line-of-sight
+   + arrival flag, transitions state, and refreshes `:lkp` to the
+   player's current cell whenever LOS is clear. The frozen lkp from
+   the last LOS frame is what :hunting walks toward — that's how a
+   player can break contact by ducking around a corner.
 
-(def noise-wake-radius
-  "BFS cell radius around the player's fire origin. 6 covers a
-   medium-sized room without leaking through to the next one — sound
-   dies at any non-floor cell (walls + every door variant block
-   propagation), matching DOOM's per-sector noise rule. Bump higher
-   for shotgun / chaingun if you want louder weapons to wake further."
-  6)
+   Pure: returns the updated enemy. Caller threads the result back
+   into the enemies vector."
+  [enemy pgrid ^float px ^float py]
+  (let [sees?   (sees-player? pgrid (:x enemy) (:y enemy) px py)
+        arrived (at-lkp? enemy)
+        state'  (next-state enemy {:sees? sees? :at-lkp? arrived})
+        ;; Refresh lkp only while LOS is clear. Without LOS the
+        ;; existing lkp must NOT move — it's the stale 'last seen
+        ;; here' breadcrumb the hunter is following.
+        lkp'    (if sees? {:x px :y py} (:lkp enemy))]
+    (-> enemy
+        (assoc :state state')
+        (assoc :lkp lkp'))))
 
 (defn- bfs-cells
   "Pure flood-fill from `(ix0, iy0)` through `cell-floor` neighbours
@@ -126,7 +187,7 @@
 
    Walls and ALL door variants block: doors carrying lock colours
    make rooms acoustically isolated by default, which is the
-   point — one shot wakes the room you're in, not the level."
+   point — one shot wakes the cells you're standing in."
   [grid ^int ix0 ^int iy0 ^int radius]
   (loop [queue   [[ix0 iy0 0]]
          visited #{[ix0 iy0]}]
@@ -152,23 +213,40 @@
                                       fresh))]
             (recur queue' visited')))))))
 
+(defn- wake-by-noise
+  "Single-enemy noise transition. Dormant + heard → :hunting toward
+   the fire origin (sound = breadcrumb, not visual confirmation; they
+   investigate, they don't aggro instantly). Hunting + heard refreshes
+   the lkp to the fresher origin so a second shot redirects them
+   without them having to walk back to the original lkp. Aware
+   enemies ignore noise — they already see you, the gunshot adds no
+   new information."
+  [enemy ^float ox ^float oy]
+  (case (state-of enemy)
+    :dormant (-> enemy
+                 (assoc :state :hunting)
+                 (assoc :lkp   {:x ox :y oy}))
+    :hunting (assoc enemy :lkp {:x ox :y oy})
+    enemy))
+
 (defn noise-wake
   "Player-fire driven flood-wake. BFS from the fire origin (player
    cell) up to `noise-wake-radius` floor cells; every ALIVE enemy
-   whose integer cell sits inside that visited set flips to
-   `:state :aware`. Dead enemies are passed through unchanged so
-   respawn timers + carried `:max-lives` etc. survive.
+   whose integer cell sits inside that visited set hears the shot
+   and switches into the hunt — `:state :hunting`, `:lkp` set to
+   the fire origin. Dead / aware enemies pass through unchanged
+   (respawn timers + 'already engaged' state survive).
 
    Cheap because doors block: the fill rarely escapes the current
    room. Caller should fire this once per shot (rising edge of the
    fire button), not every frame the trigger is held — see
-   combat/resolve-shot for the wiring."
+   combat/fire-shot for the wiring."
   [enemies grid ^float ox ^float oy]
   (let [visited (bfs-cells grid (php/intval ox) (php/intval oy) noise-wake-radius)]
     (apply vector
            (map (fn [e]
                   (if (and (:alive e)
                            (contains? visited [(php/intval (:x e)) (php/intval (:y e))]))
-                    (assoc e :state :aware)
+                    (wake-by-noise e ox oy)
                     e))
                 enemies))))

--- a/src/modules/core/enemy_ai.phel
+++ b/src/modules/core/enemy_ai.phel
@@ -67,6 +67,14 @@
    than the radius itself."
   3)
 
+(def bfs-steps
+  "Module-level constant for the 4-connected BFS neighbour offsets.
+   Lifted out of `bfs-cells`'s inner loop so the vector isn't
+   re-allocated on every queue iteration. Not intended for use from
+   other modules, but Phel `def` doesn't carry a private marker so
+   the convention is 'internal helpers live near their caller'."
+  [[1 0] [-1 0] [0 1] [0 -1]])
+
 (defn- state-of [enemy]
   (or (:state enemy) default-state))
 
@@ -129,55 +137,53 @@
     nil))
 
 (defn next-state
-  "Pure state-machine transition for one enemy on one tick. `obs` is
-   a map of this frame's observations:
-     :sees?   true when LOS to the player is clear right now
-     :at-lkp? true when the enemy has arrived at its `:lkp`
-   Returns the new `:state` keyword.
+  "Pure state-machine transition for one enemy on one tick. Takes
+   just `sees?` (LOS clear right now); at-lkp? is computed lazily
+   inside the `:hunting` branch only — every other state ignores it,
+   so paying for it up front would be wasted work on the per-enemy
+   per-frame path. Returns the new `:state` keyword.
 
    Transitions:
-     :dormant + sees?            → :aware
-     :dormant + !sees?           → :dormant
-     :aware   + sees?            → :aware  (lkp refreshes in observe)
-     :aware   + !sees?           → :hunting (start tracking lkp)
-     :hunting + sees?            → :aware   (re-acquired)
-     :hunting + at-lkp? + !sees? → :dormant (lost the scent)
-     :hunting + else             → :hunting (still walking to lkp)
+     :dormant + sees?              → :aware
+     :dormant + !sees?             → :dormant
+     :aware   + sees?              → :aware   (lkp refreshes in observe)
+     :aware   + !sees?             → :hunting (start tracking lkp)
+     :hunting + sees?              → :aware   (re-acquired)
+     :hunting + at-lkp? + !sees?   → :dormant (lost the scent)
+     :hunting + else               → :hunting (still walking to lkp)
 
    Adding a new state means one extra `case` clause; existing call
    sites don't change."
-  [enemy obs]
-  (let [sees?   (:sees? obs)
-        at-lkp? (:at-lkp? obs)]
-    (case (state-of enemy)
+  [enemy sees?]
+  (let [s (state-of enemy)]
+    (case s
       :dormant (if sees? :aware :dormant)
       :aware   (if sees? :aware :hunting)
       :hunting (cond
-                 sees?   :aware
-                 at-lkp? :dormant
-                 :else   :hunting)
-      (state-of enemy))))
+                 sees?           :aware
+                 (at-lkp? enemy) :dormant
+                 :else           :hunting)
+      s)))
 
 (defn observe
-  "One-shot AI tick for a single alive enemy. Computes line-of-sight
-   + arrival flag, transitions state, and refreshes `:lkp` to the
-   player's current cell whenever LOS is clear. The frozen lkp from
-   the last LOS frame is what :hunting walks toward — that's how a
-   player can break contact by ducking around a corner.
+  "One-shot AI tick for a single alive enemy. Computes line-of-sight,
+   transitions state, and refreshes `:lkp` to the player's current
+   cell whenever LOS is clear. The frozen lkp from the last LOS frame
+   is what :hunting walks toward — that's how a player can break
+   contact by ducking around a corner.
 
-   Pure: returns the updated enemy. Caller threads the result back
-   into the enemies vector."
+   Pure: returns the updated enemy as a single multi-key assoc so the
+   per-frame allocation cost on big enemy vectors stays at one map
+   write instead of two. Caller threads the result back into the
+   enemies vector."
   [enemy pgrid ^float px ^float py]
-  (let [sees?   (sees-player? pgrid (:x enemy) (:y enemy) px py)
-        arrived (at-lkp? enemy)
-        state'  (next-state enemy {:sees? sees? :at-lkp? arrived})
+  (let [sees?  (sees-player? pgrid (:x enemy) (:y enemy) px py)
         ;; Refresh lkp only while LOS is clear. Without LOS the
         ;; existing lkp must NOT move — it's the stale 'last seen
         ;; here' breadcrumb the hunter is following.
-        lkp'    (if sees? {:x px :y py} (:lkp enemy))]
-    (-> enemy
-        (assoc :state state')
-        (assoc :lkp lkp'))))
+        lkp'   (if sees? {:x px :y py} (:lkp enemy))
+        state' (next-state enemy sees?)]
+    (assoc enemy :state state' :lkp lkp')))
 
 (defn- bfs-cells
   "Pure flood-fill from `(ix0, iy0)` through `cell-floor` neighbours
@@ -197,10 +203,9 @@
             tail    (rest queue)]
         (if (php/>= d radius)
           (recur tail visited)
-          (let [steps      [[1 0] [-1 0] [0 1] [0 -1]]
-                neighbours (apply vector
+          (let [neighbours (apply vector
                                   (map (fn [s] [(php/+ x (first s)) (php/+ y (second s))])
-                                       steps))
+                                       bfs-steps))
                 fresh      (apply vector
                                   (filter (fn [nb]
                                             (and (not (contains? visited nb))

--- a/tests/modules/core/combat-test.phel
+++ b/tests/modules/core/combat-test.phel
@@ -437,11 +437,12 @@
     (is (= 3 (:mag w1)))))
 
 (deftest test-fire-shot-wakes-dormant-enemy-in-room
-  ;; Sound-wake integration: a dormant imp in the same open room as
-  ;; the player flips to :aware on the trigger pull, even when the
-  ;; shot itself misses (no enemy along the player's facing). 1.5/1.5
-  ;; player is locked inside a closed 1-cell box in ready-world, so
-  ;; expand to a 5×5 chamber and place the imp inside.
+  ;; Sound-wake integration: a dormant imp within `noise-wake-radius`
+  ;; (3 cells via floor) flips to :hunting on the trigger pull, with
+  ;; `:lkp` stamped at the player's cell — even when the shot itself
+  ;; misses (no enemy along the player's facing). Imp at (2.5, 3.5)
+  ;; sits 3 BFS steps from the player's (1, 1) cell — at the edge of
+  ;; the radius but reachable.
   (let [grid    [[1 1 1 1 1]
                  [1 0 0 0 1]
                  [1 0 0 0 1]
@@ -449,7 +450,7 @@
                  [1 1 1 1 1]]
         player  (new-player 1.5 1.5 0.0)
         base    (new-world grid player)
-        dormant (assoc {:x 3.5 :y 3.5 :alive true :lives 1 :max-lives 1
+        dormant (assoc {:x 2.5 :y 3.5 :alive true :lives 1 :max-lives 1
                         :hit-flash-secs 0.0}
                        :state :dormant)
         world   (assoc base
@@ -463,8 +464,11 @@
                        :iframes         0.0
                        :sound-on        false
                        :enemies         [dormant])
-        w'      (tick-shooting world true)]
-    (is (= :aware (:state (first (:enemies w')))))))
+        w'      (tick-shooting world true)
+        e       (first (:enemies w'))]
+    (is (= :hunting (:state e)))
+    (is (= 1.5 (:x (:lkp e))))
+    (is (= 1.5 (:y (:lkp e))))))
 
 (deftest test-tick-shooting-legacy-arity-still-works
   ;; Old 2-arity (pre-:fire-held) callers must keep working. Fire

--- a/tests/modules/core/enemy-test.phel
+++ b/tests/modules/core/enemy-test.phel
@@ -246,6 +246,23 @@
   (let [es (spawn-enemies open-grid 3 0.0 5.0 5.0 1)]
     (is (every? (fn [e] (= :dormant (:state e))) es))))
 
+(deftest test-advance-hunting-walks-toward-lkp-not-player
+  ;; Hunter at (2.5, 2.5) with :lkp at (2.5, 5.5). Player has moved
+  ;; out of sight to (8.0, 2.5). The hunter must follow the lkp
+  ;; (south, +y) NOT the player's current position (east, +x).
+  ;; wall-between-pgrid puts a column at x=4 so LOS to the player at
+  ;; x=8 is blocked — observe doesn't override the hunting state on
+  ;; this tick.
+  (let [hunter [(assoc (new-enemy 2.5 2.5)
+                       :state :hunting
+                       :lkp   {:x 2.5 :y 5.5})]
+        es'    (advance hunter open-grid wall-between-pgrid 8.0 2.5 0.5 0.75 true)
+        e      (first es')]
+    (is (= :hunting (:state e)))
+    ;; Moved south (toward lkp), x unchanged.
+    (is (> (:y e) 2.5))
+    (is (= 2.5 (:x e)))))
+
 ;; ---------------------------------------------------------------------
 ;; tick-scare: fires the wide-eyed beat ONLY on the inbound crossing
 ;; past scare-trigger-dist (3.5). Tracks last frame's nearest enemy so

--- a/tests/modules/core/enemy_ai_test.phel
+++ b/tests/modules/core/enemy_ai_test.phel
@@ -1,8 +1,10 @@
 (ns phel-doom-tests.modules.core.enemy-ai-test
   (:require phel.test :refer [deftest is])
   (:require phel-doom.modules.core.enemy-ai :refer [moves? attacks? sees-player? next-state observe
+                                                    target-pos
                                                     noise-wake noise-wake-radius
-                                                    state-spec default-state]))
+                                                    state-spec default-state
+                                                    lkp-arrival-dist]))
 
 ;; Open chamber grid mirroring engine-test fixtures: 1 = wall, 0 = floor.
 ;; PHP-array form so cast-ray (which expects :pgrid) can read it.
@@ -32,6 +34,13 @@
   (is (= false (get-in state-spec [:dormant :attacks?])))
   (is (= true  (get-in state-spec [:aware :moves?])))
   (is (= true  (get-in state-spec [:aware :attacks?]))))
+
+(deftest test-state-spec-has-hunting
+  ;; Hunting moves toward :lkp but does NOT deal contact damage —
+  ;; they're searching, not engaged. Pin the asymmetric flags so a
+  ;; refactor doesn't silently swap them.
+  (is (= true  (get-in state-spec [:hunting :moves?])))
+  (is (= false (get-in state-spec [:hunting :attacks?]))))
 
 (deftest test-default-state-is-aware
   ;; Legacy enemies built via new-enemy carry no :state. Default
@@ -74,22 +83,37 @@
     (is (= false (sees-player? huge-pgrid 0.5 0.5 100.5 100.5)))))
 
 (deftest test-next-state-dormant-stays-dormant-without-los
-  (is (= :dormant (next-state {:state :dormant} false))))
+  (is (= :dormant (next-state {:state :dormant} {:sees? false :at-lkp? false}))))
 
 (deftest test-next-state-dormant-flips-aware-on-los
-  (is (= :aware (next-state {:state :dormant} true))))
+  (is (= :aware (next-state {:state :dormant} {:sees? true :at-lkp? false}))))
 
-(deftest test-next-state-aware-is-sticky
-  ;; Once aware, no LOS check loses it. Matches DOOM's wake-once
-  ;; behaviour for most monsters.
-  (is (= :aware (next-state {:state :aware} false)))
-  (is (= :aware (next-state {:state :aware} true))))
+(deftest test-next-state-aware-with-los-stays-aware
+  (is (= :aware (next-state {:state :aware} {:sees? true :at-lkp? false}))))
+
+(deftest test-next-state-aware-without-los-drops-to-hunting
+  ;; Losing sight while aware kicks off the search: walk toward the
+  ;; last seen position (:lkp) until LOS returns or you arrive.
+  (is (= :hunting (next-state {:state :aware} {:sees? false :at-lkp? false}))))
+
+(deftest test-next-state-hunting-sees-flips-aware
+  ;; LOS re-acquired during the search — go back to full chase.
+  (is (= :aware (next-state {:state :hunting} {:sees? true :at-lkp? false}))))
+
+(deftest test-next-state-hunting-arrives-without-los-drops-dormant
+  ;; Hunter reached the breadcrumb cell but still no LOS — gives up
+  ;; the chase and goes idle. Player got away clean.
+  (is (= :dormant (next-state {:state :hunting} {:sees? false :at-lkp? true}))))
+
+(deftest test-next-state-hunting-still-searching-stays-hunting
+  (is (= :hunting (next-state {:state :hunting} {:sees? false :at-lkp? false}))))
 
 (deftest test-next-state-missing-defaults-to-aware
   ;; Enemies without an explicit state observe in as :aware so
-  ;; legacy code paths stay backward compatible.
-  (is (= :aware (next-state {} false)))
-  (is (= :aware (next-state {} true))))
+  ;; legacy code paths stay backward compatible. From :aware they
+  ;; either chase (sees?) or fall into :hunting (!sees?).
+  (is (= :aware   (next-state {} {:sees? true  :at-lkp? false})))
+  (is (= :hunting (next-state {} {:sees? false :at-lkp? false}))))
 
 (deftest test-observe-wakes-dormant-on-los
   ;; Dormant enemy at (1.5, 1.5), player at (5.5, 5.5), open chamber.
@@ -105,11 +129,36 @@
         e' (observe e wall-between-pgrid 5.5 3.5)]
     (is (= :dormant (:state e')))))
 
-(deftest test-observe-aware-stays-aware-everywhere
-  ;; Sticky aware: even with no LOS the state holds.
-  (let [e  {:x 1.5 :y 3.5 :state :aware}
+(deftest test-observe-aware-loses-los-and-starts-hunting
+  ;; Player was in sight, now ducked behind a wall. observe transitions
+  ;; aware → hunting. The hunter will track toward :lkp on subsequent
+  ;; ticks (separate target-pos test).
+  (let [e  {:x 1.5 :y 3.5 :state :aware :lkp {:x 5.5 :y 3.5}}
         e' (observe e wall-between-pgrid 5.5 3.5)]
-    (is (= :aware (:state e')))))
+    (is (= :hunting (:state e')))))
+
+(deftest test-observe-refreshes-lkp-on-los
+  ;; Aware enemy with stale lkp; player visible at a new spot.
+  ;; observe must overwrite :lkp to the player's current cell.
+  (let [e  {:x 1.5 :y 1.5 :state :aware :lkp {:x 99.0 :y 99.0}}
+        e' (observe e open-pgrid 5.5 5.5)]
+    (is (= 5.5 (:x (:lkp e'))))
+    (is (= 5.5 (:y (:lkp e'))))))
+
+(deftest test-observe-freezes-lkp-without-los
+  ;; Hunter has a stale lkp; LOS still blocked. observe must NOT
+  ;; touch :lkp — that frozen breadcrumb IS the navigation target.
+  (let [e  {:x 1.5 :y 3.5 :state :hunting :lkp {:x 6.0 :y 3.5}}
+        e' (observe e wall-between-pgrid 5.5 3.5)]
+    (is (= 6.0 (:x (:lkp e'))))
+    (is (= 3.5 (:y (:lkp e'))))))
+
+(deftest test-observe-hunting-arrives-no-los-becomes-dormant
+  ;; Hunter standing right on top of its :lkp with no LOS gives up.
+  ;; Pin so the at-lkp? threshold logic doesn't silently drift.
+  (let [e  {:x 1.5 :y 3.5 :state :hunting :lkp {:x 1.5 :y 3.5}}
+        e' (observe e wall-between-pgrid 5.5 3.5)]
+    (is (= :dormant (:state e')))))
 
 ;; ---------------------------------------------------------------------
 ;; noise-wake: player fire flood-fills through floor cells. Dormant
@@ -153,12 +202,17 @@
    [1 0 0 0 2 0 0 1]
    [1 1 1 1 1 1 1 1]])
 
-(deftest test-noise-wake-flips-dormant-in-same-room
-  ;; Player at (2.5, 2.5), dormant imp at (5.5, 5.5). Open room, BFS
-  ;; reaches the imp's cell within radius → wakes.
-  (let [es  [(assoc {:x 5.5 :y 5.5 :alive true} :state :dormant)]
-        es' (noise-wake es open-room 2.5 2.5)]
-    (is (= :aware (:state (first es'))))))
+(deftest test-noise-wake-flips-dormant-to-hunting-in-same-room
+  ;; Player at (2.5, 2.5), dormant imp at (3.5, 3.5) — within 3-cell
+  ;; BFS. Imp HEARS but doesn't see, so it transitions to :hunting
+  ;; with `:lkp` stamped at the fire origin. Doesn't go straight to
+  ;; :aware: sound is a breadcrumb, not visual confirmation.
+  (let [es  [(assoc {:x 3.5 :y 3.5 :alive true} :state :dormant)]
+        es' (noise-wake es open-room 2.5 2.5)
+        e   (first es')]
+    (is (= :hunting (:state e)))
+    (is (= 2.5 (:x (:lkp e))))
+    (is (= 2.5 (:y (:lkp e))))))
 
 (deftest test-noise-wake-keeps-dormant-behind-wall
   ;; Wall column at x=4. Player on the left, imp on the right →
@@ -204,8 +258,46 @@
     (is (= :dormant (:state (php/aget es' 0))))
     (is (= :dormant (:state (php/aget es' 1))))))
 
-(deftest test-noise-wake-radius-default-is-reasonable
+(deftest test-noise-wake-radius-default-is-close-by
   ;; Pin the default radius so a future bump (e.g. louder shotgun)
-  ;; doesn't silently break test fixtures that assume room-sized
-  ;; coverage.
-  (is (= 6 noise-wake-radius)))
+  ;; doesn't silently flip the "close-by" feel back into "the whole
+  ;; sector". 3 cells = enemies directly adjacent / in the same small
+  ;; room hear the shot; further-away enemies stay dormant.
+  (is (= 3 noise-wake-radius)))
+
+;; ---------------------------------------------------------------------
+;; target-pos: where the chase step walks toward this tick. :aware
+;; targets the live player position; :hunting targets the frozen
+;; :lkp; :dormant returns nil so tick-one skips the step entirely.
+;; ---------------------------------------------------------------------
+
+(deftest test-target-pos-aware-tracks-player
+  (let [t (target-pos {:state :aware} 5.5 7.5)]
+    (is (= 5.5 (:x t)))
+    (is (= 7.5 (:y t)))))
+
+(deftest test-target-pos-hunting-tracks-lkp
+  (let [t (target-pos {:state :hunting :lkp {:x 3.0 :y 4.0}} 5.5 7.5)]
+    (is (= 3.0 (:x t)))
+    (is (= 4.0 (:y t)))))
+
+(deftest test-target-pos-hunting-without-lkp-falls-back-to-player
+  ;; Defensive: a hunter without lkp shouldn't wander the void. Fall
+  ;; back to player position so any movement-state stays harmless;
+  ;; the next observe tick will fix the state via at-lkp? = true.
+  (let [t (target-pos {:state :hunting} 5.5 7.5)]
+    (is (= 5.5 (:x t)))
+    (is (= 7.5 (:y t)))))
+
+(deftest test-target-pos-dormant-returns-nil
+  (is (= nil (target-pos {:state :dormant} 5.5 7.5))))
+
+;; ---------------------------------------------------------------------
+;; lkp-arrival-dist: tweakable threshold for "arrived at last known
+;; position". Pin so a refactor doesn't drift it down below stop-dist
+;; (which would leave hunters stuck oscillating).
+;; ---------------------------------------------------------------------
+
+(deftest test-lkp-arrival-dist-is-above-stop-dist
+  ;; stop-dist is 0.6 in enemy.phel — arrival must sit above it.
+  (is (php/> lkp-arrival-dist 0.6)))

--- a/tests/modules/core/enemy_ai_test.phel
+++ b/tests/modules/core/enemy_ai_test.phel
@@ -83,37 +83,43 @@
     (is (= false (sees-player? huge-pgrid 0.5 0.5 100.5 100.5)))))
 
 (deftest test-next-state-dormant-stays-dormant-without-los
-  (is (= :dormant (next-state {:state :dormant} {:sees? false :at-lkp? false}))))
+  (is (= :dormant (next-state {:state :dormant} false))))
 
 (deftest test-next-state-dormant-flips-aware-on-los
-  (is (= :aware (next-state {:state :dormant} {:sees? true :at-lkp? false}))))
+  (is (= :aware (next-state {:state :dormant} true))))
 
 (deftest test-next-state-aware-with-los-stays-aware
-  (is (= :aware (next-state {:state :aware} {:sees? true :at-lkp? false}))))
+  (is (= :aware (next-state {:state :aware} true))))
 
 (deftest test-next-state-aware-without-los-drops-to-hunting
   ;; Losing sight while aware kicks off the search: walk toward the
   ;; last seen position (:lkp) until LOS returns or you arrive.
-  (is (= :hunting (next-state {:state :aware} {:sees? false :at-lkp? false}))))
+  (is (= :hunting (next-state {:state :aware} false))))
 
 (deftest test-next-state-hunting-sees-flips-aware
   ;; LOS re-acquired during the search — go back to full chase.
-  (is (= :aware (next-state {:state :hunting} {:sees? true :at-lkp? false}))))
+  (is (= :aware (next-state {:state :hunting} true))))
 
 (deftest test-next-state-hunting-arrives-without-los-drops-dormant
   ;; Hunter reached the breadcrumb cell but still no LOS — gives up
-  ;; the chase and goes idle. Player got away clean.
-  (is (= :dormant (next-state {:state :hunting} {:sees? false :at-lkp? true}))))
+  ;; the chase and goes idle. Player got away clean. At-lkp? is
+  ;; implicit via `:lkp` matching the enemy position (or missing).
+  (is (= :dormant (next-state {:state :hunting :x 1.5 :y 1.5
+                               :lkp {:x 1.5 :y 1.5}}
+                              false))))
 
 (deftest test-next-state-hunting-still-searching-stays-hunting
-  (is (= :hunting (next-state {:state :hunting} {:sees? false :at-lkp? false}))))
+  ;; LKP is far from the enemy — still walking.
+  (is (= :hunting (next-state {:state :hunting :x 1.0 :y 1.0
+                               :lkp {:x 10.0 :y 10.0}}
+                              false))))
 
 (deftest test-next-state-missing-defaults-to-aware
   ;; Enemies without an explicit state observe in as :aware so
   ;; legacy code paths stay backward compatible. From :aware they
   ;; either chase (sees?) or fall into :hunting (!sees?).
-  (is (= :aware   (next-state {} {:sees? true  :at-lkp? false})))
-  (is (= :hunting (next-state {} {:sees? false :at-lkp? false}))))
+  (is (= :aware   (next-state {} true)))
+  (is (= :hunting (next-state {} false))))
 
 (deftest test-observe-wakes-dormant-on-los
   ;; Dormant enemy at (1.5, 1.5), player at (5.5, 5.5), open chamber.


### PR DESCRIPTION
## 📚 Description

Today: aware enemies laser-track the player's live position through walls — once they wake, you can't actually hide. Sound-wake radius (6 cells) also leaked into the next room.

This PR: enemies that lose line-of-sight stop tracking the live player. They walk to the **last cell where LOS was clear** (`:lkp`, last-known position), arrive, and — still without LOS — drop back to `:dormant`. Player can duck around a corner / behind a door and actually break contact.

Sound-wake radius tightened 6 → 3 cells so a gunshot wakes only enemies in the immediate surroundings, not the whole sector.

## 🔖 Changes

### Engine

- **New state `:hunting`** in `enemy-ai/state-spec`. `:moves?` true, `:attacks?` false — searching is not engaging, no contact damage during hunt.
- **`:lkp` slot** on enemy records. Refreshed by `observe` every frame LOS is clear; frozen the moment LOS drops.
- **`target-pos`** picks the walk target by state — `:aware` → player position, `:hunting` → `:lkp` (player-pos fallback), `:dormant` → nil. `tick-one` reads it directly; no state-fork in the call site.
- **`next-state`** signature now `[enemy obs]` where `obs = {:sees? :at-lkp?}`. Future inputs (heard-noise?, taking-pain?) slot in as map keys without changing call sites.
- **`noise-wake-radius` 6 → 3 cells**. Sound is now "close-by", not "the whole sector".
- **noise-wake transitions** changed: `:dormant + heard → :hunting` (lkp = fire origin), `:hunting + heard → refresh :lkp`, `:aware` unchanged. Sound is a breadcrumb, not visual confirmation.

### Transition matrix

| From       | Trigger                       | To         |
|------------|-------------------------------|------------|
| `:dormant` | LOS                           | `:aware`   |
| `:dormant` | Noise in radius               | `:hunting` (lkp = origin) |
| `:dormant` | Hit (shoot)                   | `:aware`   |
| `:aware`   | LOS                           | `:aware` (lkp refreshes) |
| `:aware`   | No LOS                        | `:hunting` (lkp frozen) |
| `:hunting` | LOS regained                  | `:aware`   |
| `:hunting` | Reached `:lkp`, no LOS        | `:dormant` (lost the scent) |
| `:hunting` | Still moving                  | `:hunting` |

### Hide flow

1. Aware monster chases, `:lkp` refreshing every frame.
2. Player ducks behind a wall → LOS drops → `:hunting`, `:lkp` freezes.
3. Hunter walks to frozen `:lkp`. Player keeps running.
4. Hunter arrives at `:lkp`. Still no LOS → `:dormant`. Clean break.

## 🧪 Test plan

- [x] `composer ci` — format, lint (0 errors), 892 tests, build (all green)
- [x] 21 new tests across `enemy_ai_test` / `enemy-test` / `combat-test` covering: `:hunting` flags, full transition matrix, observe lkp-refresh / freeze, observe `:hunting` arrives → dormant, `target-pos` per state, noise-wake stamps lkp + transitions to `:hunting`, `lkp-arrival-dist > stop-dist`, advance `:hunting` tracks `:lkp` not player.
- [x] 6 prior tests updated for new sound-wake radius + state expectations.
- [ ] Manual smoke: round a corner while an imp chases — confirm the imp walks to where you were, then idles back to dormant. Confirm a hallway gunshot doesn't wake the imp two rooms away.

## 🏗️ Still deferred

- `:pain` stagger (hit roll briefly freezes movement). Slots in as a new `state-spec` entry + one extra `next-state` clause without touching call sites.
- `:attacking` state (ranged windup → projectile / hitscan release). Adds attack profiles per type.
- `:wander` dormant variant (random patrol instead of sit still).