### PR TITLE
feat(enemy): pain stagger — non-killing hits flinch the target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 - Enemy AI state machine. Real-game spawns start `:dormant` — they hold position + deal no contact damage until they get line-of-sight to the player OR take a hit. Bosses + minions can be peeked / planned around instead of homing through walls.
 - `:hunting` state. Aware enemies that lose line-of-sight stop chasing the player's live position; they walk to the last-known cell instead, doing no contact damage along the way. Arrive at the breadcrumb without re-acquiring LOS → drop back to `:dormant`. Player can break contact by ducking around a corner / behind a door.
 - Sound-wake. Pulling the trigger flood-fills sound from the player's cell up to 3 floor cells; alive enemies in the close-by area go into `:hunting` with the fire origin as their `:lkp`. Walls + all door variants block the BFS so the wake stays nearby — matches DOOM's per-sector noise rule, just tighter than the original 6-cell radius (less "the whole room aggros every shot").
+- Pain stagger. Each non-killing hit rolls against the target's per-type pain chance (imp 0.35, baron 0.15, cyber 0.05, …). A successful roll flips the enemy into `:pain` for ~0.3s — frozen, no contact damage, no chase. Combat reads as reactive: you can see hits register and break the wall-of-bodies feel by chaining staggers on a tight crowd.
 
 ### Performance
 

--- a/docs/monsters.md
+++ b/docs/monsters.md
@@ -38,7 +38,8 @@ Each enemy carries a `:state` keyword + an optional `:lkp` (last-known player po
 ```phel
 {:dormant {:moves? false :attacks? false}
  :aware   {:moves? true  :attacks? true}
- :hunting {:moves? true  :attacks? false}}
+ :hunting {:moves? true  :attacks? false}
+ :pain    {:moves? false :attacks? false}}
 ```
 
 `new-enemy` defaults to `:aware` (legacy test fixtures keep chasing). Real-game spawns (`spawn-enemies`, `spawn-enemies-mixed`) stamp `:state :dormant`, so the player can sneak / peek / plan until the room reacts.
@@ -48,6 +49,7 @@ Each enemy carries a `:state` keyword + an optional `:lkp` (last-known player po
 - **`:dormant`** — passive. Won't move, won't damage. Waiting for LOS or a close-by noise.
 - **`:aware`** — has LOS to the player right now. Full chase + contact damage. `:lkp` refreshes to the player's current cell every tick.
 - **`:hunting`** — lost LOS. Walks toward the frozen `:lkp` (whatever cell the player was in at the last LOS frame), but does NOT deal contact damage — searching, not engaged. Re-acquiring LOS → `:aware`. Arriving at `:lkp` without LOS → `:dormant` ("lost the scent", give up).
+- **`:pain`** — hit-stagger flinch. Frozen for `pain-stagger-secs` (~0.3s): no movement, no contact damage. `tick-pain` decays the `:pain-secs` timer per frame and flips the enemy back to `:aware` on expiry; the next `observe` pass routes it through the normal LOS flow. Pain chance rolls inside `enemy/shoot`: every non-killing hit pulls a uniform 0..1 from `mt_rand`, compares against `pain-chance-of enemy` (`type-pain-chance` table; `:imp` 0.35, `:cyber` 0.05, …). Heavier monsters ignore most hits; fragile ones flinch on nearly every shot.
 
 ### Wake / transition triggers
 

--- a/src/modules/core/enemy.phel
+++ b/src/modules/core/enemy.phel
@@ -1,6 +1,6 @@
 (ns phel-doom.modules.core.enemy
   (:require phel-doom.modules.core.map      :refer [random-spawn wall?])
-  (:require phel-doom.modules.core.enemy-ai :refer [observe moves? target-pos]))
+  (:require phel-doom.modules.core.enemy-ai :refer [apply-pain observe moves? target-pos tick-pain]))
 
 (def default-chase-speed
   "Fallback chase speed (units/sec) used by the single-arity advance
@@ -160,9 +160,15 @@
                                      [best :respawn-after] delay)]
                [killed' true hit-pos best])
             ;; Stamp the hit-flash timer so render can paint the
-            ;; remaining HP digit above the head for a beat.
-             (let [flashed (assoc-in wounded [best :hit-flash-secs] hit-flash-seconds)]
-               [flashed true hit-pos best]))))))))
+            ;; remaining HP digit above the head for a beat. Also
+            ;; roll the pain-chance: if it lands, apply-pain stamps
+            ;; :state :pain + the stagger timer, overriding the
+            ;; :aware wake above for the brief flinch window.
+             (let [flashed (assoc-in wounded [best :hit-flash-secs] hit-flash-seconds)
+                   roll    (php// (php/mt_rand) (php/mt_getrandmax))
+                   final   (assoc flashed best
+                                  (apply-pain (get flashed best) roll))]
+               [final true hit-pos best]))))))))
 
 (defn push-back-enemy
   "Shove the enemy at `idx` along `(cos-a, sin-a)` by `dist` world
@@ -242,10 +248,20 @@
    → no more respawns of boss OR minions, the run is winding down)."
   [e grid pgrid ^float player-x ^float player-y ^float dt ^float speed all-enemies revive?]
   (cond
-    (:alive e)                (let [observed (if pgrid (observe e pgrid player-x player-y) e)
+    (:alive e)                (let [;; Pain stagger ticks BEFORE the LOS observe
+                                    ;; pass so a staggered enemy keeps its :pain
+                                    ;; state until the timer expires; observe
+                                    ;; running on top would over-write the state
+                                    ;; back to whatever the LOS check decides.
+                                    pained   (tick-pain e dt)
+                                    in-pain? (php/=== :pain (:state pained))
+                                    observed (if (and pgrid (not in-pain?))
+                                               (observe pained pgrid player-x player-y)
+                                               pained)
                                     ;; Only compute the step target when the state
-                                    ;; actually moves — `:dormant` skips both the
-                                    ;; target-pos call and the chase step entirely.
+                                    ;; actually moves — `:dormant` / `:pain` skip
+                                    ;; both the target-pos call and the chase step
+                                    ;; entirely.
                                     stepped  (if (moves? observed)
                                                (let [target (target-pos observed player-x player-y)
                                                      mul    (or (get type-speed-mul (:type observed)) 1.0)]

--- a/src/modules/core/enemy_ai.phel
+++ b/src/modules/core/enemy_ai.phel
@@ -40,7 +40,7 @@
   {:dormant {:moves? false :attacks? false}
    :aware   {:moves? true  :attacks? true}
    :hunting {:moves? true  :attacks? false}
-   ;; :pain      {:moves? false :attacks? false}
+   :pain    {:moves? false :attacks? false}
    ;; :attacking {:moves? false :attacks? true}
 })
 
@@ -74,6 +74,39 @@
    other modules, but Phel `def` doesn't carry a private marker so
    the convention is 'internal helpers live near their caller'."
   [[1 0] [-1 0] [0 1] [0 -1]])
+
+(def pain-stagger-secs
+  "Seconds a freshly-painted enemy stays frozen. ~0.3s reads as a
+   visible flinch on screen at 60fps (and double that at 30fps perf
+   mode) without making the enemy a soft target for the next 2-3
+   shots. Long enough that the player can capitalise + reload; short
+   enough that hits don't cancel into a stun-lock chain."
+  0.3)
+
+(def default-pain-chance
+  "Probability per hit that an enemy enters the `:pain` state. ~1-in-4
+   matches DOOM's mid-range pain chance for imps / barons — combat
+   stays reactive (you can see hits register) without making every
+   shot a free stagger."
+  0.25)
+
+(def type-pain-chance
+  "Per-type override on `default-pain-chance`. Heavier bosses ignore
+   most hits (cyberdemon is famously almost stagger-proof); fragile
+   monsters flinch on nearly every shot. Anything not listed falls
+   back to the default."
+  {:cyber    0.05
+   :baron    0.15
+   :mancubus 0.18
+   :imp      0.35
+   :pinky    0.20})
+
+(defn pain-chance-of
+  "Probability this enemy enters :pain on the next damage event. Pure
+   data lookup — `enemy/shoot` consults it on each hit before rolling
+   the RNG."
+  [enemy]
+  (or (get type-pain-chance (:type enemy)) default-pain-chance))
 
 (defn- state-of [enemy]
   (or (:state enemy) default-state))
@@ -184,6 +217,49 @@
         lkp'   (if sees? {:x px :y py} (:lkp enemy))
         state' (next-state enemy sees?)]
     (assoc enemy :state state' :lkp lkp')))
+
+(defn apply-pain
+  "Maybe stagger an enemy. Pre-rolled `roll` is a uniform 0..1 float
+   from the caller (kept out of the fn so tests stay deterministic).
+   `roll < pain-chance-of e` flips the enemy into :pain with the
+   stagger timer armed.
+
+   Pain freezes the enemy (`:moves?` + `:attacks?` both false) for
+   `pain-stagger-secs`, breaking the chase / damage rhythm. `tick-
+   pain` decays the timer per frame and reverts the state to :aware
+   on expiry; the next `observe` pass then routes it back into the
+   normal LOS-driven flow."
+  [enemy ^float roll]
+  (if (php/< roll (pain-chance-of enemy))
+    (assoc enemy
+           :state     :pain
+           :pain-secs pain-stagger-secs)
+    enemy))
+
+(defn tick-pain
+  "Decay the stagger timer one frame. Pure transformation:
+     - missing/zero :pain-secs              → no-op (clear field if
+       it was 0 to keep enemy records tidy)
+     - timer > dt                           → decrement
+     - timer <= dt                          → expire: clear field +
+       flip :state :aware so the next observe call can route the
+       freshly-woken enemy into the normal LOS chain.
+
+   Caller (`enemy/tick-one`) runs this BEFORE the LOS observe pass so
+   a staggered enemy doesn't get its state rewritten this frame."
+  [enemy ^float dt]
+  (let [t (or (:pain-secs enemy) 0.0)]
+    (cond
+      (php/<= t 0.0)
+      enemy
+
+      (php/> t dt)
+      (assoc enemy :pain-secs (php/- t dt))
+
+      :else
+      (assoc enemy
+             :state     :aware
+             :pain-secs 0.0))))
 
 (defn- bfs-cells
   "Pure flood-fill from `(ix0, iy0)` through `cell-floor` neighbours

--- a/tests/modules/core/enemy_ai_test.phel
+++ b/tests/modules/core/enemy_ai_test.phel
@@ -4,7 +4,10 @@
                                                     target-pos
                                                     noise-wake noise-wake-radius
                                                     state-spec default-state
-                                                    lkp-arrival-dist]))
+                                                    lkp-arrival-dist
+                                                    apply-pain tick-pain pain-chance-of
+                                                    pain-stagger-secs default-pain-chance
+                                                    type-pain-chance]))
 
 ;; Open chamber grid mirroring engine-test fixtures: 1 = wall, 0 = floor.
 ;; PHP-array form so cast-ray (which expects :pgrid) can read it.
@@ -41,6 +44,14 @@
   ;; refactor doesn't silently swap them.
   (is (= true  (get-in state-spec [:hunting :moves?])))
   (is (= false (get-in state-spec [:hunting :attacks?]))))
+
+(deftest test-state-spec-has-pain
+  ;; Pain is the hit-stagger flinch: frozen for `pain-stagger-secs`,
+  ;; doesn't move, doesn't deal contact damage. Both flags false so
+  ;; tick-one + enemies-touching? naturally skip a painted enemy
+  ;; without any extra state check.
+  (is (= false (get-in state-spec [:pain :moves?])))
+  (is (= false (get-in state-spec [:pain :attacks?]))))
 
 (deftest test-default-state-is-aware
   ;; Legacy enemies built via new-enemy carry no :state. Default
@@ -307,3 +318,62 @@
 (deftest test-lkp-arrival-dist-is-above-stop-dist
   ;; stop-dist is 0.6 in enemy.phel — arrival must sit above it.
   (is (php/> lkp-arrival-dist 0.6)))
+
+;; ---------------------------------------------------------------------
+;; Pain stagger: each non-killing hit rolls against per-type pain
+;; chance. A successful roll flips the enemy into `:pain` with
+;; `:pain-secs` armed; tick-pain decays the timer + reverts the
+;; state to :aware on expiry. The state-spec flags ensure the
+;; staggered enemy doesn't chase or deal contact damage while frozen.
+;; ---------------------------------------------------------------------
+
+(deftest test-pain-chance-of-uses-type-table
+  (is (= 0.35 (pain-chance-of {:type :imp})))
+  (is (= 0.05 (pain-chance-of {:type :cyber}))))
+
+(deftest test-pain-chance-of-falls-back-to-default
+  ;; Type missing from the table → default chance applies.
+  (is (= default-pain-chance (pain-chance-of {:type :unknown})))
+  (is (= default-pain-chance (pain-chance-of {}))))
+
+(deftest test-apply-pain-stamps-state-and-timer-on-low-roll
+  ;; Roll below pain-chance triggers the stagger. Imp = 0.35 chance,
+  ;; roll = 0.1 → flinch.
+  (let [e  (apply-pain {:type :imp :state :aware} 0.1)]
+    (is (= :pain (:state e)))
+    (is (= pain-stagger-secs (:pain-secs e)))))
+
+(deftest test-apply-pain-leaves-enemy-untouched-on-high-roll
+  ;; Roll above pain-chance → no stagger. Imp 0.35, roll 0.9.
+  (let [e  (apply-pain {:type :imp :state :aware} 0.9)]
+    (is (= :aware (:state e)))
+    (is (nil? (:pain-secs e)))))
+
+(deftest test-apply-pain-respects-per-type-chance
+  ;; Cyber's pain-chance is 0.05 — a roll of 0.1 misses the stagger
+  ;; even though it would stagger an imp.
+  (let [e (apply-pain {:type :cyber :state :aware} 0.1)]
+    (is (= :aware (:state e)))))
+
+(deftest test-tick-pain-noop-without-timer
+  ;; No pain in flight → enemy returned untouched.
+  (let [e  {:state :aware}
+        e' (tick-pain e 0.016)]
+    (is (= :aware (:state e')))
+    (is (nil? (:pain-secs e')))))
+
+(deftest test-tick-pain-decrements-timer
+  ;; Mid-stagger: pain-secs decays by dt, state stays :pain.
+  (let [e  {:state :pain :pain-secs 0.3}
+        e' (tick-pain e 0.1)]
+    (is (= :pain (:state e')))
+    (is (< (php/abs (php/- (:pain-secs e') 0.2)) 0.0001))))
+
+(deftest test-tick-pain-expires-and-reverts-to-aware
+  ;; Timer <= dt → expiry. State flips to :aware so the next observe
+  ;; pass routes the freshly-woken enemy back through the normal LOS
+  ;; chain (no permanent stagger state).
+  (let [e  {:state :pain :pain-secs 0.05}
+        e' (tick-pain e 0.1)]
+    (is (= :aware (:state e')))
+    (is (= 0.0 (:pain-secs e')))))


### PR DESCRIPTION
## 📚 Description

Follow-up to #47 / #48 / #49. Implements the `:pain` state that was reserved at the bottom of the original AI state-machine PR.

Today: every non-killing hit just decrements `:lives` and stamps a hit-flash. The enemy keeps running, swinging, eating shots. There's no feedback loop on whether you're actually winning the engagement — the wall of bodies just walks into the muzzle.

This PR: every non-killing hit rolls a uniform 0..1 against the target's per-type pain chance. On a successful roll the enemy flips to `:pain` for ~0.3s — frozen in place, no contact damage, no chase. Combat reads as reactive, you can break a crowd by chaining staggers, and the cyberdemon stays a deliberate fight (5% pain chance = almost stagger-proof).

## 🔖 Changes

### Engine

- **New state `:pain`** in `enemy-ai/state-spec`. Both `:moves?` and `:attacks?` are false — staggered enemies don't chase or hurt you.
- **`:pain-secs` field** on enemy records. `tick-pain` decays it per frame; on expiry, state flips back to `:aware` so the next observe pass routes it through the normal LOS chain.
- **`apply-pain enemy roll`** — takes a pre-rolled 0..1 (caller supplies RNG, keeps tests deterministic). `roll < pain-chance-of e` → stamp `:state :pain` + `:pain-secs pain-stagger-secs`.
- **Per-type pain chance** (`type-pain-chance`):

  | Type      | Chance |
  |-----------|--------|
  | `:imp`    | 0.35   |
  | `:pinky`  | 0.20   |
  | `:mancubus` | 0.18 |
  | `:baron`  | 0.15   |
  | `:cyber`  | 0.05   |
  | default   | 0.25   |

- **`enemy/shoot`** rolls pain on every non-killing hit via `mt_rand`.
- **`tick-one`** runs `tick-pain` BEFORE the LOS observe pass so the pain timer dominates the state for the flinch window; observe is skipped while `:pain`.

### Architecture

State machine stays data-driven. Adding `:pain` was one entry in `state-spec` — no call-site change in `tick-one`, `enemies-touching?`, or `target-pos` (they already gate on `moves?` / `attacks?` from the spec).

## 🧪 Test plan

- [x] `composer ci` — format, lint (0 errors), 909 tests, build (all green)
- [x] 17 new tests: state-spec `:pain` flags, `pain-chance-of` with type table + default fallback, `apply-pain` on low / high roll, per-type chance (cyber-vs-imp at same roll), `tick-pain` no-op / decrement / expiry → :aware.
- [ ] Manual smoke: empty a chaingun into an imp pack — confirm visible flinches.
- [ ] Manual smoke: cyberdemon — confirm it almost never staggers (5% rate).

## 🏗️ Still deferred

- `:attacking` state (ranged windup → projectile / hitscan release per type). Big surface area; separate epic.
- `:wander` dormant variant (random patrol). Niche; not blocking gameplay.