### PR TITLE
fix(render): start menu gray borders on dim-attribute rows

### DIFF
--- a/src/modules/io/render.phel
+++ b/src/modules/io/render.phel
@@ -2821,16 +2821,19 @@
   "Right-pad `text` with spaces so its visible width (ignoring ANSI
    escapes, counting wide chars correctly) hits `width`.
 
-   Items typically end with an internal `\\e[0m` that resets every SGR
-   attribute, including the menu's dark BG. Re-apply `\\e[40;97m`
-   before the padding so trailing spaces stay on the menu's dark
-   wash; otherwise the gap between the item and the right `│` shows
-   through as default terminal BG."
+   Items typically end with an internal `\\e[40;97m` (or `\\e[0m`)
+   that resets BG + FG. The `22` in the trailing reset also clears
+   any sticky intensity attribute — `\\e[2;97m` (dim) sets bit `2`
+   which `\\e[40;97m` alone does NOT cancel, so without the `22` the
+   trailing pad spaces and the closing `│` border inherit the dim
+   wash and read as gray. Re-applies `\\e[40;97m` (with `22` for
+   intensity-normal) before the padding so trailing spaces stay on
+   the menu's dark BG at full brightness."
   [text width]
   (let [stripped (php/preg_replace "/\\x1b\\[[0-9;]*[a-zA-Z]/" "" text)
         visible  (php/mb_strwidth stripped)
         pad      (php/str_repeat " " (php/max 0 (php/- width visible)))]
-    (str text "\e[40;97m" pad)))
+    (str text "\e[22;40;97m" pad)))
 
 (defn- start-menu-rows
   "Interior strings for the start-menu box. `:sep` markers between


### PR DESCRIPTION
## 📚 Description

Same SGR-stickiness bug as #46's keys/buffs fix, surfaced on the welcome screen. Rows containing `\e[2;97m` (dim) — `// crafted by Chemaclass`, `press any key to start`, `resize terminal for full menu` — rendered with gray right borders because `pad-visible` re-applied `\e[40;97m` (BG + FG) but didn't clear the `2` intensity attribute.

## 🔖 Changes

- `pad-visible` now emits `\e[22;40;97m` (intensity-normal + BG + FG) before the trailing pad spaces. Single change covers every start-menu row plus anything else routed through the helper.

## 🧪 Test plan

- [x] `composer ci` — 953 tests pass, 0 lint errors, format clean
- [x] Piped `echo q | phel run play` — visually confirmed `\e[22;40;97m` follows every `\e[2;97m` segment now, no more dim bleed before the closing `│`.