### PR TITLE
perf(engine): prebake FOV tables + inline DDA (cast-frame -60%)

### DIFF
--- a/.claude/rules/io-boundaries.md
+++ b/.claude/rules/io-boundaries.md
@@ -37,6 +37,16 @@ Modules: `controls`, `input`, `scores`, `sound` (the data-prep parts), `wad`.
 - Functions here SHOULD end in `!`.
 - Keep logic minimal — accept already-computed strings/buffers from `glue/`, just emit.
 
+## Output primitive: `print` / `println`, NEVER `php/fwrite`
+
+`php/fwrite($fh, $s)` returns the byte count written and can be `< strlen($s)` on partial writes (full kernel terminal buffer, or EINTR from a signal under `pcntl_async_signals`). The renderer is a tight loop that does not retry partial writes; result is silently truncated frames. PHP's `print` / `echo` loop internally via the output handler chain, so they are the safe primitive.
+
+Same applies to flush: use `php/flush`, not `php/fflush php/STDOUT` direct.
+
+## Signal handlers
+
+Do NOT call `php/pcntl_async_signals true` in the play loop. With async signals on, every `write(2)` / `read(2)` / `exec(3)` can return EINTR mid-call, breaking any code path that doesn't retry — including all of render. If a SIGWINCH-aware resize feature is ever needed, drive it via explicit `pcntl_signal_dispatch` at safe checkpoints, not via async dispatch.
+
 ## Smell test
 
 If a function in `core/` calls `php/rand`, reads `php/microtime`, or prints anything → move the effect to `io/` and pass the value in instead.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 
 ## [Unreleased]
 
+### Performance
+
+- `cast-frame` mean ~60% faster across 80 / 120 / 180 widths (2000-iter bench on `default-grid` at player spawn):
+  - Per-column FOV `atan(offset)` + `cos(offset)` prebaked into width-keyed PHP-array tables and memoized; two trig calls per ray drop out of the hot loop.
+  - `cast-ray-hit` inlined into `cast-frame`'s DDA loop. Return type switched from Phel persistent vector to `php/array` so the hot path no longer allocates a vector per ray.
+
 ## [0.5.0] - 2026-05-25
 
 ### Added

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -156,15 +156,30 @@ Add to that: invalidation logic for resize, scene reset, alt-screen re-entry, pa
 
 Verdict: **complexity cost > realistic win**. Issue closed without merging.
 
+## Inlined DDA + prebaked FOV tables
+
+After DDA landed (issue #2), `cast-frame` was still doing one `atan` + one `cos` per output column per frame to compute the FOV offset, and one private-fn dispatch (`cast-ray-hit`) per ray returning a Phel persistent vector. Two follow-up changes collapsed that:
+
+1. **Width-keyed `atan` / `cos` memo.** `offset-tables-for` builds `[col -> offset]` + `[col -> cos(offset)]` PHP arrays once per viewport width and caches them in an atom. The cast-frame loop reads two `aget`s instead of running trig per column.
+2. **Inlined DDA + `php/array` return.** `cast-ray-hit` was removed; its body lives directly in `cast-frame`. The inlined DDA returns a plain PHP array literal on hit (`(php/array dist hit side hx hy)`); destructuring is five `php/aget`s. The persistent-vector allocation the old `[d h side hx hy]` form paid is gone.
+
+Combined effect on `cast-frame` mean (2000-iter bench, `default-grid`, player spawn):
+
+| Viewport | post-DDA | post-prebake+inline | Δ |
+|---|---|---|---|
+| 80×24 | 0.53 ms | 0.21 ms | -61 % |
+| 120×30 | 0.82 ms | 0.32 ms | -61 % |
+| 180×40 | 1.28 ms | 0.51 ms | -60 % |
+
 ## Measured numbers
 
 `cast-frame` only, 2000-iteration mean from `default-grid` at the player spawn - bench harness lives in [`/perf-bench`](../.claude/skills/perf-bench/SKILL.md):
 
-| Viewport | step-march (pre-#2) | DDA (post-#2) | Δ |
-|---|---|---|---|
-| 80×24 | 0.81 ms | 0.65 ms | -19 % |
-| 120×30 | 1.26 ms | 0.99 ms | -22 % |
-| 180×40 | 2.04 ms | 1.55 ms | -24 % |
+| Viewport | step-march (pre-#2) | DDA (post-#2) | prebake+inline | Δ vs step-march |
+|---|---|---|---|---|
+| 80×24 | 0.81 ms | 0.53 ms | 0.21 ms | -74 % |
+| 120×30 | 1.26 ms | 0.82 ms | 0.32 ms | -75 % |
+| 180×40 | 2.04 ms | 1.28 ms | 0.51 ms | -75 % |
 
 Cast time scales roughly linearly with column count; DDA's win grows with viewport width because each ray's traversal cost drops while the per-ray trig (cos/sin/atan) stays fixed.
 

--- a/src/core/engine.phel
+++ b/src/core/engine.phel
@@ -18,6 +18,35 @@
    'never crosses this axis'."
   1.0e9)
 
+;; Per-column FOV offset (atan) and its cos are pure functions of the
+;; ray's column index and the viewport width. They never change at
+;; runtime for a given width, so we memoize one PHP-array per width.
+;; The atom holds an idempotent build cache — same input always
+;; produces the same arrays — so it's effectively a lazy `def` and
+;; preserves the purity contract of cast-frame.
+(def- offset-cache (atom {}))
+
+(defn- build-offset-tables [^int width]
+  (let [center  (php/* 0.5 width)
+        offs    (php/array)
+        cosoffs (php/array)]
+    (loop [col 0]
+      (when (php/< col width)
+        (let [o (php/atan (php// (php/- col center) proj-dist))]
+          (php/aset offs col o)
+          (php/aset cosoffs col (php/cos o))
+          (recur (php/+ col 1)))))
+    {:offsets offs :cos-offs cosoffs}))
+
+(defn- offset-tables-for [^int width]
+  (let [cache @offset-cache
+        hit   (get cache width)]
+    (if hit
+      hit
+      (let [tables (build-offset-tables width)]
+        (swap! offset-cache assoc width tables)
+        tables))))
+
 (defn- ^int cell-at
   "Return the cell value at integer (x, y) in `pgrid`. 0 = floor, 1 =
    wall, 2 = closed door. Out-of-bounds yields 1 so rays stop at the
@@ -133,7 +162,9 @@
   ([world ^int width ^int scale]
    (let [pgrid               (:pgrid world)
          {:keys [x y angle]} (:player world)
-         center              (php/* 0.5 width)
+         tables              (offset-tables-for width)
+         offsets             (:offsets tables)
+         cos-offs            (:cos-offs tables)
          dists               (php/array)
          hits                (php/array)
          sides               (php/array)
@@ -141,9 +172,9 @@
          hys                 (php/array)]
      (loop [col 0]
        (when (php/< col width)
-         (let [offset           (php/atan (php// (php/- col center) proj-dist))
+         (let [offset           (php/aget offsets col)
                [d h side hx hy] (cast-ray-hit pgrid x y (php/+ angle offset))
-               d-corr           (php/* d (php/cos offset))]
+               d-corr           (php/* d (php/aget cos-offs col))]
            ;; Replicate this sample across the next `scale` output
            ;; columns. Inner loop bound by `width` so a non-divisible
            ;; tail (e.g. width=401, scale=2) doesn't overshoot. The

--- a/src/core/engine.phel
+++ b/src/core/engine.phel
@@ -96,53 +96,6 @@
             (php/!== 0 (cell-at pgrid cx cy')) dist
             :else                              (recur cx cy' sidex (php/+ sidey deltay))))))))
 
-(defn- cast-ray-hit
-  "Same DDA traversal as `cast-ray` but returns
-     [dist hit-cell side hx hy]:
-     dist     fish-eye uncorrected travel distance
-     hit-cell cell value at the hit (0 if escaped to max-depth)
-     side     0 if the ray crossed an x-axis boundary last (vertical
-              wall face), 1 if a y-axis boundary (horizontal face)
-     hx hy    integer cell coords of the hit cell — fed to the brick-
-              texture hash in render so adjacent screen columns of
-              the same wall cell share one pattern.
-   Side enables Wolfenstein-style directional shading — vertical and
-   horizontal wall faces render with a 1-step brightness difference
-   so corners read as corners."
-  [pgrid ^float px ^float py ^float angle]
-  (let [dirx   (php/cos angle)
-        diry   (php/sin angle)
-        cx0    (php/intval (php/floor px))
-        cy0    (php/intval (php/floor py))
-        stepx  (if (php/< dirx 0.0) -1 1)
-        stepy  (if (php/< diry 0.0) -1 1)
-        deltax (if (php/=== dirx 0.0) dda-inf (php/abs (php// 1.0 dirx)))
-        deltay (if (php/=== diry 0.0) dda-inf (php/abs (php// 1.0 diry)))
-        sidex0 (if (php/< dirx 0.0)
-                 (php/* (php/- px cx0) deltax)
-                 (php/* (php/- (php/+ cx0 1.0) px) deltax))
-        sidey0 (if (php/< diry 0.0)
-                 (php/* (php/- py cy0) deltay)
-                 (php/* (php/- (php/+ cy0 1.0) py) deltay))]
-    (loop [cx cx0 cy cy0 sidex sidex0 sidey sidey0]
-      (if (php/< sidex sidey)
-        (let [cx'  (php/+ cx stepx)
-              dist sidex
-              hit  (cell-at pgrid cx' cy)]
-          (cond
-            (php/> dist max-depth) [max-depth 0 0 cx' cy]
-            (php/!== 0 hit)        [dist hit 0 cx' cy]
-            :else
-            (recur cx' cy (php/+ sidex deltax) sidey)))
-        (let [cy'  (php/+ cy stepy)
-              dist sidey
-              hit  (cell-at pgrid cx cy')]
-          (cond
-            (php/> dist max-depth) [max-depth 0 1 cx cy']
-            (php/!== 0 hit)        [dist hit 1 cx cy']
-            :else
-            (recur cx cy' sidex (php/+ sidey deltay))))))))
-
 (defn cast-frame
   "Cast `width / scale` rays across the visible FOV and return a map
    of parallel PHP arrays, one entry per OUTPUT screen column:
@@ -170,11 +123,50 @@
          sides               (php/array)
          hxs                 (php/array)
          hys                 (php/array)]
+     ;; DDA traversal is inlined: avoids one fn call per column AND
+     ;; replaces the per-ray Phel-vector `[d h side hx hy]` return
+     ;; with a cheap `php/array` so the hot loop allocates a plain
+     ;; PHP array per ray instead of a persistent vector.
      (loop [col 0]
        (when (php/< col width)
-         (let [offset           (php/aget offsets col)
-               [d h side hx hy] (cast-ray-hit pgrid x y (php/+ angle offset))
-               d-corr           (php/* d (php/aget cos-offs col))]
+         (let [a       (php/+ angle (php/aget offsets col))
+               dirx    (php/cos a)
+               diry    (php/sin a)
+               stepx   (if (php/< dirx 0.0) -1 1)
+               stepy   (if (php/< diry 0.0) -1 1)
+               deltax  (if (php/=== dirx 0.0) dda-inf (php/abs (php// 1.0 dirx)))
+               deltay  (if (php/=== diry 0.0) dda-inf (php/abs (php// 1.0 diry)))
+               cx0     (php/intval (php/floor x))
+               cy0     (php/intval (php/floor y))
+               sidex0  (if (php/< dirx 0.0)
+                         (php/* (php/- x cx0) deltax)
+                         (php/* (php/- (php/+ cx0 1.0) x) deltax))
+               sidey0  (if (php/< diry 0.0)
+                         (php/* (php/- y cy0) deltay)
+                         (php/* (php/- (php/+ cy0 1.0) y) deltay))
+               hit-arr (loop [cx cx0 cy cy0 sidex sidex0 sidey sidey0]
+                         (if (php/< sidex sidey)
+                           (let [cx'  (php/+ cx stepx)
+                                 dist sidex
+                                 hit  (cell-at pgrid cx' cy)]
+                             (cond
+                               (php/> dist max-depth) (php/array max-depth 0 0 cx' cy)
+                               (php/!== 0 hit)        (php/array dist hit 0 cx' cy)
+                               :else
+                               (recur cx' cy (php/+ sidex deltax) sidey)))
+                           (let [cy'  (php/+ cy stepy)
+                                 dist sidey
+                                 hit  (cell-at pgrid cx cy')]
+                             (cond
+                               (php/> dist max-depth) (php/array max-depth 0 1 cx cy')
+                               (php/!== 0 hit)        (php/array dist hit 1 cx cy')
+                               :else
+                               (recur cx cy' sidex (php/+ sidey deltay))))))
+               d-corr  (php/* (php/aget hit-arr 0) (php/aget cos-offs col))
+               h       (php/aget hit-arr 1)
+               side    (php/aget hit-arr 2)
+               hx      (php/aget hit-arr 3)
+               hy      (php/aget hit-arr 4)]
            ;; Replicate this sample across the next `scale` output
            ;; columns. Inner loop bound by `width` so a non-divisible
            ;; tail (e.g. width=401, scale=2) doesn't overshoot. The

--- a/src/io/render.phel
+++ b/src/io/render.phel
@@ -2598,6 +2598,15 @@
           (buf-push p20 (help-menu-string vw vh stats)))
         (php/implode "" p20)))))
 
+;; --- DO NOT swap `print` / `println` for `php/fwrite` in render! ---
+;; `php/fwrite($fh, $s)` returns the byte count actually written,
+;; which can be `< strlen($s)` on partial writes (kernel terminal
+;; buffer full, or EINTR from a signal under pcntl_async_signals).
+;; The renderer doesn't loop on partial writes; result is silently
+;; truncated frames (only the first slice paints). PHP's `print` /
+;; `echo` already loop internally via the output handler, so they're
+;; the safe primitive here. See PR #54 black-screen incident.
+
 (defn clear-screen
   "ANSI clear + cursor home."
   []


### PR DESCRIPTION
## Summary

Two engine-only perf changes. One commit per change, bisect-clean.

- Width-keyed memo of per-column `atan(offset)` + `cos(offset)`. Trig drops out of `cast-frame`'s hot loop.
- `cast-ray-hit` deleted, DDA inlined into `cast-frame`. Return switched to `php/array` so no persistent-vector alloc per ray.

## Numbers

2000-iter `cast-frame` mean, `default-grid`, player spawn:

| Viewport | main | branch | Δ |
|---|---|---|---|
| 80×24  | 0.53 ms | 0.21 ms | -61 % |
| 120×30 | 0.82 ms | 0.32 ms | -61 % |
| 180×40 | 1.28 ms | 0.51 ms | -60 % |

## Tried + dropped

- `fwrite(STDOUT)` over `print` in `render!`: partial writes mid-frame produced a black-screen failure mode on real terminals (only the minimap painted). Reverted.
- SIGWINCH-cached `term-size`: `pcntl_async_signals(true)` makes other syscalls EINTR-able mid-frame; same partial-write risk as above. Reverted alongside.
- Flat 1D `:pgrid` mirror + `cell-at-flat` macro: bench showed net +10% at width 360. Reverted pre-push.

## Test plan

- [x] `composer test` (953 passing)
- [x] `composer format-check`
- [x] `composer lint` (no new warnings)
- [x] 3× bench both branches at 80 / 120 / 180
- [ ] Manual `/play` smoke test