### PR TITLE
ref(lint): drop redundant multi-arity wrappers (shadowed-binding clean)

### DIFF
--- a/src/core/enemy.phel
+++ b/src/core/enemy.phel
@@ -329,23 +329,19 @@
    tick their respawn timer and rejoin the fight once it expires
    (unless their `:max-concurrent` cap is already met — see tick-one).
 
-   The optional `pgrid` slot is the PHP-array grid mirror the AI
-   uses for line-of-sight raycasts. Real game callers pass it from
-   the world (`:pgrid`); test callers may omit it (legacy 6/7-arity
-   forms below), in which case the AI observation pass is skipped
-   and enemies behave per their existing :state — default :aware →
-   they chase as before, so old tests don't churn.
+   The 7-arity form skips the LOS pass (`pgrid` defaults to nil) so
+   test callers don't have to build a PHP-array grid mirror; the AI
+   then falls through to the enemy's existing `:state` (default
+   `:aware` → they chase as before).
 
-   The 7-arity opt-in `revive?` flag, when false, freezes every dead
-   enemy in place — used on L10 once the boss is down so neither the
-   cyberdemon nor its capped minions ever come back."
-  ([enemies grid player-x player-y dt speed]
-   (advance enemies grid nil player-x player-y dt speed true))
+   `revive?`, when false, freezes every dead enemy in place — used on
+   L10 once the boss is down so neither the cyberdemon nor its capped
+   minions ever come back."
   ([enemies grid player-x player-y dt speed revive?]
    (advance enemies grid nil player-x player-y dt speed revive?))
-  ([es g pg x y delta sp revive?]
+  ([es g pg x y delta sp rev?]
    (apply vector
-          (map (fn [e] (tick-one e g pg x y delta sp es revive?))
+          (map (fn [e] (tick-one e g pg x y delta sp es rev?))
                es))))
 
 (def scare-trigger-dist

--- a/src/core/engine.phel
+++ b/src/core/engine.phel
@@ -111,62 +111,61 @@
    render at half the cast cost with a chunkier per-block look.
    Sprites + HUD remain at full vw because they read these arrays
    by column index and overlay independently."
-  ([world ^int width] (cast-frame world width 1))
-  ([world ^int width ^int scale]
-   (let [pgrid               (:pgrid world)
-         {:keys [x y angle]} (:player world)
-         tables              (offset-tables-for width)
-         offsets             (:offsets tables)
-         cos-offs            (:cos-offs tables)
-         dists               (php/array)
-         hits                (php/array)
-         sides               (php/array)
-         hxs                 (php/array)
-         hys                 (php/array)]
+  [world ^int width ^int scale]
+  (let [pgrid               (:pgrid world)
+        {:keys [x y angle]} (:player world)
+        tables              (offset-tables-for width)
+        offsets             (:offsets tables)
+        cos-offs            (:cos-offs tables)
+        dists               (php/array)
+        hits                (php/array)
+        sides               (php/array)
+        hxs                 (php/array)
+        hys                 (php/array)]
      ;; DDA traversal is inlined: avoids one fn call per column AND
      ;; replaces the per-ray Phel-vector `[d h side hx hy]` return
      ;; with a cheap `php/array` so the hot loop allocates a plain
      ;; PHP array per ray instead of a persistent vector.
-     (loop [col 0]
-       (when (php/< col width)
-         (let [a       (php/+ angle (php/aget offsets col))
-               dirx    (php/cos a)
-               diry    (php/sin a)
-               stepx   (if (php/< dirx 0.0) -1 1)
-               stepy   (if (php/< diry 0.0) -1 1)
-               deltax  (if (php/=== dirx 0.0) dda-inf (php/abs (php// 1.0 dirx)))
-               deltay  (if (php/=== diry 0.0) dda-inf (php/abs (php// 1.0 diry)))
-               cx0     (php/intval (php/floor x))
-               cy0     (php/intval (php/floor y))
-               sidex0  (if (php/< dirx 0.0)
-                         (php/* (php/- x cx0) deltax)
-                         (php/* (php/- (php/+ cx0 1.0) x) deltax))
-               sidey0  (if (php/< diry 0.0)
-                         (php/* (php/- y cy0) deltay)
-                         (php/* (php/- (php/+ cy0 1.0) y) deltay))
-               hit-arr (loop [cx cx0 cy cy0 sidex sidex0 sidey sidey0]
-                         (if (php/< sidex sidey)
-                           (let [cx'  (php/+ cx stepx)
-                                 dist sidex
-                                 hit  (cell-at pgrid cx' cy)]
-                             (cond
-                               (php/> dist max-depth) (php/array max-depth 0 0 cx' cy)
-                               (php/!== 0 hit)        (php/array dist hit 0 cx' cy)
-                               :else
-                               (recur cx' cy (php/+ sidex deltax) sidey)))
-                           (let [cy'  (php/+ cy stepy)
-                                 dist sidey
-                                 hit  (cell-at pgrid cx cy')]
-                             (cond
-                               (php/> dist max-depth) (php/array max-depth 0 1 cx cy')
-                               (php/!== 0 hit)        (php/array dist hit 1 cx cy')
-                               :else
-                               (recur cx cy' sidex (php/+ sidey deltay))))))
-               d-corr  (php/* (php/aget hit-arr 0) (php/aget cos-offs col))
-               h       (php/aget hit-arr 1)
-               side    (php/aget hit-arr 2)
-               hx      (php/aget hit-arr 3)
-               hy      (php/aget hit-arr 4)]
+    (loop [col 0]
+      (when (php/< col width)
+        (let [a       (php/+ angle (php/aget offsets col))
+              dirx    (php/cos a)
+              diry    (php/sin a)
+              stepx   (if (php/< dirx 0.0) -1 1)
+              stepy   (if (php/< diry 0.0) -1 1)
+              deltax  (if (php/=== dirx 0.0) dda-inf (php/abs (php// 1.0 dirx)))
+              deltay  (if (php/=== diry 0.0) dda-inf (php/abs (php// 1.0 diry)))
+              cx0     (php/intval (php/floor x))
+              cy0     (php/intval (php/floor y))
+              sidex0  (if (php/< dirx 0.0)
+                        (php/* (php/- x cx0) deltax)
+                        (php/* (php/- (php/+ cx0 1.0) x) deltax))
+              sidey0  (if (php/< diry 0.0)
+                        (php/* (php/- y cy0) deltay)
+                        (php/* (php/- (php/+ cy0 1.0) y) deltay))
+              hit-arr (loop [cx cx0 cy cy0 sidex sidex0 sidey sidey0]
+                        (if (php/< sidex sidey)
+                          (let [cx'  (php/+ cx stepx)
+                                dist sidex
+                                hit  (cell-at pgrid cx' cy)]
+                            (cond
+                              (php/> dist max-depth) (php/array max-depth 0 0 cx' cy)
+                              (php/!== 0 hit)        (php/array dist hit 0 cx' cy)
+                              :else
+                              (recur cx' cy (php/+ sidex deltax) sidey)))
+                          (let [cy'  (php/+ cy stepy)
+                                dist sidey
+                                hit  (cell-at pgrid cx cy')]
+                            (cond
+                              (php/> dist max-depth) (php/array max-depth 0 1 cx cy')
+                              (php/!== 0 hit)        (php/array dist hit 1 cx cy')
+                              :else
+                              (recur cx cy' sidex (php/+ sidey deltay))))))
+              d-corr  (php/* (php/aget hit-arr 0) (php/aget cos-offs col))
+              h       (php/aget hit-arr 1)
+              side    (php/aget hit-arr 2)
+              hx      (php/aget hit-arr 3)
+              hy      (php/aget hit-arr 4)]
            ;; Replicate this sample across the next `scale` output
            ;; columns. Inner loop bound by `width` so a non-divisible
            ;; tail (e.g. width=401, scale=2) doesn't overshoot. The
@@ -176,13 +175,13 @@
            ;; cos(offset), reading as slightly chunkier walls. The
            ;; per-cell-accurate alternative would mean N atan + cos
            ;; calls per sample, defeating the perf-mode win.
-           (loop [c col fill 0]
-             (when (and (php/< c width) (php/< fill scale))
-               (php/aset dists c d-corr)
-               (php/aset hits c h)
-               (php/aset sides c side)
-               (php/aset hxs c hx)
-               (php/aset hys c hy)
-               (recur (php/+ c 1) (php/+ fill 1))))
-           (recur (php/+ col scale)))))
-     {:dists dists :hits hits :sides sides :hxs hxs :hys hys})))
+          (loop [c col fill 0]
+            (when (and (php/< c width) (php/< fill scale))
+              (php/aset dists c d-corr)
+              (php/aset hits c h)
+              (php/aset sides c side)
+              (php/aset hxs c hx)
+              (php/aset hys c hy)
+              (recur (php/+ c 1) (php/+ fill 1))))
+          (recur (php/+ col scale)))))
+    {:dists dists :hits hits :sides sides :hxs hxs :hys hys}))

--- a/tests/core/enemy-test.phel
+++ b/tests/core/enemy-test.phel
@@ -50,7 +50,7 @@
   ;; Flash timer should tick down each frame so the HP digit fades on
   ;; its own without needing a separate ticker.
   (let [es' (advance [(assoc (new-enemy 5.0 5.0 3) :hit-flash-secs 1.0)]
-                     open-grid 8.0 5.0 0.25 0.75)]
+                     open-grid 8.0 5.0 0.25 0.75 true)]
     (is (< (:hit-flash-secs (first es')) 1.0))
     (is (>= (:hit-flash-secs (first es')) 0.0))))
 
@@ -102,14 +102,14 @@
 
 (deftest test-advance-moves-enemy-toward-player
   ;; Enemy at (5,5), player at (8,5), open grid -> enemy x increases.
-  (let [es' (advance [(new-enemy 5.0 5.0)] open-grid 8.0 5.0 0.5 0.75)]
+  (let [es' (advance [(new-enemy 5.0 5.0)] open-grid 8.0 5.0 0.5 0.75 true)]
     (is (> (:x (first es')) 5.0))
     (is (< (:x (first es')) 8.0))
     (is (= 5.0 (:y (first es'))))))
 
 (deftest test-advance-respects-stop-dist
   ;; Already on top of player, must not pile in further.
-  (let [es' (advance [(new-enemy 5.1 5.0)] open-grid 5.0 5.0 0.5 0.75)]
+  (let [es' (advance [(new-enemy 5.1 5.0)] open-grid 5.0 5.0 0.5 0.75 true)]
     (is (= 5.1 (:x (first es'))))
     (is (= 5.0 (:y (first es'))))))
 
@@ -117,18 +117,18 @@
   ;; Player at (3.5, 2.5), enemy at (1.5, 2.5). Direct east step hits the
   ;; x=2 wall; the chase should pivot and at least slide on the y axis
   ;; instead of staying put.
-  (let [e (first (advance [(new-enemy 1.5 2.5)] wall-between-grid 3.5 2.5 0.5 0.75))]
+  (let [e (first (advance [(new-enemy 1.5 2.5)] wall-between-grid 3.5 2.5 0.5 0.75 true))]
     (is (or (not (= 1.5 (:x e)))
             (not (= 2.5 (:y e)))))))
 
 (deftest test-advance-leaves-dead-enemies-untouched
-  (let [es' (advance [{:x 5.0 :y 5.0 :alive false}] open-grid 8.0 5.0 0.5 0.75)]
+  (let [es' (advance [{:x 5.0 :y 5.0 :alive false}] open-grid 8.0 5.0 0.5 0.75 true)]
     (is (= 5.0 (:x (first es'))))
     (is (= 5.0 (:y (first es'))))))
 
 (deftest test-advance-ticks-down-respawn-timer
   (let [es' (advance [{:x 5.0 :y 5.0 :alive false :respawn-after 4.0}]
-                     open-grid 8.0 5.0 0.5 0.75)]
+                     open-grid 8.0 5.0 0.5 0.75 true)]
     (is (= false (:alive (first es'))))
     (is (= 3.5 (:respawn-after (first es'))))))
 
@@ -136,7 +136,7 @@
   ;; respawn-after = 0.1 with dt = 0.5 -> timer expires this frame,
   ;; enemy revives at a random open cell.
   (let [es' (advance [{:x 5.0 :y 5.0 :alive false :respawn-after 0.1}]
-                     open-grid 8.0 5.0 0.5 0.75)]
+                     open-grid 8.0 5.0 0.5 0.75 true)]
     (is (= true (:alive (first es'))))))
 
 (deftest test-respawn-carries-max-lives-and-refills
@@ -144,7 +144,7 @@
   ;; trivially-one-shot like a fresh imp would be.
   (let [es' (advance [{:x 5.0 :y 5.0 :alive false :respawn-after 0.0
                        :lives 0 :max-lives 4}]
-                     open-grid 8.0 5.0 0.5 0.75)]
+                     open-grid 8.0 5.0 0.5 0.75 true)]
     (is (= true (:alive (first es'))))
     (is (= 4 (:lives (first es'))))
     (is (= 4 (:max-lives (first es'))))))
@@ -223,11 +223,11 @@
     (is (= 4.5 (:y e)))))
 
 (deftest test-advance-without-pgrid-skips-observation
-  ;; 6-arity legacy form (no pgrid) doesn't run observe. Enemies keep
+  ;; 7-arity advance (nil pgrid) doesn't run observe. Enemies keep
   ;; whatever state they have; default :aware → they chase as before.
   ;; This pins backward-compat for unit tests that build enemies via
   ;; new-enemy without going through spawn-enemies.
-  (let [es' (advance [(new-enemy 5.0 5.0)] open-grid 8.0 5.0 0.5 0.75)
+  (let [es' (advance [(new-enemy 5.0 5.0)] open-grid 8.0 5.0 0.5 0.75 true)
         e   (first es')]
     (is (> (:x e) 5.0))))
 
@@ -446,7 +446,7 @@
               :type :imp :max-concurrent 1 :hit-flash-secs 0.0}
              {:x 0.0 :y 0.0 :alive false :lives 0 :max-lives 1
               :type :imp :max-concurrent 1 :respawn-after 0.0}]
-        es' (advance es open-grid 5.0 5.0 0.1 0.5)]
+        es' (advance es open-grid 5.0 5.0 0.1 0.5 true)]
     (is (= true  (:alive (first  es'))))   ; the live one stays
     (is (= false (:alive (second es')))))) ; the dead one stays dead
 
@@ -455,14 +455,14 @@
   ;; (0 alive < 1), so revival proceeds.
   (let [es  [{:x 0.0 :y 0.0 :alive false :lives 0 :max-lives 1
               :type :imp :max-concurrent 1 :respawn-after 0.0}]
-        es' (advance es open-grid 5.0 5.0 0.1 0.5)]
+        es' (advance es open-grid 5.0 5.0 0.1 0.5 true)]
     (is (= true (:alive (first es'))))))
 
 (deftest test-advance-respawn-uncapped-still-works
   ;; No :max-concurrent → unchanged behaviour from earlier PRs.
   (let [es  [{:x 0.0 :y 0.0 :alive false :lives 0 :max-lives 2
               :type :baron :respawn-after 0.0}]
-        es' (advance es open-grid 5.0 5.0 0.1 0.5)
+        es' (advance es open-grid 5.0 5.0 0.1 0.5 true)
         e   (first es')]
     (is (= true (:alive e)))
     ;; Respawn now carries :type forward (was a bug previously —

--- a/tests/core/engine-test.phel
+++ b/tests/core/engine-test.phel
@@ -38,7 +38,7 @@
 (defn- one-ray-frame [world angle]
   ;; A single-column cast-frame so we can read column 0 directly.
   (let [w' (assoc world :player (new-player 2.5 2.5 angle))
-        c  (cast-frame w' 1)]
+        c  (cast-frame w' 1 1)]
     {:dist (php/aget (:dists c) 0)
      :hit  (php/aget (:hits c)  0)
      :side (php/aget (:sides c) 0)
@@ -70,7 +70,7 @@
   ;; cast-frame and walks them by column index. Pin that they all
   ;; have the same length so a column-major loop stays safe.
   (let [w (new-world chamber-grid (new-player 2.5 2.5 0.0))
-        c (cast-frame w 8)]
+        c (cast-frame w 8 1)]
     (is (= 8 (php/count (:dists c))))
     (is (= 8 (php/count (:hits c))))
     (is (= 8 (php/count (:sides c))))
@@ -104,13 +104,14 @@
     ;; Col 4 stands alone — just needs to be populated (not nil).
     (is (php/!== nil (php/aget (:dists c) 4)))))
 
-(deftest test-cast-frame-scale-1-matches-default-arity
-  ;; Explicit scale=1 must behave identically to the 2-arity call.
+(deftest test-cast-frame-scale-1-fills-every-column
+  ;; scale=1 is the canonical 1:1 ray-per-column path; pin that every
+  ;; output slot is populated (not nil) so the renderer's per-column
+  ;; walk never reads an unset cell.
   (let [w (new-world chamber-grid (new-player 2.5 2.5 0.0))
-        a (cast-frame w 6)
-        b (cast-frame w 6 1)]
+        c (cast-frame w 6 1)]
     (loop [i 0]
       (when (php/< i 6)
-        (is (= (php/aget (:dists a) i) (php/aget (:dists b) i)))
-        (is (= (php/aget (:hits  a) i) (php/aget (:hits  b) i)))
+        (is (php/!== nil (php/aget (:dists c) i)))
+        (is (php/!== nil (php/aget (:hits  c) i)))
         (recur (php/+ i 1))))))


### PR DESCRIPTION
## Summary

`composer lint` flagged 8 `phel/shadowed-binding` warnings, all from multi-arity defns where a pass-through arity re-bound the same param names as the real-body arity.

- `cast-frame` (engine.phel): dropped the 2-arity `(cast-frame w width)` wrapper. Tests add the explicit `scale=1` they were already deferring.
- `advance` (enemy.phel): dropped the 6-arity `(advance es g px py dt sp)` wrapper. Tests add the explicit `revive?=true` they were already deferring. Renamed the 8-arity's `revive?` to `rev?` so it doesn't shadow the 7-arity's `revive?`.

Production code already called the full-args form in both cases; only test fixtures used the dropped arities.

## Verification

- `composer format-check` clean
- `composer lint` 0 warnings (was 8)
- `composer test` 953 / 953
- `composer ci` exits 0 end-to-end

## Test plan

- [x] All existing tests green
- [x] Lint clean