### PR TITLE
feat(combat): 4-way damage-direction HUD cue (closes #66)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 
 ## [Unreleased]
 
+### Added
+
+- 4-way damage-direction HUD cue (issue #66). `attacker-side` now returns `:front` / `:back` / `:left` / `:right` (was `:left` / `:right` only); render paints a red strip on the matching screen edge so a hit from behind is visually distinct from a flank. Front / back use a narrow ±30° wedge so 45° off-axis hits keep using the wider left / right edge bar.
+
 ### Performance
 
 - `cast-frame` mean ~60% faster across 80 / 120 / 180 widths (2000-iter bench on `default-grid` at player spawn):

--- a/docs/combat.md
+++ b/docs/combat.md
@@ -135,7 +135,7 @@ Four gates: i-frame window, invulnerability sphere timer, dev god mode, AND at l
 - Otherwise loses one life (clamped at 0).
 - 1.0s i-frame: `vulnerable?` returns false, single touch can't drain multiple lives.
 - 0.05s flash: `render!` paints viewport white. One-frame jolt before the red i-frame wash.
-- Player knockback shove away from the attacker; arms `:hurt-side` so the directional red band paints on the correct edge.
+- Player knockback shove away from the attacker; arms `:hurt-side` (one of `:left` `:right` `:front` `:back`) so the directional red band paints on the matching edge. Front and back use a narrow ±30° wedge around the player's facing / anti-facing vectors; everything else routes to the wider left / right edges. Closes the rear blind spot that the previous left-only / right-only routing left open (issue #66).
 
 ### Shot knockback (enemy-only)
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -46,7 +46,7 @@ See [level-system.md](level-system.md), [map.md](map.md).
 
   Pistol + chaingun spray while space is held; shotgun needs a fresh pull per shell. Pistol is the only weapon that overheats / jams. Distinct silhouette + palette per slot. Per-weapon mag/reserve persists across switches. First-time pickup auto-switches. Drop/refill/raise reload anim; sprite recoils 2 rows per shot.
 - Kill-loot ammo skips the pistol when other weapons are owned - biases toward the scarce shotgun + chaingun the player had to hunt for. Level-spawn boxes still refill the active weapon.
-- 5 lives, 1s i-frame, directional red hurt-side band, knockback shove on contact damage.
+- 5 lives, 1s i-frame, 4-way directional red hurt-side band (left / right edge bar OR top / bottom row depending on attacker bearing), knockback shove on contact damage.
 
 See [monsters.md](monsters.md), [combat.md](combat.md).
 

--- a/src/core/combat.phel
+++ b/src/core/combat.phel
@@ -262,13 +262,24 @@
           (recur (next es) best-d best))))))
 
 (defn attacker-side
-  "Map an attacker position to `:left` / `:right` relative to player
-   facing (atan2 convention). nil if attacker is nil. Exported for
-   the directional-hit-vignette behaviour to be testable."
+  "Map an attacker position to one of four bearings relative to player
+   facing (atan2 convention): `:front`, `:back`, `:left`, `:right`. nil
+   if `att` is nil. Front and back are narrow ±30° wedges around the
+   player's facing and anti-facing vectors (`cos rel > cos(30°)` /
+   `cos rel < -cos(30°)`) so the off-axis 45° hits stay on left/right.
+   The remaining ~300° splits left vs right on the sign of `sin rel`.
+   Render reads this to paint a directional damage indicator on the
+   matching screen edge."
   [att ^float px ^float py ^float pangle]
   (when att
-    (let [rel (php/- (php/atan2 (php/- (:y att) py) (php/- (:x att) px)) pangle)]
-      (if (php/> (php/sin rel) 0.0) :right :left))))
+    (let [rel (php/- (php/atan2 (php/- (:y att) py) (php/- (:x att) px)) pangle)
+          c   (php/cos rel)
+          s   (php/sin rel)]
+      (cond
+        (php/> c 0.866)  :front
+        (php/< c -0.866) :back
+        (php/> s 0.0)    :right
+        :else            :left))))
 
 (defn knockback
   "Shove the player one knockback-distance step AWAY from `att`.

--- a/src/io/render.phel
+++ b/src/io/render.phel
@@ -1575,17 +1575,27 @@
   parts)
 
 (defn- paint-hit-vignette
-  "2-col red bar down the screen edge on the side the attacker came
-   from. Painted while iframes active AND :hurt-side is set."
+  "Red bar on the screen edge the attacker came from. Painted while
+   iframes active AND :hurt-side is set. :left / :right paint a 2-col
+   vertical strip; :front / :back paint a 1-row horizontal strip at
+   the top / bottom so the player can read all four directions of
+   incoming damage from the cue alone (issue #66)."
   [parts stats bloody? vw vh]
   (when (and bloody? (get stats :hurt-side))
-    (let [side    (get stats :hurt-side)
-          edge-bg "\e[48;5;160m  "
-          edge-c0 (if (php/=== side :left) 1 (php/max 1 (php/- vw 1)))]
-      (loop [r 1]
-        (when (php/<= r vh)
-          (buf-push parts (str "\e[" r ";" edge-c0 "H" edge-bg "\e[0m"))
-          (recur (php/+ r 1))))))
+    (let [side  (get stats :hurt-side)
+          edge  "\e[48;5;160m  "
+          strip (str "\e[48;5;160m" (php/str_repeat " " vw))]
+      (cond
+        (or (php/=== side :left) (php/=== side :right))
+        (let [c0 (if (php/=== side :left) 1 (php/max 1 (php/- vw 1)))]
+          (loop [r 1]
+            (when (php/<= r vh)
+              (buf-push parts (str "\e[" r ";" c0 "H" edge "\e[0m"))
+              (recur (php/+ r 1)))))
+        (php/=== side :front)
+        (buf-push parts (str "\e[1;1H" strip "\e[0m"))
+        (php/=== side :back)
+        (buf-push parts (str "\e[" vh ";1H" strip "\e[0m")))))
   parts)
 
 (defn- paint-heat-bar

--- a/tests/core/combat-test.phel
+++ b/tests/core/combat-test.phel
@@ -52,6 +52,28 @@
   ;; that was on the right now reads as on the left.
   (is (= :left (attacker-side {:x 1.0 :y 1.0} 0.0 0.0 (php/* 0.5 php/M_PI)))))
 
+(deftest test-attacker-side-enemy-directly-front
+  ;; Player facing +x. Enemy due east at (1, 0) is in the ±30° front
+  ;; arc -> :front (the new direction for issue #66).
+  (is (= :front (attacker-side {:x 1.0 :y 0.0} 0.0 0.0 0.0))))
+
+(deftest test-attacker-side-enemy-directly-behind
+  ;; Player facing +x. Enemy due west at (-1, 0) lands in the ±30°
+  ;; back arc -> :back. This is the case the old left/right scheme
+  ;; silently misrouted; closes the rear blind spot.
+  (is (= :back (attacker-side {:x -1.0 :y 0.0} 0.0 0.0 0.0))))
+
+(deftest test-attacker-side-front-arc-narrow-by-design
+  ;; Enemy at 45° off the facing axis (1, 1) must STAY on :right; the
+  ;; ±30° wedge is intentionally narrow so off-axis hits keep using
+  ;; the wider left/right edge.
+  (is (= :right (attacker-side {:x 1.0 :y 1.0} 0.0 0.0 0.0))))
+
+(deftest test-attacker-side-back-arc-narrow-by-design
+  ;; Symmetric to the front-arc test: 135° relative bearing stays as
+  ;; :left, not :back.
+  (is (= :left (attacker-side {:x -1.0 :y -1.0} 0.0 0.0 0.0))))
+
 ;; ---------------------------------------------------------------------
 ;; can-fire?: gate around cooldown + jam.
 ;; ---------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`attacker-side` now resolves to `:front` / `:back` / `:left` / `:right` instead of just `:left` / `:right`. Front and back use a narrow ±30° wedge (`abs(cos rel) > 0.866`) around the player's facing / anti-facing vectors; the remaining ~300° splits left vs right exactly as before, so off-axis attackers keep using the wider edge bar.

`render!`'s `paint-hit-vignette` extends the existing 2-col red side strip with a 1-row red top / bottom strip for `:front` / `:back`. Closes the rear blind spot from the previous left-only / right-only routing: a fast melee enemy closing from behind out of sight now paints a red bottom strip distinct from a flank hit.

Closes #66.

## Test plan

- [x] 5 new `combat-test` cases pin `:front` / `:back` classification + the ±30° wedge boundary (45° hit stays `:right`, 135° hit stays `:left`).
- [x] Existing `:left` / `:right` tests stay green (the wedge thresholds keep 45° off-axis hits on the side edges).
- [x] `composer ci` clean (964 / 964 tests).
- [ ] Manual `/play` smoke: take a hit from front / back / sides and confirm strip lands on the expected edge.

## Docs

- `docs/combat.md`, `docs/features.md`, `CHANGELOG.md` updated.