### PR TITLE
ref(physics): swap php/* for native arith in apply-translation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 
 ## [Unreleased]
 
+### Changed
+
+- Bump `phel-lang/phel-lang` to `dev-main` post phel-lang#2148 + #2181 (typed-binding native arith inside `let` / `loop` + return-type table for `php/cos` / `php/sin` / `php/sqrt` / etc.). `apply-translation` in `core/physics.phel` swaps `php/* php/- php/+` for native `* - +` plus a `^float a` hint on the angle binding; emitted PHP is identical, Phel source no longer shouts `php/` at the reader for plain arithmetic.
+
 ### Added
 
 - 4-way damage-direction HUD cue (issue #66). `attacker-side` now returns `:front` / `:back` / `:left` / `:right` (was `:left` / `:right` only); render paints a red strip on the matching screen edge so a hit from behind is visually distinct from a flank. Front / back use a narrow ±30° wedge so 45° off-axis hits keep using the wider left / right edge bar.

--- a/src/core/physics.phel
+++ b/src/core/physics.phel
@@ -134,10 +134,16 @@
 (defn- apply-translation [world ^float long-d ^float lat-d]
   (if (and (php/=== long-d 0.0) (php/=== lat-d 0.0))
     world
-    (let [a (:angle (:player world))]
+    (let [^float a (:angle (:player world))]
+      ;; Post phel-lang#2181: native `+` `-` `*` emit raw PHP arith when
+      ;; one operand is a typed local (`long-d` / `lat-d` / `a`) and the
+      ;; other is `(php/cos x)` / `(php/sin x)` (return-typed by the
+      ;; compiler's PHP-native return-type table). Same PHP as the
+      ;; previous `php/*` / `php/-` form, no perf delta, plain Phel
+      ;; reads.
       (try-move world
-                (php/- (php/* long-d (php/cos a)) (php/* lat-d (php/sin a)))
-                (php/+ (php/* long-d (php/sin a)) (php/* lat-d (php/cos a)))))))
+                (- (* long-d (php/cos a)) (* lat-d (php/sin a)))
+                (+ (* long-d (php/sin a)) (* lat-d (php/cos a)))))))
 
 (defn- decay-counter [n]
   (php/max 0 (php/- n 1)))


### PR DESCRIPTION
## Summary

phel-lang#2181 added a return-type table for known `php/*` scalar functions plus propagation through nested typed arithmetic. With the dep bumped past that commit, the rotation matrix in `apply-translation` can switch from `php/-` / `php/*` / `php/+` to native `-` / `*` / `+` without changing the emitted PHP.

Before:
```phel
(php/- (php/* long-d (php/cos a)) (php/* lat-d (php/sin a)))
```

After:
```phel
(- (* long-d (php/cos a)) (* lat-d (php/sin a)))
```

Both compile to:
```php
($long_d * cos($a)) - ($lat_d * sin($a))
```

`^float a` added to the angle binding so the generated PHP also carries a `/** @var float $a */` doctag for static analysers (free win from phel-lang#2147).

## Verification

- `composer ci` clean (964 / 964 tests).
- Build output diffed; `apply_translation` body identical aside from the new `@var` doctag on `$a`.
- Bench: no perf delta expected (same emit); skipped to keep the PR scope clean.

## Why this is a narrow swap

`php/* php/- php/+` etc. only become safe to drop the `php/` prefix when EVERY operand is one of:
- a tagged local (`^int` / `^float`),
- a literal numeric (`0.0` / `1`),
- or a call to a `php/*` function whose return type is in phel-lang's known-return-types table.

`(php/aget arr i)` is NOT in that table (phel-lang#2175 path 2 still open), so any hot loop that mixes `php/aget` with arithmetic must keep the `php/` prefix or it falls back to runtime dispatch. Scope this PR to the rotation matrix because it's the cleanest qualifying site.

## Test plan

- [x] `composer ci` clean
- [x] No format / lint regressions
- [x] Emitted PHP identical (manual diff)