### PR TITLE
feat(combat): nightmare difficulty modifier (closes #65)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 
 ### Added
 
+- Nightmare difficulty modifier (issue #65): `--difficulty=nightmare` now also stamps `:nightmare?` on every spawned enemy. Killed nightmare enemies respawn on a 1-2s timer instead of the regular 3-6s and bypass the `:max-concurrent` cap entirely, restoring DOOM's signature swarm pressure on top of the existing HP / speed / count scalars.
 - 4-way damage-direction HUD cue (issue #66). `attacker-side` now returns `:front` / `:back` / `:left` / `:right` (was `:left` / `:right` only); render paints a red strip on the matching screen edge so a hit from behind is visually distinct from a flank. Front / back use a narrow ±30° wedge so 45° off-axis hits keep using the wider left / right edge bar.
 
 ### Performance

--- a/docs/combat.md
+++ b/docs/combat.md
@@ -137,6 +137,15 @@ Four gates: i-frame window, invulnerability sphere timer, dev god mode, AND at l
 - 0.05s flash: `render!` paints viewport white. One-frame jolt before the red i-frame wash.
 - Player knockback shove away from the attacker; arms `:hurt-side` (one of `:left` `:right` `:front` `:back`) so the directional red band paints on the matching edge. Front and back use a narrow ±30° wedge around the player's facing / anti-facing vectors; everything else routes to the wider left / right edges. Closes the rear blind spot that the previous left-only / right-only routing left open (issue #66).
 
+### Nightmare respawn
+
+`--difficulty=nightmare` stamps `:nightmare? true` on every enemy at level build time. Two downstream effects:
+
+- `shoot` reads `:nightmare?` on the kill victim and draws the respawn cooldown from a tighter `[nightmare-respawn-delay-min, nightmare-respawn-delay-max]` band (1.0s to 2.0s) instead of the regular 3.0s to 6.0s.
+- `tick-one`'s `:max-concurrent` gate skips entirely for nightmare enemies, so the L10 boss-arena cap (1 alive imp at a time) no longer applies and the swarm reasserts itself.
+
+Other difficulties are unchanged. The HUD nightmare badge (red `[nightmare]` tag in the top strip) already existed.
+
 ### Shot knockback (enemy-only)
 
 Every wounding enemy hit (`:lives > 0` after damage) pushes the enemy ~1 cell back along the shot direction. Movement respects walls (half-step or quarter-step fallback if full step hits a wall). Killing blows skip knockback so the corpse lands on the death cell and loot drops cleanly. See `enemy/push-back-enemy`.

--- a/src/core/enemy.phel
+++ b/src/core/enemy.phel
@@ -27,6 +27,26 @@
 (def respawn-delay-max
   "Upper bound (seconds) on the respawn cooldown."
   6.0)
+
+(def nightmare-respawn-delay-min
+  "Lower bound on the respawn cooldown for `:nightmare?` enemies.
+   DOOM-faithful nightmare: dead enemies barely give you breathing
+   room before they're back chasing."
+  1.0)
+(def nightmare-respawn-delay-max
+  "Upper bound on the respawn cooldown for `:nightmare?` enemies."
+  2.0)
+
+(defn- respawn-delay-for
+  "Random respawn-cooldown seconds for the given enemy. Nightmare-flagged
+   enemies (set at level build time when `--difficulty=nightmare`) draw
+   from a much shorter range; everything else uses the standard band."
+  [enemy]
+  (let [nm (:nightmare? enemy)
+        lo (if nm nightmare-respawn-delay-min respawn-delay-min)
+        hi (if nm nightmare-respawn-delay-max respawn-delay-max)]
+    (php/+ lo (php/* (php// (php/mt_rand) (php/mt_getrandmax))
+                     (php/- hi lo)))))
 (def respawn-min-dist
   "Minimum spawn distance from the player a revived enemy must claim,
    so the next frame isn't an ambush."
@@ -153,9 +173,7 @@
                woken      (assoc-in hit-vec [best :state] :aware)
                wounded    (assoc-in woken [best :lives] new-lives)]
            (if (php/<= new-lives 0)
-             (let [delay   (php/+ respawn-delay-min
-                                  (php/* (php// (php/mt_rand) (php/mt_getrandmax))
-                                         (php/- respawn-delay-max respawn-delay-min)))
+             (let [delay   (respawn-delay-for hit-enemy)
                    killed' (assoc-in (assoc-in wounded [best :alive] false)
                                      [best :respawn-after] delay)]
                [killed' true hit-pos best])
@@ -304,15 +322,20 @@
         (assoc e :respawn-after t)
         (let [cap     (:max-concurrent e)
               type-kw (:type e)
-              capped? (and cap (php/>= (alive-count-of-type all-enemies type-kw) cap))
+              ;; Nightmare bypasses :max-concurrent: every minion can
+              ;; come back regardless of how many of its type are alive,
+              ;; matching DOOM's nightmare swarm pressure.
+              capped? (and cap (not (:nightmare? e))
+                           (php/>= (alive-count-of-type all-enemies type-kw) cap))
               pos     (when (not capped?)
                         (random-spawn-far-from grid respawn-min-dist player-x player-y))]
           (if pos
-            ;; Carry :max-lives, :type, :max-concurrent across the
-            ;; respawn so a revived baron is still a baron and the
-            ;; mixed-room cap keeps holding. Refill :lives to full
-            ;; and clear the timer. Older fixtures without :max-lives
-            ;; fall back to 1.
+            ;; Carry :max-lives, :type, :max-concurrent, :nightmare?
+            ;; across the respawn so a revived baron is still a baron,
+            ;; the mixed-room cap keeps holding, and a nightmare-flagged
+            ;; minion stays nightmare-flagged across deaths. Refill
+            ;; :lives to full and clear the timer. Older fixtures
+            ;; without :max-lives fall back to 1.
             (let [mx (or (:max-lives e) 1)]
               (merge e
                      {:x         (first pos)

--- a/src/core/level.phel
+++ b/src/core/level.phel
@@ -374,9 +374,16 @@
          specs                (normalise-enemies cfg)
          world                (new-world grid (new-player px py (php/* (rand-int 360)
                                                                        (php// php/M_PI 180.0))))
-         with-foes            (with-enemies world
-                                            (spawn-enemies-mixed grid specs
-                                                                 enemy-min-spawn-dist px py))]
+         spawned              (spawn-enemies-mixed grid specs
+                                                   enemy-min-spawn-dist px py)
+         ;; Nightmare: stamp every spawned enemy so respawn picks the
+         ;; shorter delay range AND the :max-concurrent cap is bypassed
+         ;; (see core/enemy.phel/tick-one). Other difficulties get no
+         ;; stamp -> default respawn behaviour.
+         tagged-foes          (if (php/=== :nightmare diff')
+                                (apply vector (map (fn [e] (assoc e :nightmare? true)) spawned))
+                                spawned)
+         with-foes            (with-enemies world tagged-foes)]
      (assoc with-foes
             :level         lv
             :lives         life

--- a/tests/core/enemy-test.phel
+++ b/tests/core/enemy-test.phel
@@ -471,6 +471,36 @@
     (is (= :baron (:type e)))))
 
 ;; ---------------------------------------------------------------------
+;; Nightmare modifier (issue #65): :nightmare? flag on the enemy bypasses
+;; :max-concurrent on respawn AND draws from a tighter respawn-delay
+;; range (set in shoot, not exercised here — that path is covered by
+;; the integration smoke test below).
+;; ---------------------------------------------------------------------
+
+(deftest test-advance-nightmare-bypasses-max-concurrent-cap
+  ;; Two imps both flagged :nightmare?, cap 1. One alive, one dead with
+  ;; expired timer. The cap that would normally block revival is
+  ;; ignored on nightmare; the dead one revives this frame.
+  (let [es  [{:x 3.0 :y 3.0 :alive true :lives 1 :max-lives 1
+              :type :imp :max-concurrent 1 :nightmare? true :hit-flash-secs 0.0}
+             {:x 0.0 :y 0.0 :alive false :lives 0 :max-lives 1
+              :type :imp :max-concurrent 1 :nightmare? true :respawn-after 0.0}]
+        es' (advance es open-grid 5.0 5.0 0.1 0.5 true)]
+    (is (= true (:alive (first  es'))))
+    (is (= true (:alive (second es'))))))
+
+(deftest test-advance-non-nightmare-still-respects-cap
+  ;; Sanity: drop the :nightmare? flag from the previous fixture and
+  ;; the cap re-engages. Pins that nightmare doesn't accidentally
+  ;; bypass the cap for non-nightmare runs.
+  (let [es  [{:x 3.0 :y 3.0 :alive true :lives 1 :max-lives 1
+              :type :imp :max-concurrent 1 :hit-flash-secs 0.0}
+             {:x 0.0 :y 0.0 :alive false :lives 0 :max-lives 1
+              :type :imp :max-concurrent 1 :respawn-after 0.0}]
+        es' (advance es open-grid 5.0 5.0 0.1 0.5 true)]
+    (is (= false (:alive (second es'))))))
+
+;; ---------------------------------------------------------------------
 ;; push-back-enemy: shove an enemy along a unit vector by `dist`
 ;; units, wall-clamped via the existing wall? predicate.
 ;; ---------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`--difficulty=nightmare` previously was only an HP / speed / count scalar. This PR adds DOOM's signature nightmare behaviour: dead enemies respawn fast, max-concurrent caps melt away, the swarm reasserts.

Implementation: every enemy spawned by `level.phel/build-world` under `:nightmare` difficulty gets a `:nightmare? true` stamp. Two downstream effects in `core/enemy.phel`:

- `shoot` reads the kill victim's `:nightmare?` (via the new `respawn-delay-for` helper) and draws the respawn cooldown from a tighter 1.0-2.0s band instead of the regular 3.0-6.0s.
- `tick-one`'s `:max-concurrent` gate skips entirely for nightmare enemies, so the L10 boss-arena cap (1 alive imp at a time) no longer applies on nightmare.

The `:nightmare?` stamp is also threaded through the merge that revives an enemy, so a respawned minion stays nightmare-flagged across deaths.

Other difficulties: unchanged. HUD nightmare badge (red `[nightmare]` in the top strip) already existed; no render-side change.

Closes #65.

## Test plan

- [x] `composer ci` clean (966 / 966; 2 new enemy-test cases).
- [x] `test-advance-nightmare-bypasses-max-concurrent-cap` pins the cap-bypass.
- [x] `test-advance-non-nightmare-still-respects-cap` pins the standard cap behaviour is unchanged when the flag is absent.
- [ ] Manual L10 nightmare run: confirm boss-arena imp respawns no longer stop at 1 alive.