### PR TITLE
feat(combat): per-enemy damage resistances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 
 ### Added
 
+- Per-enemy damage resistances (issue #60). Weapons now carry a `:damage-type` tag (currently `:ballistic` for the pistol / shotgun / chaingun roster) and the enemy catalog grows an optional `:resists` set. Cacodemon, baron, archvile, and mancubus resist `:fire` so future fire-flavoured weapons (BFG splash, plasma rifle) bounce off them while ballistic damage keeps cutting through. `enemy/shoot` gains an extra `damage-type` arg that combat's `resolve-shot` threads through from the active weapon spec - on a catalog match the per-hit damage is zeroed, so the target stays alive but registers as a hit (blood + flash) for feedback.
 - Nightmare difficulty modifier (issue #65): `--difficulty=nightmare` now also stamps `:nightmare?` on every spawned enemy. Killed nightmare enemies respawn on a 1-2s timer instead of the regular 3-6s and bypass the `:max-concurrent` cap entirely, restoring DOOM's signature swarm pressure on top of the existing HP / speed / count scalars.
 - 4-way damage-direction HUD cue (issue #66). `attacker-side` now returns `:front` / `:back` / `:left` / `:right` (was `:left` / `:right` only); render paints a red strip on the matching screen edge so a hit from behind is visually distinct from a flank. Front / back use a narrow ±30° wedge so 45° off-axis hits keep using the wider left / right edge bar.
 

--- a/docs/combat.md
+++ b/docs/combat.md
@@ -137,6 +137,21 @@ Four gates: i-frame window, invulnerability sphere timer, dev god mode, AND at l
 - 0.05s flash: `render!` paints viewport white. One-frame jolt before the red i-frame wash.
 - Player knockback shove away from the attacker; arms `:hurt-side` (one of `:left` `:right` `:front` `:back`) so the directional red band paints on the matching edge. Front and back use a narrow ±30° wedge around the player's facing / anti-facing vectors; everything else routes to the wider left / right edges. Closes the rear blind spot that the previous left-only / right-only routing left open (issue #66).
 
+### Damage resistance
+
+`enemy/shoot` takes a `damage-type` keyword (threaded in by `resolve-shot` from the active weapon's `:damage-type` field). The enemy catalog (`core/enemies.phel`) optionally tags monster types with `:resists #{...}`; if the picked target's type resists the incoming damage type, the per-hit damage is multiplied by zero so the target survives the hit with its lives unchanged. Hit registration (blood splatter, flash, sfx, wake) still fires so the player sees the bullet land and reads "no effect" from the missing HP digit / fading health bar.
+
+Current catalog:
+
+| Type | Resists |
+|------|---------|
+| caco | `:fire` |
+| baron | `:fire` |
+| archvile | `:fire` |
+| mancubus | `:fire` |
+
+All current weapons deal `:ballistic`, so the resist data is dormant until the BFG / plasma roster lands. Adding a new resistance is a one-line catalog edit; adding a new damage type is one keyword on the weapon spec.
+
 ### Nightmare respawn
 
 `--difficulty=nightmare` stamps `:nightmare? true` on every enemy at level build time. Two downstream effects:

--- a/src/core/combat.phel
+++ b/src/core/combat.phel
@@ -358,11 +358,13 @@
 
 (defn- resolve-shot [world]
   (let [p        (:player world)
-        base-dmg (or (:damage (w-spec world)) 1)
-        dmg      (if (berserk? world) (php/* base-dmg berserk-damage-mul) base-dmg)]
+        spec     (w-spec world)
+        base-dmg (or (:damage spec) 1)
+        dmg      (if (berserk? world) (php/* base-dmg berserk-damage-mul) base-dmg)
+        dmg-type (:damage-type spec)]
     (shoot (:enemies world) (:x p) (:y p) (:angle p)
            (cast-wall-distance world)
-           shot-hit-radius shot-max-range dmg)))
+           shot-hit-radius shot-max-range dmg dmg-type)))
 
 (defn- push-blood-fx [world hit-pos]
   (update world :fx

--- a/src/core/enemies.phel
+++ b/src/core/enemies.phel
@@ -64,7 +64,8 @@
     :body-glyph-fg  24
     :face           "\e[48;5;51;38;5;232;1m◉\e[0m"
     :face-alt       "\e[48;5;51;38;5;232;1m◎\e[0m"
-    :face-attack    "\e[5;48;5;51;38;5;196;1m✺\e[0m"}
+    :face-attack    "\e[5;48;5;51;38;5;196;1m✺\e[0m"
+    :resists        #{:fire}}
 
    :baron
    {:name           "baron"
@@ -77,7 +78,8 @@
     :body-glyph-fg  22
     :face           "\e[48;5;46;38;5;232;1mΛ\e[0m"
     :face-alt       "\e[48;5;46;38;5;232;1mλ\e[0m"
-    :face-attack    "\e[5;48;5;46;38;5;196;1m▲\e[0m"}
+    :face-attack    "\e[5;48;5;46;38;5;196;1m▲\e[0m"
+    :resists        #{:fire}}
 
    :cyber
    {:name           "cyberdemon"
@@ -136,7 +138,8 @@
     :body-glyph-fg  130
     :face           "\e[48;5;208;38;5;232;1m∺\e[0m"
     :face-alt       "\e[48;5;208;38;5;232;1m≋\e[0m"
-    :face-attack    "\e[5;48;5;208;38;5;226;1m♨\e[0m"}
+    :face-attack    "\e[5;48;5;208;38;5;226;1m♨\e[0m"
+    :resists        #{:fire}}
 
    :mancubus
    ;; Bulky brown: warm tan head, mid-brown body, bog-brown legs.
@@ -151,7 +154,8 @@
     :body-glyph-fg  58
     :face           "\e[48;5;137;38;5;232;1m═\e[0m"
     :face-alt       "\e[48;5;137;38;5;232;1m─\e[0m"
-    :face-attack    "\e[5;48;5;137;38;5;226;1m◐\e[0m"}
+    :face-attack    "\e[5;48;5;137;38;5;226;1m◐\e[0m"
+    :resists        #{:fire}}
 
    :pinky
    ;; Pink rusher: hot-pink head, magenta body, low HP high speed.
@@ -185,3 +189,15 @@
    so an unknown type still spawns as a single-shot enemy."
   [type-kw]
   (or (get-in enemy-types [type-kw :default-lives]) 1))
+
+(defn resists?
+  "True when the monster `type-kw` resists damage of `damage-type`.
+   Lookup is data-driven: each catalog entry may carry a `:resists`
+   set (e.g. `#{:fire}` on cacodemon). Nil `damage-type` or unknown
+   `type-kw` → false. Used by `enemy/shoot` to zero incoming damage
+   on a match; gives each monster type a distinct identity beyond
+   HP + speed."
+  [type-kw damage-type]
+  (and (some? damage-type)
+       (some? type-kw)
+       (contains? (or (get-in enemy-types [type-kw :resists]) #{}) damage-type)))

--- a/src/core/enemy.phel
+++ b/src/core/enemy.phel
@@ -1,5 +1,6 @@
 (ns phel-doom.core.enemy
   (:require phel-doom.core.map      :refer [random-spawn wall?])
+  (:require phel-doom.core.enemies  :refer [resists?])
   (:require phel-doom.core.enemy-ai :refer [apply-pain maybe-start-attack moves? observe target-pos tick-attack tick-pain tick-wander]))
 
 (def default-chase-speed
@@ -129,8 +130,8 @@
    shell drops it. `damage` defaults to 1 for callers that don't
    carry a weapon spec (older tests, etc)."
   ([enemies ^float px ^float py ^float angle ^float wall-dist ^float hit-radius ^float max-range]
-   (shoot enemies px py angle wall-dist hit-radius max-range 1))
-  ([es' ^float x' ^float y' ^float a' ^float wd' ^float hr ^float max-r ^int damage]
+   (shoot enemies px py angle wall-dist hit-radius max-range 1 nil))
+  ([es' ^float x' ^float y' ^float a' ^float wd' ^float hr ^float max-r ^int damage damage-type]
    (let [cos-a (php/cos a')
          sin-a (php/sin a')]
      (let [best (loop [i      0
@@ -163,7 +164,8 @@
          (let [hit-enemy  (get es' best)
                hit-pos    {:x (:x hit-enemy) :y (:y hit-enemy)}
                prev-lives (or (:lives hit-enemy) 1)
-               new-lives  (php/max 0 (php/- prev-lives damage))
+               eff-dmg    (if (resists? (:type hit-enemy) damage-type) 0 damage)
+               new-lives  (php/max 0 (php/- prev-lives eff-dmg))
                hit-vec    (apply vector es')
                ;; Any hit wakes the target — being shot is the
                ;; loudest possible "I see you" signal, and a dormant

--- a/src/core/weapons.phel
+++ b/src/core/weapons.phel
@@ -36,6 +36,7 @@
               :fire-cooldown   0.12
               :reload-duration 1.2
               :damage          1
+              :damage-type     :ballistic
               :auto-fire?      true
               ;; Pistol is the only overheating weapon. Trade-off
               ;; for its 0.12s cd + auto-fire: hold space too long
@@ -57,6 +58,7 @@
               :fire-cooldown   0.6
               :reload-duration 2.0
               :damage          3
+              :damage-type     :ballistic
               ;; Shotgun is single-action: each space press = one
               ;; shell. Holding the trigger does NOT auto-fire — the
               ;; player has to re-pull for every shot. Matches DOOM2's
@@ -79,6 +81,7 @@
               :fire-cooldown   0.05
               :reload-duration 1.8
               :damage          1
+              :damage-type     :ballistic
               ;; Auto-fire: holding space sprays at the 0.05s cd
               ;; until mag empties or trigger releases. This is what
               ;; makes the 20 dps niche real — without it the player

--- a/tests/core/enemies-test.phel
+++ b/tests/core/enemies-test.phel
@@ -1,7 +1,7 @@
 (ns phel-doom-tests.core.enemies-test
   (:require phel.test :refer [deftest is])
   (:require phel-doom.core.enemies
-            :refer [default-lives-for enemy-types required-keys type-spec]))
+            :refer [default-lives-for enemy-types required-keys resists? type-spec]))
 
 ;; ---------------------------------------------------------------------
 ;; Catalog completeness: every entry must carry every required field.
@@ -72,3 +72,35 @@
 
 (deftest test-type-spec-unknown-returns-nil
   (is (nil? (type-spec :nope))))
+
+;; ---------------------------------------------------------------------
+;; Per-enemy resistances. Catalog carries a `:resists` set for the
+;; fire-themed monsters so weapons that deal :fire bounce off them.
+;; Catalog-wired so adding a new monster + resist is one entry.
+;; ---------------------------------------------------------------------
+
+(deftest test-fire-resistant-types-pinned
+  ;; Pinning the set guards against an accidental rename / drop that
+  ;; would silently make a BFG round one-shot a cacodemon.
+  (doseq [t [:caco :baron :archvile :mancubus]]
+         (is (contains? (or (:resists (type-spec t)) #{}) :fire)
+             (str t " must resist :fire"))))
+
+(deftest test-non-resistant-types-have-no-resists
+  ;; Imps + demons stay vanilla so the early game balance is unchanged.
+  (doseq [t [:imp :demon :cyber :pinky :spectre :revenant]]
+         (is (not (contains? (or (:resists (type-spec t)) #{}) :fire))
+             (str t " must NOT resist :fire"))))
+
+(deftest test-resists-helper-matches-set
+  (is (true?  (resists? :caco :fire)))
+  (is (false? (resists? :caco :ballistic)))
+  (is (false? (resists? :imp  :fire))))
+
+(deftest test-resists-helper-nil-safe
+  ;; Nil damage-type (legacy 8-arity shoot) or nil type-kw (raw new-enemy
+  ;; without a catalog tag) must never throw - just return false so the
+  ;; default damage path runs.
+  (is (false? (resists? nil  :fire)))
+  (is (false? (resists? :imp nil)))
+  (is (false? (resists? nil  nil))))

--- a/tests/core/enemy-test.phel
+++ b/tests/core/enemy-test.phel
@@ -100,6 +100,39 @@
     (is (= nil hit-pos))
     (is (= -1 idx))))
 
+(deftest test-shoot-resistance-zeros-damage
+  ;; Cacodemon (3 HP) shot by a fire round: hit registers but lives
+  ;; stay at 3 because the catalog flags caco as fire-resistant.
+  ;; The trailing damage-type kw is the new 9-arity arg the combat
+  ;; path threads through from the active weapon spec.
+  (let [caco           (new-enemy 3.5 1.5 3 :caco)
+        [es' hit? _ _]
+        (shoot [caco] 1.5 1.5 0.0 10.0 0.5 12.0 3 :fire)]
+    (is (= true hit?))
+    (is (= true (:alive (first es'))))
+    (is (= 3 (:lives (first es'))))))
+
+(deftest test-shoot-resistance-misses-do-not-affect-non-resistant
+  ;; Imp (1 HP) shot by a fire round: dies — imps are not on the
+  ;; fire-resist list, so the damage applies normally. Guards
+  ;; against accidentally zeroing all :fire damage.
+  (let [imp            (new-enemy 3.5 1.5 1 :imp)
+        [es' hit? _ _]
+        (shoot [imp] 1.5 1.5 0.0 10.0 0.5 12.0 1 :fire)]
+    (is (= true hit?))
+    (is (= false (:alive (first es'))))
+    (is (= 0 (:lives (first es'))))))
+
+(deftest test-shoot-ballistic-unaffected-by-fire-resist
+  ;; Same caco target, but the shot is :ballistic — the :fire resist
+  ;; must not block ballistic damage. Pistol / shotgun / chaingun
+  ;; keep their old behaviour.
+  (let [caco        (new-enemy 3.5 1.5 3 :caco)
+        [es' _ _ _]
+        (shoot [caco] 1.5 1.5 0.0 10.0 0.5 12.0 3 :ballistic)]
+    (is (= 0 (:lives (first es'))))
+    (is (= false (:alive (first es'))))))
+
 (deftest test-advance-moves-enemy-toward-player
   ;; Enemy at (5,5), player at (8,5), open grid -> enemy x increases.
   (let [es' (advance [(new-enemy 5.0 5.0)] open-grid 8.0 5.0 0.5 0.75 true)]

--- a/tests/core/weapons-test.phel
+++ b/tests/core/weapons-test.phel
@@ -108,3 +108,13 @@
   (let [w (give-weapon (fresh-world) :rocket-launcher)]
     (is (= :pistol (:weapon w)))
     (is (= false (owns? w :rocket-launcher)))))
+
+(deftest test-every-weapon-carries-a-damage-type
+  ;; Damage typing is the foundation for per-enemy resistances
+  ;; (issue #60). Every weapon must declare what kind of damage it
+  ;; deals so enemy/shoot can lookup resists. Current roster is all
+  ;; ballistic; the chainsaw / BFG will pick :melee / :plasma when
+  ;; they land.
+  (is (= :ballistic (:damage-type (get weapons :pistol))))
+  (is (= :ballistic (:damage-type (get weapons :shotgun))))
+  (is (= :ballistic (:damage-type (get weapons :chaingun)))))


### PR DESCRIPTION
## Summary

- Weapons declare `:damage-type` (currently `:ballistic` across the existing roster - pistol / shotgun / chaingun) so future fire / plasma weapons can route through the same resistance lookup.
- Enemy catalog grows an optional `:resists #{...}` set. Cacodemon, baron, archvile, and mancubus resist `:fire`; imps / demons / cyber stay vanilla so the early-game balance is unchanged.
- `enemy/shoot` gains a `damage-type` arg that `combat/resolve-shot` threads through from the active weapon spec. On a catalog match the per-hit damage is multiplied by zero so the target survives, but the hit still fires blood + flash + sfx so the player sees the bullet land.
- Sets the foundation for #58 (BFG) and #59 (chainsaw) to plug into typed damage.

Closes #60

## Test plan

- [x] `composer ci` green (994 tests, 0 warnings).
- [x] `tests/core/enemies-test.phel` pins fire-resist set + `resists?` helper (nil-safe).
- [x] `tests/core/enemy-test.phel` covers caco vs `:fire` (no damage), imp vs `:fire` (dies), caco vs `:ballistic` (dies).
- [x] `tests/core/weapons-test.phel` pins `:damage-type :ballistic` for each weapon.