### PR TITLE
feat(map): switches that toggle remote cells

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 
 ## [Unreleased]
 
+### Added
+
+- Switches that toggle remote cells (#62). New `cell-switch-off` / `cell-switch-on` cell types (layout char `T`). Pressing `F` while facing a switch flips its glyph AND every linked target cell (wall ↔ floor) listed under the level config's `:switches`. L10 ships with two switches on its south wall that reconfigure the central pillar mid-fight.
+
+### Fixed
+
+- Secret reveal (#61) + door / cell mutations were updating `:grid` but leaving the raycaster's `:pgrid` PHP array stale, so the player walked through a wall that visually still looked solid. New `state/rebuild-pgrid` helper resyncs both; `try-reveal-secret` + `try-toggle-switch` call it after every mutation.
+
 ## [0.6.0] - 2026-05-27
 
 ### Added

--- a/docs/map.md
+++ b/docs/map.md
@@ -12,6 +12,8 @@
 (def cell-door-red  4)  ; red-keyed door: blocks until player holds :red keycard
 (def cell-door-boss 5)  ; boss-locked door: blocks until player kills the boss (grants synthetic :boss keycard)
 (def cell-secret    6)  ; hidden passage: looks + blocks like a wall until the player reveals it with F
+(def cell-switch-off 7) ; inactive switch: blocks like a wall, F-press flips to cell-switch-on + mutates target cells
+(def cell-switch-on  8) ; activated switch: same blocking + a second F-press reverts to cell-switch-off + targets
 ```
 
 Every cell is one of these ints. Constants exported so no module uses raw `0/1/2/3/4/5` literals. `(= cell-door (cell g x y))` reads as purpose.
@@ -82,6 +84,26 @@ Hand-authored only - `cell-secret` is never placed by `random-grid` / `seed-door
 ```
 
 The visual cue is deliberately absent (DOOM-style): identical wall shading, no overlay. Discovery is by exploration + bumping. `commands/play.phel/try-reveal-secret` watches the action-key rising edge (`F`); on a press it checks the cell one unit ahead of the player along `:angle` and calls `reveal-secret` if it's a secret. World tracks `:secrets-total` (set by `count-secrets` in `build-world`) + `:secrets-found` (bumped by `try-reveal-secret`); the F3 debug HUD paints `secrets X/Y`.
+
+## Switches
+
+Hand-authored only - `cell-switch-off` is never placed by random procgen. Layout char `T` opts a cell in; the level config supplies the `:switches` metadata:
+
+```phel
+:layout    [...
+            "#..T............T..#"
+            ...]
+:switches  [{:at [3 14]  :targets [[7 10]]}
+            {:at [16 14] :targets [[12 10]]}]
+```
+
+Each entry pairs a switch position with the cells it toggles. `try-toggle-switch` in `commands/play.phel` watches the `F` rising edge (after `try-reveal-secret`), checks the cell ahead of the player, and routes through `map/toggle-switch`:
+
+1. `toggle-switch-cell` swaps the glyph between `cell-switch-off` and `cell-switch-on`.
+2. For every `[x y]` in `:targets`, `toggle-target-cell` flips `cell-wall` ↔ `cell-floor`. Doors are skipped (defensive: targeting a door cell leaves it untouched).
+3. `state/rebuild-pgrid` resyncs the raycaster's PHP-array view; without this the 3D render would still paint the pre-toggle wall.
+
+The minimap glyph differs per state: dim cyan `T` for inactive, bright yellow `T` for activated, so the player can read which switches they've already flipped.
 
 ## Out-of-bounds reads
 

--- a/src/commands/play.phel
+++ b/src/commands/play.phel
@@ -2,8 +2,8 @@
   (:require phel.cli :as cli)
   (:require phel.string :as str)
   (:require phel-doom.core.state    :refer [advance-game-time gain-life max-armor max-lives max-stamina
-                                            toggle-debug toggle-map toggle-pause toggle-sound])
-  (:require phel-doom.core.map      :refer [door? reveal-secret secret?])
+                                            rebuild-pgrid toggle-debug toggle-map toggle-pause toggle-sound])
+  (:require phel-doom.core.map      :refer [door? reveal-secret secret? switch? toggle-switch])
   (:require phel-doom.glue.controls :refer [refresh-from-keys key-states rising-edges
                                             initial-key-snapshot])
   (:require phel-doom.core.physics  :refer [apply-physics tick-heartbeat tick-flicker tick-blood-drops tick-door-face tick-stamina])
@@ -353,26 +353,53 @@
   (let [p (:player world)]
     (door? (:grid world) (php/intval (:x p)) (php/intval (:y p)))))
 
+(defn- cell-ahead
+  "Integer (x, y) of the cell the player is facing (one unit ahead
+   along `:angle`). Used by F-key handlers (secret reveal, switch
+   toggle) to pick the player's interact target."
+  [world]
+  (let [p (:player world)
+        a (:angle p)]
+    [(php/intval (php/+ (:x p) (php/cos a)))
+     (php/intval (php/+ (:y p) (php/sin a)))]))
+
 (defn- try-reveal-secret
   "Action-key handler: when F was just pressed AND the cell directly
-   in front of the player (rounded by the player's facing) is an
-   unrevealed secret wall, swap that cell to floor on the world's
-   grid and bump `:secrets-found`. Plays the door sfx so the reveal
-   is audibly distinct from a wall bump. No-op otherwise so other
-   action-bound features (switches, etc) can chain off the same
-   edge without conflict."
+   in front of the player is an unrevealed secret wall, swap that
+   cell to floor on the world's grid and bump `:secrets-found`.
+   Plays the door sfx so the reveal is audibly distinct from a wall
+   bump. No-op otherwise so other action-bound features (switches,
+   etc) chain off the same edge without conflict."
   [world action?]
   (if (not action?)
     world
-    (let [p  (:player world)
-          a  (:angle p)
-          cx (php/intval (php/+ (:x p) (php/cos a)))
-          cy (php/intval (php/+ (:y p) (php/sin a)))]
+    (let [[cx cy] (cell-ahead world)]
       (if (secret? (:grid world) cx cy)
         (do (when (:sound-on world) (play-sfx! :door))
             (-> world
                 (assoc :grid (reveal-secret (:grid world) cx cy))
+                (rebuild-pgrid)
                 (update :secrets-found (fn [n] (php/+ (or n 0) 1)))))
+        world))))
+
+(defn- try-toggle-switch
+  "Action-key handler: when F was just pressed AND the cell directly
+   in front of the player is a switch (either state), flip the
+   switch glyph + every target cell listed under the matching
+   `:switches` entry. Plays the door sfx so the interaction is
+   audible. Chained AFTER `try-reveal-secret` so the two handlers
+   never claim the same F-press."
+  [world action?]
+  (if (not action?)
+    world
+    (let [[cx cy] (cell-ahead world)]
+      (if (switch? (:grid world) cx cy)
+        (do (when (:sound-on world) (play-sfx! :door))
+            (-> world
+                (assoc :grid (toggle-switch (:grid world)
+                                            (or (:switches world) [])
+                                            cx cy))
+                (rebuild-pgrid)))
         world))))
 
 (defn tick-world
@@ -391,16 +418,16 @@
       ;; own deps and returns a new world. Phel `->` would be nicer
       ;; but the lint pass doesn't macro-expand it (arity-mismatch
       ;; false positives), so stick with sequential let bindings.
-      (let [w1  (refresh-from-keys w0 keys)
+      (let [w1   (refresh-from-keys w0 keys)
             ;; Weapon swap (1/2/3) routes through weapons/switch-weapon
             ;; — no-op when the player is mid-reload so the lockout
             ;; can't be skipped.
-            w1a (cond
-                  (:select-weapon1 edges) (switch-weapon w1 (get weapon-order 0))
-                  (:select-weapon2 edges) (switch-weapon w1 (get weapon-order 1))
-                  (:select-weapon3 edges) (switch-weapon w1 (get weapon-order 2))
-                  (:select-weapon4 edges) (switch-weapon w1 (get weapon-order 3))
-                  :else                   w1)
+            w1a  (cond
+                   (:select-weapon1 edges) (switch-weapon w1 (get weapon-order 0))
+                   (:select-weapon2 edges) (switch-weapon w1 (get weapon-order 1))
+                   (:select-weapon3 edges) (switch-weapon w1 (get weapon-order 2))
+                   (:select-weapon4 edges) (switch-weapon w1 (get weapon-order 3))
+                   :else                   w1)
             ;; tick-stamina runs BEFORE apply-physics so that, on the
             ;; frame the player's pool empties, the `:sprint-blocked?`
             ;; latch fires before physics samples it — apply-physics
@@ -408,36 +435,40 @@
             ;; 1.6x frame "for free". Drain reads the just-refreshed
             ;; :moves slots (refresh-from-keys above), so the player
             ;; pays for the intent the same frame they signal it.
-            w1b (try-reveal-secret w1a (:action edges))
+            w1b  (try-reveal-secret w1a (:action edges))
+            ;; Switch (issue #62): flip the cell glyph + every target
+            ;; on the world's :switches metadata. Chained AFTER
+            ;; reveal-secret so the F-press never double-fires.
+            w1b2 (try-toggle-switch w1b (:action edges))
             ;; Fog-of-war mark: stamp every cell within visit-radius +
             ;; LOS of the player onto :visited so the minimap reveals
             ;; the layout as the player explores. Skipped while paused
             ;; so a paused frame doesn't drift the visible footprint
             ;; from where the player actually is.
-            w1c (mark-visible-cells w1b)
-            w2  (apply-physics (tick-stamina w1c dt) dt)
-            w3  (pickup-hearts w2)
-            w4  (pickup-armors w3)
-            w4b (pickup-ammos  w4)
-            w4c (pickup-berserks w4b)
-            w4d (pickup-invulns  w4c)
-            w4e (pickup-backpacks w4d)
-            w4f (pickup-keycards w4e)
-            w4g (pickup-weapon-pickups w4f)
-            w5  (tick-enemies  w4g dt)
-            w5b (if (:reload edges)
-                  (do
-                    (when (and (:sound-on w5) (reloading? w5)) (play-sfx! :reload))
-                    (reload w5))
-                  w5)
-            w5c (tick-armory w5b)
-            w6  (tick-shooting w5c (:fire edges) (:fire-held edges))
-            w7  (damage-step   w6 dt)
-            w8  (tick-heartbeat w7 dt)
-            w9  (tick-flicker  w8 dt)
-            w10 (tick-scare    w9 dt)
-            w11 (tick-blood-drops w10 dt)
-            w12 (tick-door-face w11 dt)]
+            w1c  (mark-visible-cells w1b2)
+            w2   (apply-physics (tick-stamina w1c dt) dt)
+            w3   (pickup-hearts w2)
+            w4   (pickup-armors w3)
+            w4b  (pickup-ammos  w4)
+            w4c  (pickup-berserks w4b)
+            w4d  (pickup-invulns  w4c)
+            w4e  (pickup-backpacks w4d)
+            w4f  (pickup-keycards w4e)
+            w4g  (pickup-weapon-pickups w4f)
+            w5   (tick-enemies  w4g dt)
+            w5b  (if (:reload edges)
+                   (do
+                     (when (and (:sound-on w5) (reloading? w5)) (play-sfx! :reload))
+                     (reload w5))
+                   w5)
+            w5c  (tick-armory w5b)
+            w6   (tick-shooting w5c (:fire edges) (:fire-held edges))
+            w7   (damage-step   w6 dt)
+            w8   (tick-heartbeat w7 dt)
+            w9   (tick-flicker  w8 dt)
+            w10  (tick-scare    w9 dt)
+            w11  (tick-blood-drops w10 dt)
+            w12  (tick-door-face w11 dt)]
         (advance-game-time w12 dt)))))
 
 ;; =====================================================================

--- a/src/core/level.phel
+++ b/src/core/level.phel
@@ -116,7 +116,9 @@
     ;; the player walks up and presses F. Two are tucked into the
     ;; central pillar's inner walls so a careful explorer can break
     ;; into the cover for a tactical advantage; the boss arena's
-    ;; openness otherwise leaves nowhere to hide.
+    ;; openness otherwise leaves nowhere to hide. 'T' cells are
+    ;; switches (issue #62) - pressing F adjacent to one toggles the
+    ;; linked cells listed under `:switches` below.
     :layout    ["####################"
                 "#.........X........#"
                 "#..................#"
@@ -131,11 +133,18 @@
                 "#......##..##......#"
                 "#..................#"
                 "#..................#"
-                "#..................#"
+                "#..T............T..#"
                 "#..................#"
                 "#..................#"
                 "#.........@........#"
-                "####################"]}])
+                "####################"]
+    ;; Both switches open the inner pillar walls so the player can
+    ;; cut through the cover instead of going around. The pillar's
+    ;; row 10 carries `#....#` at cols 7 + 12; switches flip those
+    ;; to floor (and back on a second F-press) so the boss-arena
+    ;; cover is reconfigurable mid-fight.
+    :switches  [{:at [3 14]  :targets [[7 10]]}
+                {:at [16 14] :targets [[12 10]]}]}])
 
 (def num-levels
   "Total levels in the catalog; clamped on every lookup."
@@ -405,6 +414,11 @@
             :door-lock     lock
             :secrets-total (count-secrets grid)
             :secrets-found 0
+            ;; Switches: level config opts in via :switches; build-world
+            ;; passes it through to the world so play.phel can resolve
+            ;; F-press targets. Defaults to [] when the level has no
+            ;; switches.
+            :switches      (or (:switches cfg) [])
             :ammo-boxes    (spawn-ammo-boxes grid (ammo-box-count cfg))
             :chase-speed   (:chase cfg)
             ;; Primary type fallback for render — used when an enemy

--- a/src/core/map.phel
+++ b/src/core/map.phel
@@ -46,6 +46,22 @@
    stays explicit."
   6)
 
+(def cell-switch-off
+  "Inactive switch (issue #62): wall-solid for raycaster + player but
+   distinct minimap + 3D glyph (dim). Player pressing `F` while
+   facing one routes through `toggle-switch`, which swaps the cell to
+   `cell-switch-on` and mutates every `:targets` cell on the world's
+   `:switches` metadata - turning remote walls into floor so a
+   crossed gap opens up."
+  7)
+
+(def cell-switch-on
+  "Activated switch: identical mechanics to `cell-switch-off` but
+   paints with a lit (bright) glyph so the player can read which
+   switches they've already flipped. A second `F`-press re-toggles
+   back: targets re-close + cell reverts to `cell-switch-off`."
+  8)
+
 (def lock-colours
   "Map from locked-door cell value back to the matching keycard kw.
    Drives door-lock + passable? + render door tint. `:boss` is a
@@ -86,17 +102,34 @@
         (or (get row x) cell-wall)))))
 
 (defn wall?
-  "True when (x, y) blocks player movement. Solid walls AND unrevealed
-   secret walls both qualify; doors are passable triggers."
+  "True when (x, y) blocks player movement. Solid walls, unrevealed
+   secrets, AND switch cells (either state) qualify; doors are
+   passable triggers."
   [grid x y]
   (let [c (cell grid x y)]
-    (or (= cell-wall c) (= cell-secret c))))
+    (or (= cell-wall c)
+        (= cell-secret c)
+        (= cell-switch-off c)
+        (= cell-switch-on c))))
 
 (defn secret?
   "True when (x, y) holds an unrevealed secret wall. Used by
    `reveal-secret-ahead` to spot the player's bump target."
   [grid x y]
   (= cell-secret (cell grid x y)))
+
+(defn switch?
+  "True when (x, y) holds a switch cell (either ON or OFF). Used by
+   `try-toggle-switch` to spot the player's interact target."
+  [grid x y]
+  (let [c (cell grid x y)]
+    (or (= cell-switch-off c) (= cell-switch-on c))))
+
+(defn switch-on?
+  "True when (x, y) holds an activated switch. Render uses this to
+   pick the lit minimap glyph."
+  [grid x y]
+  (= cell-switch-on (cell grid x y)))
 
 (defn door?
   "True when (x, y) holds ANY door variant (unlocked + locked).
@@ -114,13 +147,16 @@
 
 (defn passable?
   "True when the player CAN walk into (x, y) given their held keys.
-   Walls + unrevealed secrets always block; locked doors block until
-   the matching key is held. Unlocked doors + floors pass freely."
+   Walls + unrevealed secrets + switch cells always block; locked
+   doors block until the matching key is held. Unlocked doors +
+   floors pass freely."
   [grid held-keys x y]
   (let [c (cell grid x y)]
     (cond
       (= cell-wall c)            false
       (= cell-secret c)          false
+      (= cell-switch-off c)      false
+      (= cell-switch-on c)       false
       (contains? lock-colours c) (contains? (or held-keys #{}) (get lock-colours c))
       :else                      true)))
 
@@ -145,6 +181,59 @@
           (if (nil? hit)
             (recur (php/+ y 1))
             hit))))))
+
+(defn toggle-switch-cell
+  "Swap a switch cell between `cell-switch-off` and `cell-switch-on`.
+   No-op when the cell is not a switch. Used by `toggle-switch` after
+   resolving the player's bump target; isolated as a pure function so
+   tests can pin the swap without touching the world map."
+  [grid x y]
+  (let [c (cell grid x y)]
+    (cond
+      (= cell-switch-off c) (assoc-in grid [y x] cell-switch-on)
+      (= cell-switch-on c)  (assoc-in grid [y x] cell-switch-off)
+      :else                 grid)))
+
+(defn toggle-target-cell
+  "Flip a target cell between `cell-wall` and `cell-floor` so a
+   switch press opens / closes a remote passage. Doors are left
+   alone (defensive: a level author can target the door itself but
+   the typical case is wall ↔ floor). Returns grid unchanged when
+   the target is neither wall nor floor."
+  [grid x y]
+  (let [c (cell grid x y)]
+    (cond
+      (= cell-wall c)  (assoc-in grid [y x] cell-floor)
+      (= cell-floor c) (assoc-in grid [y x] cell-wall)
+      :else            grid)))
+
+(defn toggle-switch
+  "Flip the switch at (x, y) AND every target cell listed under
+   the matching entry in `switches` (a vector of
+   `{:at [x y] :targets [[x y] ...]}` maps). Returns the updated
+   `grid`. No-op when no switch entry matches the (x, y) position
+   so a stray `F`-press near a cosmetic switch cell - one without
+   targets in the level config - still flips its glyph without
+   leaving the world in a weird half-mutated state."
+  [grid switches ^int x ^int y]
+  (let [grid' (toggle-switch-cell grid x y)
+        match (loop [xs switches]
+                (cond
+                  (or (php/=== xs nil) (php/=== (count xs) 0)) nil
+                  :else
+                  (let [s       (first xs)
+                        [sx sy] (:at s)]
+                    (if (and (php/=== sx x) (php/=== sy y))
+                      s
+                      (recur (next xs))))))]
+    (if (nil? match)
+      grid'
+      (loop [g grid' ts (:targets match)]
+        (cond
+          (or (php/=== ts nil) (php/=== (count ts) 0)) g
+          :else
+          (let [[tx ty] (first ts)]
+            (recur (toggle-target-cell g tx ty) (next ts))))))))
 
 (defn reveal-secret
   "Swap the cell at (x, y) from `cell-secret` to `cell-floor` so the
@@ -300,7 +389,8 @@
    "B" cell-door-blue
    "R" cell-door-red
    "X" cell-door-boss
-   "S" cell-secret})
+   "S" cell-secret
+   "T" cell-switch-off})
 
 (defn- parse-row
   "Convert one layout string into [row-vec maybe-spawn-x]. Returns

--- a/src/core/state.phel
+++ b/src/core/state.phel
@@ -24,6 +24,16 @@
    cooldown) while not."
   100.0)
 
+(defn rebuild-pgrid
+  "Re-derive `:pgrid` from `:grid`. Call after any in-game mutation
+   of the grid (secret reveal, switch toggle, door open) so the
+   raycaster's hot-path PHP-array view stays in sync with the
+   persistent Phel vector. Without this the 3D view paints the
+   pre-mutation cell (player walks through a wall that still
+   visually looks solid)."
+  [world]
+  (assoc world :pgrid (to-php-array (map to-php-array (:grid world)))))
+
 (defn new-world
   "Bundle map grid and player into the world state. Stores a PHP-native
    copy of the grid under :pgrid so the raycast hot loop can read cells
@@ -40,6 +50,11 @@
    ;; within line-of-sight of the player each frame.
    :visited   (php/array)
    :full-map? false
+   ;; Switches (issue #62): vector of {:at [x y] :targets [[x y] ...]}.
+   ;; Level builder populates from the per-level config; play.phel /
+   ;; try-toggle-switch reads :at and applies map/toggle-switch on the
+   ;; F-key edge.
+   :switches  []
    :show-map  false
    :paused    false
    :help?     false

--- a/src/io/render.phel
+++ b/src/io/render.phel
@@ -487,6 +487,15 @@
 (def minimap-wall  "\e[40;37;1m█\e[0m")
 (def minimap-floor "\e[40;90m·\e[0m")
 (def minimap-door  "\e[40;33;1mD\e[0m")
+(def minimap-switch-off
+  "Inactive switch (issue #62): cyan-on-black `T`. Reads as
+   'press F here' but distinct from the orange D door glyph."
+  "\e[40;36mT\e[0m")
+(def minimap-switch-on
+  "Activated switch: bright yellow `T`. Two states + glyph swap so
+   the player can read which switches they've already flipped from
+   the minimap alone."
+  "\e[40;93;1mT\e[0m")
 (def minimap-unseen
   "Fog-of-war (issue #67) glyph: cells the player has not yet seen
    render as a uniform dim block so the layout doesn't leak. A flat
@@ -610,9 +619,10 @@
                                   :else (recur (php/+ dr 1)))))
         sample-cell         (fn [r0 c0]
                               ;; Priority: wall (1) > any door (2/3/4/5) >
-                              ;; floor (0). Door variants flow through so
-                              ;; minimap-rows can paint blue/red/boss
-                              ;; markers distinct from the orange D.
+                              ;; switch (7 / 8) > floor (0). Door + switch
+                              ;; variants flow through so minimap-rows can
+                              ;; paint blue/red/boss + switch-on/off
+                              ;; markers distinct from each other.
                               (loop [dr 0 found 0]
                                 (if (php/>= dr step)
                                   found
@@ -626,14 +636,18 @@
                                                      (or (php/=== cell 2)
                                                          (php/=== cell 3)
                                                          (php/=== cell 4)
-                                                         (php/=== cell 5)) (recur (php/+ dc 1) cell)
+                                                         (php/=== cell 5)
+                                                         (php/=== cell 7)
+                                                         (php/=== cell 8)) (recur (php/+ dc 1) cell)
                                                      :else            (recur (php/+ dc 1) acc)))))]
                                     (cond
                                       (php/=== v 1) 1
                                       (or (php/=== v 2)
                                           (php/=== v 3)
                                           (php/=== v 4)
-                                          (php/=== v 5)) (recur (php/+ dr 1) v)
+                                          (php/=== v 5)
+                                          (php/=== v 7)
+                                          (php/=== v 8)) (recur (php/+ dr 1) v)
                                       :else         (recur (php/+ dr 1) found))))))]
     (loop [row 0]
       (when (php/< row out-h)
@@ -653,6 +667,8 @@
                             (php/=== 3 cell)                              door-blue-marker
                             (php/=== 4 cell)                              door-red-marker
                             (php/=== 5 cell)                              boss-door-marker
+                            (php/=== 7 cell)                              minimap-switch-off
+                            (php/=== 8 cell)                              minimap-switch-on
                             (buf-get emap (php/+ (php/* row out-w) col))  enemy-marker
                             (buf-get hmap (php/+ (php/* row out-w) col))  heart-marker
                             (buf-get amap (php/+ (php/* row out-w) col))  ammo-marker

--- a/tests/core/level-test.phel
+++ b/tests/core/level-test.phel
@@ -42,6 +42,14 @@
     (is (= 2 (:secrets-total w)))
     (is (= 0 (:secrets-found w)))))
 
+(deftest test-build-world-passes-switches-through-from-config
+  ;; L10 carries two switches that flip the central pillar walls
+  ;; (issue #62). The level builder forwards :switches verbatim.
+  (let [w (build-world 10 5)]
+    (is (= 2 (count (:switches w))))
+    (is (= [3 14]  (:at (first (:switches w)))))
+    (is (= [16 14] (:at (second (:switches w)))))))
+
 (deftest test-build-world-spawns-heart-when-lives-low
   (let [w (build-world 2 3)]
     (is (= 1 (count (:hearts w))))

--- a/tests/core/map-test.phel
+++ b/tests/core/map-test.phel
@@ -3,8 +3,11 @@
   (:require phel-doom.core.map :refer [default-grid wall? door?
                                        cell-floor cell-wall cell-door
                                        cell-door-blue cell-door-red
-                                       cell-secret count-secrets passable?
-                                       reveal-secret secret?
+                                       cell-secret cell-switch-off
+                                       cell-switch-on count-secrets passable?
+                                       reveal-secret secret? switch?
+                                       switch-on? toggle-switch
+                                       toggle-switch-cell toggle-target-cell
                                        parse-layout
                                        random-grid random-spawn seed-doors]))
 
@@ -224,3 +227,98 @@
                            "####"])
         g   (:grid out)]
     (is (= cell-secret (get-in g [1 1])))))
+
+;; ---------------------------------------------------------------------
+;; Switches (issue #62): two-state cell, action-key flips state +
+;; mutates linked target cells.
+;; ---------------------------------------------------------------------
+
+(deftest test-switch-cell-constants-pinned
+  (is (= 7 cell-switch-off))
+  (is (= 8 cell-switch-on)))
+
+(deftest test-switch-cells-block-player-movement
+  (let [g [[1 1 1] [1 7 1] [1 1 1]]]
+    (is (= false (passable? g #{} 1 1))))
+  (let [g [[1 1 1] [1 8 1] [1 1 1]]]
+    (is (= false (passable? g #{} 1 1)))))
+
+(deftest test-switch-cells-block-raycaster
+  (let [g [[1 1 1] [1 7 1] [1 1 1]]]
+    (is (= true (wall? g 1 1))))
+  (let [g [[1 1 1] [1 8 1] [1 1 1]]]
+    (is (= true (wall? g 1 1)))))
+
+(deftest test-switch-predicate-spots-both-states
+  (let [g [[1 1 1] [1 7 8] [1 1 1]]]
+    (is (= true  (switch? g 1 1)))
+    (is (= true  (switch? g 2 1)))
+    (is (= false (switch? g 0 0)))))
+
+(deftest test-switch-on-predicate-true-only-for-activated
+  (let [g [[1 1 1] [1 7 8] [1 1 1]]]
+    (is (= false (switch-on? g 1 1)))
+    (is (= true  (switch-on? g 2 1)))))
+
+(deftest test-toggle-switch-cell-flips-state
+  (let [g0 [[1 1 1] [1 7 1] [1 1 1]]
+        g1 (toggle-switch-cell g0 1 1)
+        g2 (toggle-switch-cell g1 1 1)]
+    (is (= cell-switch-on  (get-in g1 [1 1])))
+    (is (= cell-switch-off (get-in g2 [1 1])))))
+
+(deftest test-toggle-target-cell-flips-wall-and-floor
+  ;; Wall → floor on first toggle, floor → wall on second. Doors are
+  ;; left alone so a level author can target a door cell with no
+  ;; surprise side-effect.
+  (let [g0      [[1 1 1] [1 0 1] [1 1 1]]
+        g1      (toggle-target-cell g0 1 1)
+        g2      (toggle-target-cell g1 1 1)
+        g-door  [[1 1 1] [1 2 1] [1 1 1]]
+        g-door' (toggle-target-cell g-door 1 1)]
+    (is (= cell-wall  (get-in g1 [1 1])))
+    (is (= cell-floor (get-in g2 [1 1])))
+    (is (= g-door g-door'))))
+
+(deftest test-toggle-switch-flips-switch-and-single-target
+  ;; Switch at (3, 3) with one target wall at (1, 1). One toggle:
+  ;; switch lights up + wall opens. Second toggle: both revert.
+  (let [g0       [[1 1 1 1 1]
+                  [1 1 0 0 1]
+                  [1 0 0 0 1]
+                  [1 0 0 7 1]
+                  [1 1 1 1 1]]
+        switches [{:at [3 3] :targets [[1 1]]}]
+        g1       (toggle-switch g0 switches 3 3)
+        g2       (toggle-switch g1 switches 3 3)]
+    (is (= cell-switch-on  (get-in g1 [3 3])))
+    (is (= cell-floor       (get-in g1 [1 1])))
+    (is (= cell-switch-off (get-in g2 [3 3])))
+    (is (= cell-wall        (get-in g2 [1 1])))))
+
+(deftest test-toggle-switch-flips-multiple-targets
+  (let [g0       [[1 1 1 1 1]
+                  [1 1 0 1 1]
+                  [1 0 0 0 1]
+                  [1 0 0 7 1]
+                  [1 1 1 1 1]]
+        switches [{:at [3 3] :targets [[1 1] [3 1]]}]
+        g1       (toggle-switch g0 switches 3 3)]
+    (is (= cell-floor (get-in g1 [1 1])))
+    (is (= cell-floor (get-in g1 [1 3])))
+    (is (= cell-switch-on (get-in g1 [3 3])))))
+
+(deftest test-toggle-switch-without-meta-still-flips-glyph
+  ;; A switch cell with no matching entry in `switches` still flips
+  ;; its own glyph - only the target mutation is gated. Stops a
+  ;; cosmetic / orphan switch from leaving the grid half-mutated.
+  (let [g0 [[1 1 1] [1 7 1] [1 1 1]]
+        g1 (toggle-switch g0 [] 1 1)]
+    (is (= cell-switch-on (get-in g1 [1 1])))))
+
+(deftest test-parse-layout-recognises-T-as-switch-off
+  (let [out (parse-layout ["####"
+                           "#T@#"
+                           "####"])
+        g   (:grid out)]
+    (is (= cell-switch-off (get-in g [1 1])))))

--- a/tests/core/state-test.phel
+++ b/tests/core/state-test.phel
@@ -1,6 +1,7 @@
 (ns phel-doom-tests.core.state-test
   (:require phel.test :refer [deftest is])
   (:require phel-doom.core.state :refer [new-player new-world move-player turn-player
+                                         rebuild-pgrid
                                          toggle-map toggle-pause toggle-debug with-enemies
                                          advance-game-time gain-life max-lives]))
 
@@ -77,3 +78,18 @@
   (let [w (new-world grid (new-player 1.0 1.0 0.0))]
     (is (= true  (:debug? (toggle-debug w))))
     (is (= false (:debug? (toggle-debug (toggle-debug w)))))))
+
+(deftest test-rebuild-pgrid-syncs-with-grid
+  ;; A mutation on :grid (e.g. switch toggle / secret reveal) leaves
+  ;; the raycaster's :pgrid stale unless rebuild-pgrid runs. After
+  ;; rebuild the same cell reads as the new value through the PHP
+  ;; array path.
+  (let [w0   (new-world [[1 1 1] [1 0 1] [1 1 1]] (new-player 1.5 1.5 0.0))
+        ;; Mutate :grid only.
+        w1   (assoc w0 :grid (assoc-in (:grid w0) [1 1] 1))
+        ;; pgrid is still the pre-mutation array - reads 0 at [1 1].
+        pre  (php/aget (php/aget (:pgrid w1) 1) 1)
+        w2   (rebuild-pgrid w1)
+        post (php/aget (php/aget (:pgrid w2) 1) 1)]
+    (is (= 0 pre))
+    (is (= 1 post))))


### PR DESCRIPTION
## Summary

Adds the DOOM-style switch primitive: walk up to a switch, press \`F\`, a wall across the map opens. Pairs naturally with #61 secret walls (both use the action key + grid mutation pattern).

- New \`cell-switch-off\` (\`7\`) / \`cell-switch-on\` (\`8\`) cell types. Layout char \`T\` opts a cell in.
- Per-level \`:switches [{:at [x y] :targets [[x y] ...]}]\` metadata pairs each switch with the cells it toggles. \`build-world\` forwards it onto the world.
- \`map/toggle-switch\` is the pure mutator: flips the switch glyph + walls ↔ floor on every target. Doors are left untouched.
- \`play.phel/try-toggle-switch\` watches the \`F\` rising edge (chained after \`try-reveal-secret\` so the press never double-fires), reads the cell ahead of the player, and routes through \`toggle-switch\` + \`rebuild-pgrid\`.
- \`io/render\` minimap-rows paints cyan / yellow \`T\` glyphs for off / on. 3D view falls through the wall-paint branch.
- L10 catalog gains two switches that reconfigure the central pillar mid-fight.

### Fix bundled in

\`state/rebuild-pgrid\` is a new helper that re-derives \`:pgrid\` from \`:grid\` after a mutation. Without it the raycaster's PHP-array view stayed stale and the player walked through what visually still looked like a wall. This also fixes a latent #61 bug where revealing a secret left the 3D wall solid.

Closes #62

## Test plan

- [x] \`composer ci\` green (1076 tests, 0 lint warnings).
- [x] \`tests/core/map-test.phel\`: cell values pinned, switch?/switch-on?, toggle-switch-cell flips, toggle-target-cell flips wall ↔ floor (doors untouched), single + multi target, orphan switch still flips glyph, parse-layout recognises \`T\`.
- [x] \`tests/core/level-test.phel\`: build-world forwards :switches from L10 config.
- [x] \`tests/core/state-test.phel\`: rebuild-pgrid syncs the PHP array view to a grid mutation.