### PR TITLE
feat(state): soulsphere pickup (issue #68 part 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 
 ### Added
 
+- Soulsphere pickup (#68 part 1). Rare (~1 in 10 levels) cyan sphere that bumps `:lives` toward `soulsphere-cap` (max-lives + 2 over-cap). The over-cap portion decays back to max-lives over time (one life every 5s) so the buff is a real defensive window, not permanent. Distinct cyan circle glyph + slower pulse cadence keep it readable next to berserk + invuln spheres.
 - Switches that toggle remote cells (#62). New `cell-switch-off` / `cell-switch-on` cell types (layout char `T`). Pressing `F` while facing a switch flips its glyph AND every linked target cell (wall ↔ floor) listed under the level config's `:switches`. L10 ships with two switches on its south wall that reconfigure the central pillar mid-fight.
 
 ### Fixed

--- a/docs/state.md
+++ b/docs/state.md
@@ -21,6 +21,8 @@ Pure data shapes that every other module operates on. `src/core/state.phel`.
  :ammo-boxes <vector of {:x :y}>
  :berserks   <vector of {:x :y}>           ; rage spheres (20s ×2 damage)
  :invulns    <vector of {:x :y}>           ; immunity spheres (10s invincible)
+ :soulspheres <vector of {:x :y}>          ; over-cap lives pickup (issue #68)
+ :soul-decay-secs <float seconds>          ; over-cap decay clock; decrements lives once per 5s while > max-lives
  :backpacks  <vector of {:x :y}>           ; one-shot reserve doubler
  :keycards   <vector of {:x :y :colour}>   ; :blue / :red / :boss keycards for locked exits (boss = synthetic, no pickup)
  :held-keys  <set of colour kws>           ; #{:blue :red :boss} collected so far

--- a/src/commands/play.phel
+++ b/src/commands/play.phel
@@ -1,7 +1,8 @@
 (ns phel-doom.commands.play
   (:require phel.cli :as cli)
   (:require phel.string :as str)
-  (:require phel-doom.core.state    :refer [advance-game-time gain-life max-armor max-lives max-stamina
+  (:require phel-doom.core.state    :refer [advance-game-time decay-soul-overcap gain-life gain-soulsphere
+                                            max-armor max-lives max-stamina
                                             rebuild-pgrid toggle-debug toggle-map toggle-pause toggle-sound])
   (:require phel-doom.core.map      :refer [door? reveal-secret secret? switch? toggle-switch])
   (:require phel-doom.glue.controls :refer [refresh-from-keys key-states rising-edges
@@ -265,6 +266,26 @@
                  :invulns     kept
                  :invuln-secs invuln-seconds)))))
 
+(defn- soulspheres-not-at [ss px py]
+  (apply vector
+         (filter (fn [s]
+                   (not (and (= (php/intval (:x s)) px)
+                             (= (php/intval (:y s)) py))))
+                 (or ss []))))
+
+(defn- pickup-soulspheres
+  "Step-on consumes a soulsphere + bumps `:lives` toward
+   `soulsphere-cap` via `gain-soulsphere`. Over-cap lives decay back
+   to `max-lives` over time (see `decay-soul-overcap`)."
+  [world]
+  (let [kept (soulspheres-not-at (:soulspheres world)
+                                 (php/intval (:x (:player world)))
+                                 (php/intval (:y (:player world))))]
+    (if (= (count kept) (count (or (:soulspheres world) [])))
+      world
+      (do (when (:sound-on world) (play-sfx! :berserk))
+          (gain-soulsphere (assoc world :soulspheres kept))))))
+
 (defn- backpacks-not-at [bs px py]
   (apply vector
          (filter (fn [b]
@@ -452,7 +473,8 @@
             w4b  (pickup-ammos  w4)
             w4c  (pickup-berserks w4b)
             w4d  (pickup-invulns  w4c)
-            w4e  (pickup-backpacks w4d)
+            w4d2 (pickup-soulspheres w4d)
+            w4e  (pickup-backpacks w4d2)
             w4f  (pickup-keycards w4e)
             w4g  (pickup-weapon-pickups w4f)
             w5   (tick-enemies  w4g dt)
@@ -468,8 +490,9 @@
             w9   (tick-flicker  w8 dt)
             w10  (tick-scare    w9 dt)
             w11  (tick-blood-drops w10 dt)
-            w12  (tick-door-face w11 dt)]
-        (advance-game-time w12 dt)))))
+            w12  (tick-door-face w11 dt)
+            w13  (decay-soul-overcap w12 dt)]
+        (advance-game-time w13 dt)))))
 
 ;; =====================================================================
 ;; § Per-frame IO + stats

--- a/src/core/level.phel
+++ b/src/core/level.phel
@@ -192,6 +192,17 @@
       [{:x ix :y iy}])
     []))
 
+(defn- maybe-spawn-soulsphere
+  "Rare soulsphere (issue #68): ~1 in 10 levels. Bumps `:lives` over
+   the normal cap by `soul-overcap`; the over-cap portion decays
+   back to `max-lives` over time, so the player gets a real defensive
+   buffer for a stretch of fight."
+  [grid]
+  (if (php/=== 0 (mod (rand-int 10) 10))
+    (let [[sx sy] (random-spawn grid)]
+      [{:x sx :y sy}])
+    []))
+
 (defn- maybe-spawn-backpack
   "One-shot backpack: L2+ only, ~1 in 5 qualifying levels (was 30%).
    Skipped once owned."
@@ -408,6 +419,7 @@
             :armors        (maybe-spawn-armor grid)
             :berserks      (maybe-spawn-berserk grid)
             :invulns       (maybe-spawn-invuln grid)
+            :soulspheres   (maybe-spawn-soulsphere grid)
             :backpacks     (maybe-spawn-backpack grid lv pack?)
             :keycards      (maybe-spawn-keycard grid lock)
             :weapon-pickups (maybe-spawn-weapon-pickups grid lv (or owned #{:pistol}))

--- a/src/core/state.phel
+++ b/src/core/state.phel
@@ -11,6 +11,27 @@
    this; new runs start here."
   5)
 
+(def soul-overcap
+  "Lives the soulsphere pickup (issue #68) is allowed to push the
+   player above `max-lives` for. Soulsphere bumps lives toward
+   `(+ max-lives soul-overcap)` (7) so the player feels a real
+   buffer; the over-cap portion decays back to `max-lives` over
+   time via `decay-soul-overcap`."
+  2)
+
+(def soulsphere-cap
+  "Hard ceiling on lives after a soulsphere pickup: `max-lives +
+   soul-overcap` = 7. Set so a player at full health still benefits
+   from grabbing one (no fully-wasted pickup)."
+  (php/+ max-lives soul-overcap))
+
+(def soul-overcap-decay-secs
+  "Seconds the over-cap portion of `:lives` lingers before ticking
+   down by 1. DOOM's soulsphere starts decaying ~1 HP / sec; with
+   integer lives we use a coarser cadence so each over-cap point
+   sticks for the duration."
+  5.0)
+
 (def max-armor
   "Hard cap on stacked armor pickups. Each absorbs one contact-damage
    hit (combat/take-damage). Picked-up armor beyond this is silently
@@ -55,6 +76,10 @@
    ;; try-toggle-switch reads :at and applies map/toggle-switch on the
    ;; F-key edge.
    :switches  []
+   ;; Soulsphere (issue #68). Per-level pickup spawn vector + the
+   ;; decay clock for the over-cap portion of `:lives`.
+   :soulspheres        []
+   :soul-decay-secs    0.0
    :show-map  false
    :paused    false
    :help?     false
@@ -143,6 +168,37 @@
   "Add one life to the player, capped at max-lives."
   [world]
   (update world :lives (fn [l] (php/min max-lives (php/+ l 1)))))
+
+(defn gain-soulsphere
+  "Boost lives toward `soulsphere-cap` (max-lives + over-cap bonus).
+   Adds `max-lives` worth of lives but clamps so a fresh player ends
+   at the cap and a player already over-cap doesn't stack further.
+   Resets the over-cap decay clock so the new lives start fresh
+   regardless of when the previous sphere was picked up."
+  [world]
+  (let [lives (or (:lives world) 0)
+        next  (php/min soulsphere-cap (php/+ lives max-lives))]
+    (assoc world
+           :lives           next
+           :soul-decay-secs 0.0)))
+
+(defn decay-soul-overcap
+  "Tick the over-cap decay clock. While `:lives > max-lives`, the
+   timer accumulates dt; once it reaches `soul-overcap-decay-secs`
+   one over-cap life is consumed (clamped to max-lives) and the
+   timer resets. Below the cap the clock is held at zero so the
+   first frame after picking up a sphere always pays full duration."
+  [world ^float dt]
+  (let [lives (or (:lives world) 0)
+        clock (or (:soul-decay-secs world) 0.0)]
+    (if (php/<= lives max-lives)
+      (assoc world :soul-decay-secs 0.0)
+      (let [clock' (php/+ clock dt)]
+        (if (php/>= clock' soul-overcap-decay-secs)
+          (assoc world
+                 :lives           (php/max max-lives (php/- lives 1))
+                 :soul-decay-secs 0.0)
+          (assoc world :soul-decay-secs clock'))))))
 
 (defn with-enemies
   "Attach an enemies vector to the world. Kept as a separate step so

--- a/src/io/render.phel
+++ b/src/io/render.phel
@@ -61,6 +61,12 @@
 (def ammo-marker     "\e[40;93;1mA\e[0m")
 (def berserk-marker  "\e[40;91;1mB\e[0m")
 (def invuln-marker   "\e[40;96;1mI\e[0m")
+(def soulsphere-marker
+  "Soulsphere minimap glyph (issue #68): bright cyan circle on
+   black. Distinct from `I` (invuln) and `B` (berserk) on the same
+   palette family so the player can tell which powerup is which at
+   a glance."
+  "\e[40;96;1m●\e[0m")
 (def backpack-marker "\e[40;33;1mP\e[0m")
 (def keycard-blue-marker "\e[40;94;1mk\e[0m")
 (def keycard-red-marker  "\e[40;91;1mk\e[0m")
@@ -198,6 +204,25 @@
 (def invuln-glyph-bright
   "Yellow star on cyan pulse."
   "\e[48;5;51;38;5;226;1m★")
+
+(def soulsphere-shade
+  "Soulsphere idle BG: deep sea blue so it sits visually between
+   invuln (bright cyan flare) and the wall greys."
+  "\e[48;5;25m ")
+
+(def soulsphere-shade-bright
+  "Soulsphere pulse BG: lighter sky-cyan flare."
+  "\e[48;5;39m ")
+
+(def soulsphere-glyph
+  "Cyan circle on deep blue: round shape distinguishes it from
+   invuln's star + berserk's omega so the shape-not-colour rule
+   from CHANGELOG 0.3.0 holds."
+  "\e[48;5;25;38;5;87;1m●")
+
+(def soulsphere-glyph-bright
+  "Bright white circle on sky-cyan pulse."
+  "\e[48;5;39;38;5;231;1m●")
 
 (def backpack-shade
   "Backpack idle BG: dim olive-tan crate so it reads as field gear."
@@ -544,6 +569,9 @@
 (defn- invuln-cells [is step out-w]
   (scaled-cells is step out-w (fn [_] true)))
 
+(defn- soulsphere-cells [ss step out-w]
+  (scaled-cells ss step out-w (fn [_] true)))
+
 (defn- backpack-cells [bs step out-w]
   (scaled-cells bs step out-w (fn [_] true)))
 
@@ -596,6 +624,7 @@
         amap                (ammo-cells  (:ammo-boxes world) step out-w)
         bmap                (berserk-cells (:berserks world) step out-w)
         imap                (invuln-cells  (:invulns world) step out-w)
+        ssmap               (soulsphere-cells (:soulspheres world) step out-w)
         pmap                (backpack-cells (:backpacks world) step out-w)
         kbmap               (scaled-cells (:keycards world) step out-w
                                           (fn [k] (php/=== (:colour k) :blue)))
@@ -674,6 +703,7 @@
                             (buf-get amap (php/+ (php/* row out-w) col))  ammo-marker
                             (buf-get bmap (php/+ (php/* row out-w) col))  berserk-marker
                             (buf-get imap (php/+ (php/* row out-w) col))  invuln-marker
+                            (buf-get ssmap (php/+ (php/* row out-w) col)) soulsphere-marker
                             (buf-get pmap (php/+ (php/* row out-w) col))  backpack-marker
                             (buf-get kbmap (php/+ (php/* row out-w) col)) keycard-blue-marker
                             (buf-get krmap (php/+ (php/* row out-w) col)) keycard-red-marker
@@ -2331,6 +2361,11 @@
         invuln-bright?                     (pulse t 8.0)
         invuln-shade-now                   (if invuln-bright? invuln-shade-bright invuln-shade)
         invuln-glyph-now                   (if invuln-bright? invuln-glyph-bright invuln-glyph)
+        ;; Soulsphere pulse — slower than invuln so a co-spawn reads
+        ;; with two distinct cadences instead of synced flashes.
+        soulsphere-bright?                 (pulse t 6.0)
+        soulsphere-shade-now               (if soulsphere-bright? soulsphere-shade-bright soulsphere-shade)
+        soulsphere-glyph-now               (if soulsphere-bright? soulsphere-glyph-bright soulsphere-glyph)
         ;; Backpack pulse — slowest of the powerup family so the
         ;; one-shot pickup reads as 'permanent gear' rather than a
         ;; ticking buff.
@@ -2541,7 +2576,10 @@
           bp-inv    (paint-pickups-into  bp-bers (or (:invulns world) [])
                                          (:player world) dists edists vw vh
                                          invuln-shade-now invuln-glyph-now)
-          bp-pack   (paint-pickups-into  bp-inv (or (:backpacks world) [])
+          bp-soul   (paint-pickups-into  bp-inv (or (:soulspheres world) [])
+                                         (:player world) dists edists vw vh
+                                         soulsphere-shade-now soulsphere-glyph-now)
+          bp-pack   (paint-pickups-into  bp-soul (or (:backpacks world) [])
                                          (:player world) dists edists vw vh
                                          backpack-shade-now backpack-glyph-now)
           bp-kb     (paint-pickups-into  bp-pack

--- a/tests/core/state-test.phel
+++ b/tests/core/state-test.phel
@@ -3,7 +3,9 @@
   (:require phel-doom.core.state :refer [new-player new-world move-player turn-player
                                          rebuild-pgrid
                                          toggle-map toggle-pause toggle-debug with-enemies
-                                         advance-game-time gain-life max-lives]))
+                                         advance-game-time gain-life gain-soulsphere
+                                         decay-soul-overcap max-lives soul-overcap-decay-secs
+                                         soulsphere-cap]))
 
 (def grid [[1 1 1] [1 0 1] [1 1 1]])
 
@@ -93,3 +95,56 @@
         post (php/aget (php/aget (:pgrid w2) 1) 1)]
     (is (= 0 pre))
     (is (= 1 post))))
+
+;; ---------------------------------------------------------------------
+;; Soulsphere (issue #68): pickup pushes lives over max-lives toward
+;; soulsphere-cap; the over-cap portion decays back to max-lives over
+;; time.
+;; ---------------------------------------------------------------------
+
+(deftest test-soulsphere-cap-is-max-plus-overcap
+  (is (= 7 soulsphere-cap)))
+
+(deftest test-gain-soulsphere-bumps-fresh-player-to-cap
+  ;; A fresh player at 5 lives picking up a soulsphere gets 5 more
+  ;; (clamped to soulsphere-cap = 7).
+  (let [w (gain-soulsphere {:lives 5})]
+    (is (= 7 (:lives w)))
+    (is (= 0.0 (:soul-decay-secs w)))))
+
+(deftest test-gain-soulsphere-from-low-lives
+  ;; 1 + max-lives = 6, capped to 7. Lower starting health benefits
+  ;; less than full-health pickup so the buff feels valuable AT all
+  ;; health levels.
+  (let [w (gain-soulsphere {:lives 1})]
+    (is (= 6 (:lives w)))))
+
+(deftest test-gain-soulsphere-resets-decay-clock
+  ;; Picking up a sphere mid-decay rearms the timer so the new lives
+  ;; get full duration.
+  (let [w (gain-soulsphere {:lives 7 :soul-decay-secs 3.0})]
+    (is (= 0.0 (:soul-decay-secs w)))))
+
+(deftest test-decay-soul-overcap-holds-clock-at-zero-when-not-over-cap
+  ;; lives <= max-lives → clock parked at 0, lives untouched.
+  (let [w (decay-soul-overcap {:lives 5 :soul-decay-secs 1.0} 2.0)]
+    (is (= 5 (:lives w)))
+    (is (= 0.0 (:soul-decay-secs w)))))
+
+(deftest test-decay-soul-overcap-accumulates-and-decrements
+  ;; Below the threshold: clock advances, lives untouched.
+  (let [w (decay-soul-overcap {:lives 7 :soul-decay-secs 0.0} 1.0)]
+    (is (= 7 (:lives w)))
+    (is (= 1.0 (:soul-decay-secs w))))
+  ;; At the threshold: clock resets, lives drop by one.
+  (let [w (decay-soul-overcap {:lives 7 :soul-decay-secs (php/- soul-overcap-decay-secs 0.01)} 0.1)]
+    (is (= 6 (:lives w)))
+    (is (= 0.0 (:soul-decay-secs w)))))
+
+(deftest test-decay-soul-overcap-stops-at-max-lives
+  ;; The decay never drops the player below max-lives even if the
+  ;; timer keeps ticking — soulsphere can't punish the player past
+  ;; the over-cap bonus.
+  (let [w (decay-soul-overcap {:lives (php/+ max-lives 1)
+                               :soul-decay-secs (php/+ soul-overcap-decay-secs 1.0)} 0.0)]
+    (is (= max-lives (:lives w)))))


### PR DESCRIPTION
## Summary

First sub-PR of #68 (pickup variety). Adds the soulsphere - rare cyan pickup that bumps \`:lives\` over the normal cap, with the over-cap portion decaying back to \`max-lives\` over time.

- New constants in \`core/state.phel\`: \`soul-overcap\` (2), \`soulsphere-cap\` (\`max-lives + soul-overcap\` = 7), \`soul-overcap-decay-secs\` (5.0).
- New pure helpers: \`gain-soulsphere\` bumps lives toward the cap + arms the decay clock; \`decay-soul-overcap\` ticks the over-cap portion back down by 1 life every 5 seconds.
- World gains \`:soulspheres\` (per-level pickup vector) + \`:soul-decay-secs\` (decay clock).
- \`core/level/maybe-spawn-soulsphere\` (~1 in 10 levels) + \`build-world\` forwards onto the world.
- \`commands/play.phel\`: \`pickup-soulspheres\` step in the tick chain; \`decay-soul-overcap\` at the end of the per-frame pipeline.
- \`io/render\`: distinct cyan-circle glyph (●) for 3D + minimap, slower pulse (6 rad/s) than invuln's 8 rad/s so co-spawned spheres read with different rhythms.

Sub-PRs to follow (still under #68):
- Armor shards: small +1 armor pickup, common drop.
- Backpack expansion: stack a second backpack for further reserve-cap doubling.

## Test plan

- [x] \`composer ci\` green (1088 tests, 0 lint warnings).
- [x] \`tests/core/state-test.phel\`: cap pinned, gain-soulsphere bumps fresh + low-lives correctly + resets decay clock, decay holds at zero below cap, decay ticks lives at threshold, never punishes below max-lives.