### PR TITLE
feat(state): armor shard pickup (issue #68 part 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 
 ### Added
 
+- Armor shards (#68 part 2). Common +1 armor pickup that stacks PAST the regular `max-armor` cap up to `armor-shard-cap` (2x max-armor = 10). No decay - shards bank as a permanent buffer (DOOM-style helmet bonus). Distinct green triangle glyph + faster pulse cadence than the full armor pickup. Three shards seed per level.
 - Soulsphere pickup (#68 part 1). Rare (~1 in 10 levels) cyan sphere that bumps `:lives` toward `soulsphere-cap` (max-lives + 2 over-cap). The over-cap portion decays back to max-lives over time (one life every 5s) so the buff is a real defensive window, not permanent. Distinct cyan circle glyph + slower pulse cadence keep it readable next to berserk + invuln spheres.
 - Switches that toggle remote cells (#62). New `cell-switch-off` / `cell-switch-on` cell types (layout char `T`). Pressing `F` while facing a switch flips its glyph AND every linked target cell (wall ↔ floor) listed under the level config's `:switches`. L10 ships with two switches on its south wall that reconfigure the central pillar mid-fight.
 

--- a/docs/state.md
+++ b/docs/state.md
@@ -23,6 +23,7 @@ Pure data shapes that every other module operates on. `src/core/state.phel`.
  :invulns    <vector of {:x :y}>           ; immunity spheres (10s invincible)
  :soulspheres <vector of {:x :y}>          ; over-cap lives pickup (issue #68)
  :soul-decay-secs <float seconds>          ; over-cap decay clock; decrements lives once per 5s while > max-lives
+ :armor-shards <vector of {:x :y}>         ; +1 over-cap armor; banks up to armor-shard-cap (10), no decay
  :backpacks  <vector of {:x :y}>           ; one-shot reserve doubler
  :keycards   <vector of {:x :y :colour}>   ; :blue / :red / :boss keycards for locked exits (boss = synthetic, no pickup)
  :held-keys  <set of colour kws>           ; #{:blue :red :boss} collected so far

--- a/src/commands/play.phel
+++ b/src/commands/play.phel
@@ -1,7 +1,8 @@
 (ns phel-doom.commands.play
   (:require phel.cli :as cli)
   (:require phel.string :as str)
-  (:require phel-doom.core.state    :refer [advance-game-time decay-soul-overcap gain-life gain-soulsphere
+  (:require phel-doom.core.state    :refer [advance-game-time decay-soul-overcap gain-armor-shard
+                                            gain-life gain-soulsphere
                                             max-armor max-lives max-stamina
                                             rebuild-pgrid toggle-debug toggle-map toggle-pause toggle-sound])
   (:require phel-doom.core.map      :refer [door? reveal-secret secret? switch? toggle-switch])
@@ -286,6 +287,28 @@
       (do (when (:sound-on world) (play-sfx! :berserk))
           (gain-soulsphere (assoc world :soulspheres kept))))))
 
+(defn- armor-shards-not-at [shards px py]
+  (apply vector
+         (filter (fn [s]
+                   (not (and (= (php/intval (:x s)) px)
+                             (= (php/intval (:y s)) py))))
+                 (or shards []))))
+
+(defn- pickup-armor-shards
+  "Step-on consumes an armor shard + adds +1 armor via
+   `gain-armor-shard` (capped at `armor-shard-cap` = 2x max-armor).
+   No decay - shards bank as a permanent buffer (DOOM helmet bonus
+   pattern). Common pickup so the door tink reads as routine
+   loot rather than a special-event sfx."
+  [world]
+  (let [kept (armor-shards-not-at (:armor-shards world)
+                                  (php/intval (:x (:player world)))
+                                  (php/intval (:y (:player world))))]
+    (if (= (count kept) (count (or (:armor-shards world) [])))
+      world
+      (do (when (:sound-on world) (play-sfx! :door))
+          (gain-armor-shard (assoc world :armor-shards kept))))))
+
 (defn- backpacks-not-at [bs px py]
   (apply vector
          (filter (fn [b]
@@ -469,7 +492,7 @@
             w1c  (mark-visible-cells w1b2)
             w2   (apply-physics (tick-stamina w1c dt) dt)
             w3   (pickup-hearts w2)
-            w4   (pickup-armors w3)
+            w4   (pickup-armor-shards (pickup-armors w3))
             w4b  (pickup-ammos  w4)
             w4c  (pickup-berserks w4b)
             w4d  (pickup-invulns  w4c)

--- a/src/core/level.phel
+++ b/src/core/level.phel
@@ -203,6 +203,34 @@
       [{:x sx :y sy}])
     []))
 
+(defn- spawn-armor-shards
+  "Common armor shards (issue #68): seed `n` of them at random open
+   cells. Each adds +1 armor over the normal `max-armor` cap up to
+   `armor-shard-cap` (10). Skip duplicates so two shards can't share
+   a cell (silently merging into one pickup)."
+  [grid n]
+  (loop [acc [] attempts 0]
+    (cond
+      (php/>= (count acc) n)       acc
+      (php/> attempts (php/* n 6)) acc
+      :else
+      (let [[sx sy] (random-spawn grid)
+            dup?    (loop [xs acc]
+                      (cond
+                        (php/=== xs nil) false
+                        (let [s (first xs)]
+                          (and (php/=== (:x s) sx) (php/=== (:y s) sy))) true
+                        :else (recur (next xs))))]
+        (if dup?
+          (recur acc (php/+ attempts 1))
+          (recur (conj acc {:x sx :y sy}) (php/+ attempts 1)))))))
+
+(def armor-shards-per-level
+  "Tunable: how many shards seed per level. Three keeps the level
+   floor visibly seeded with the common pickup without overwhelming
+   the heart / armor / ammo balance."
+  3)
+
 (defn- maybe-spawn-backpack
   "One-shot backpack: L2+ only, ~1 in 5 qualifying levels (was 30%).
    Skipped once owned."
@@ -420,6 +448,7 @@
             :berserks      (maybe-spawn-berserk grid)
             :invulns       (maybe-spawn-invuln grid)
             :soulspheres   (maybe-spawn-soulsphere grid)
+            :armor-shards  (spawn-armor-shards grid armor-shards-per-level)
             :backpacks     (maybe-spawn-backpack grid lv pack?)
             :keycards      (maybe-spawn-keycard grid lock)
             :weapon-pickups (maybe-spawn-weapon-pickups grid lv (or owned #{:pistol}))

--- a/src/core/state.phel
+++ b/src/core/state.phel
@@ -38,6 +38,20 @@
    ignored so the player can't farm an indestructible buffer."
   5)
 
+(def armor-shard-overcap
+  "Lives the armor-shard pickup (issue #68) is allowed to push the
+   player above `max-armor` for. Shards add +1 each up to
+   `(+ max-armor armor-shard-overcap)`; the over-cap portion does
+   NOT decay (DOOM-style helmet bonus), so the player banks shards
+   as a long-term buffer rather than a ticking buff."
+  5)
+
+(def armor-shard-cap
+  "Hard ceiling on armor after stacking shards: `max-armor +
+   armor-shard-overcap` = 10. Twice the regular cap. Shards beyond
+   this are silently ignored so the pickup never wastes."
+  (php/+ max-armor armor-shard-overcap))
+
 (def max-stamina
   "Hard cap on the sprint stamina pool. Fresh runs start at this value
    so the player has a full burst available the moment they spawn.
@@ -80,6 +94,11 @@
    ;; decay clock for the over-cap portion of `:lives`.
    :soulspheres        []
    :soul-decay-secs    0.0
+   ;; Armor shards (issue #68): common pickup that adds +1 armor
+   ;; over the normal `max-armor` cap, up to `armor-shard-cap`.
+   ;; No decay - shards are a permanent buffer (DOOM-style helmet
+   ;; bonus) so the player can stockpile them across rooms.
+   :armor-shards       []
    :show-map  false
    :paused    false
    :help?     false
@@ -168,6 +187,16 @@
   "Add one life to the player, capped at max-lives."
   [world]
   (update world :lives (fn [l] (php/min max-lives (php/+ l 1)))))
+
+(defn gain-armor-shard
+  "Stamp +1 armor on the player, capped at `armor-shard-cap` (2x
+   `max-armor`). No-op when already at cap so a wasted pickup is
+   silent rather than confusing. Used by `pickup-armor-shards` in
+   play.phel."
+  [world]
+  (let [armor (or (:armor world) 0)
+        next  (php/min armor-shard-cap (php/+ armor 1))]
+    (assoc world :armor next)))
 
 (defn gain-soulsphere
   "Boost lives toward `soulsphere-cap` (max-lives + over-cap bonus).

--- a/src/io/render.phel
+++ b/src/io/render.phel
@@ -67,6 +67,11 @@
    palette family so the player can tell which powerup is which at
    a glance."
   "\e[40;96;1m●\e[0m")
+(def armor-shard-marker
+  "Armor-shard minimap glyph (issue #68): green caret. Shape +
+   colour both distinct from the heart `♥` and ammo `A` so the
+   common shard pickup reads as its own kind on a busy minimap."
+  "\e[40;92;1m▲\e[0m")
 (def backpack-marker "\e[40;33;1mP\e[0m")
 (def keycard-blue-marker "\e[40;94;1mk\e[0m")
 (def keycard-red-marker  "\e[40;91;1mk\e[0m")
@@ -151,6 +156,26 @@
 (def armor-glyph-bright
   "Yellow ◆ on the bright-blue BG for the pulse frame."
   "\e[48;5;33;38;5;226;1m◆")
+
+(def armor-shard-shade
+  "Armor-shard idle BG: dim slate-blue. Lower contrast than the
+   full armor pickup so a player can read shard vs armor at a
+   glance: shards are the common, less-impactful drop."
+  "\e[48;5;60m ")
+
+(def armor-shard-shade-bright
+  "Armor-shard pulse BG: lighter slate flare."
+  "\e[48;5;67m ")
+
+(def armor-shard-glyph
+  "Small green triangle (▲) on slate - distinct from the full
+   armor's white diamond. Shape-not-colour rule: shards vs armor
+   stay readable even on the same monitor."
+  "\e[48;5;60;38;5;46;1m▲")
+
+(def armor-shard-glyph-bright
+  "Yellow triangle on the slate pulse."
+  "\e[48;5;67;38;5;226;1m▲")
 
 (def ammo-shade
   "Ammo-box idle BG: warm brown so it reads as a wooden crate from a
@@ -572,6 +597,9 @@
 (defn- soulsphere-cells [ss step out-w]
   (scaled-cells ss step out-w (fn [_] true)))
 
+(defn- armor-shard-cells [ss step out-w]
+  (scaled-cells ss step out-w (fn [_] true)))
+
 (defn- backpack-cells [bs step out-w]
   (scaled-cells bs step out-w (fn [_] true)))
 
@@ -625,6 +653,7 @@
         bmap                (berserk-cells (:berserks world) step out-w)
         imap                (invuln-cells  (:invulns world) step out-w)
         ssmap               (soulsphere-cells (:soulspheres world) step out-w)
+        asmap               (armor-shard-cells (:armor-shards world) step out-w)
         pmap                (backpack-cells (:backpacks world) step out-w)
         kbmap               (scaled-cells (:keycards world) step out-w
                                           (fn [k] (php/=== (:colour k) :blue)))
@@ -704,6 +733,7 @@
                             (buf-get bmap (php/+ (php/* row out-w) col))  berserk-marker
                             (buf-get imap (php/+ (php/* row out-w) col))  invuln-marker
                             (buf-get ssmap (php/+ (php/* row out-w) col)) soulsphere-marker
+                            (buf-get asmap (php/+ (php/* row out-w) col)) armor-shard-marker
                             (buf-get pmap (php/+ (php/* row out-w) col))  backpack-marker
                             (buf-get kbmap (php/+ (php/* row out-w) col)) keycard-blue-marker
                             (buf-get krmap (php/+ (php/* row out-w) col)) keycard-red-marker
@@ -2366,6 +2396,13 @@
         soulsphere-bright?                 (pulse t 6.0)
         soulsphere-shade-now               (if soulsphere-bright? soulsphere-shade-bright soulsphere-shade)
         soulsphere-glyph-now               (if soulsphere-bright? soulsphere-glyph-bright soulsphere-glyph)
+        ;; Armor-shard pulse: faster than the full armor pickup
+        ;; (5 rad/s) so a shard sitting next to an armor item reads
+        ;; with a quicker tempo - matches its 'common chip drop'
+        ;; feel vs the rarer fuller pickup.
+        armor-shard-bright?                (pulse t 5.5)
+        armor-shard-shade-now              (if armor-shard-bright? armor-shard-shade-bright armor-shard-shade)
+        armor-shard-glyph-now              (if armor-shard-bright? armor-shard-glyph-bright armor-shard-glyph)
         ;; Backpack pulse — slowest of the powerup family so the
         ;; one-shot pickup reads as 'permanent gear' rather than a
         ;; ticking buff.
@@ -2567,7 +2604,10 @@
           bp-armors (paint-pickups-into  bp-hearts (or (:armors world) [])
                                          (:player world) dists edists vw vh
                                          armor-shade-now armor-glyph-now)
-          bp-ammos  (paint-pickups-into  bp-armors (or (:ammo-boxes world) [])
+          bp-shards (paint-pickups-into  bp-armors (or (:armor-shards world) [])
+                                         (:player world) dists edists vw vh
+                                         armor-shard-shade-now armor-shard-glyph-now)
+          bp-ammos  (paint-pickups-into  bp-shards (or (:ammo-boxes world) [])
                                          (:player world) dists edists vw vh
                                          ammo-shade-now ammo-glyph-now)
           bp-bers   (paint-pickups-into  bp-ammos (or (:berserks world) [])

--- a/tests/core/state-test.phel
+++ b/tests/core/state-test.phel
@@ -3,8 +3,9 @@
   (:require phel-doom.core.state :refer [new-player new-world move-player turn-player
                                          rebuild-pgrid
                                          toggle-map toggle-pause toggle-debug with-enemies
-                                         advance-game-time gain-life gain-soulsphere
-                                         decay-soul-overcap max-lives soul-overcap-decay-secs
+                                         advance-game-time gain-armor-shard gain-life
+                                         gain-soulsphere decay-soul-overcap max-armor max-lives
+                                         armor-shard-cap soul-overcap-decay-secs
                                          soulsphere-cap]))
 
 (def grid [[1 1 1] [1 0 1] [1 1 1]])
@@ -148,3 +149,28 @@
   (let [w (decay-soul-overcap {:lives (php/+ max-lives 1)
                                :soul-decay-secs (php/+ soul-overcap-decay-secs 1.0)} 0.0)]
     (is (= max-lives (:lives w)))))
+
+;; ---------------------------------------------------------------------
+;; Armor shards (issue #68 part 2): common +1 armor pickup over the
+;; normal max-armor cap, up to armor-shard-cap. No decay.
+;; ---------------------------------------------------------------------
+
+(deftest test-armor-shard-cap-is-twice-max-armor
+  (is (= (php/* 2 max-armor) armor-shard-cap)))
+
+(deftest test-gain-armor-shard-adds-one
+  (let [w (gain-armor-shard {:armor 0})]
+    (is (= 1 (:armor w))))
+  (let [w (gain-armor-shard {:armor 4})]
+    (is (= 5 (:armor w)))))
+
+(deftest test-gain-armor-shard-pushes-past-max-armor
+  ;; Shards keep stacking past max-armor (5) up to armor-shard-cap (10).
+  ;; Distinct from the regular armor pickup which caps at max-armor.
+  (let [w (gain-armor-shard {:armor max-armor})]
+    (is (= (php/+ max-armor 1) (:armor w)))))
+
+(deftest test-gain-armor-shard-clamped-at-shard-cap
+  ;; At cap, the pickup is a silent no-op.
+  (let [w (gain-armor-shard {:armor armor-shard-cap})]
+    (is (= armor-shard-cap (:armor w)))))


### PR DESCRIPTION
## Summary

Second sub-PR of #68 (pickup variety). Adds armor shards: common +1 armor pickup that stacks PAST the regular \`max-armor\` cap up to \`armor-shard-cap\` (\`2x max-armor\` = 10). No decay - shards bank as a permanent buffer (DOOM-style helmet bonus pattern).

- New constants in \`core/state.phel\`: \`armor-shard-overcap\` (5), \`armor-shard-cap\` (10).
- New pure helper: \`gain-armor-shard\` adds +1 armor, clamped at the shard cap.
- World gains \`:armor-shards\` (per-level pickup vector).
- \`core/level\`: \`spawn-armor-shards\` seeds N shards per level (3 by default via \`armor-shards-per-level\`); de-duped so two shards can't share a cell.
- \`commands/play.phel\`: \`pickup-armor-shards\` step chained after \`pickup-armors\`.
- \`io/render\`: distinct slate-blue BG + green triangle glyph (▲) for both 3D + minimap; faster pulse (5.5 rad/s) than the full armor pickup's 5 rad/s. Shape-not-colour rule keeps shard vs armor readable on the same screen.

Sub-PR to follow (still under #68):
- Backpack capacity expansion: stack a second backpack for further reserve-cap doubling.

## Test plan

- [x] \`composer ci\` green (1093 tests, 0 lint warnings).
- [x] \`tests/core/state-test.phel\`: cap pinned at 2x max-armor, gain-armor-shard adds +1, pushes past max-armor, clamped at shard-cap.