### PR TITLE
feat(state): backpack capacity expansion (issue #68 part 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 
 ### Added
 
+- Backpack capacity expansion (#68 part 3). Backpack pickup now stacks: each grabbed backpack bumps `:backpack-level` by one up to `max-backpacks` (3). Reserve cap on every weapon scales linearly as `base * (1 + backpack-level)` so 1 = 2x (the previous one-shot behaviour), 2 = 3x, 3 = 4x. HUD chip swaps from `+pack` to `+pack x2` / `+pack x3` while stacked. Legacy `:backpack?` boolean still translated for older fixtures + saved state.
 - Armor shards (#68 part 2). Common +1 armor pickup that stacks PAST the regular `max-armor` cap up to `armor-shard-cap` (2x max-armor = 10). No decay - shards bank as a permanent buffer (DOOM-style helmet bonus). Distinct green triangle glyph + faster pulse cadence than the full armor pickup. Three shards seed per level.
 - Soulsphere pickup (#68 part 1). Rare (~1 in 10 levels) cyan sphere that bumps `:lives` toward `soulsphere-cap` (max-lives + 2 over-cap). The over-cap portion decays back to max-lives over time (one life every 5s) so the buff is a real defensive window, not permanent. Distinct cyan circle glyph + slower pulse cadence keep it readable next to berserk + invuln spheres.
 - Switches that toggle remote cells (#62). New `cell-switch-off` / `cell-switch-on` cell types (layout char `T`). Pressing `F` while facing a switch flips its glyph AND every linked target cell (wall ↔ floor) listed under the level config's `:switches`. L10 ships with two switches on its south wall that reconfigure the central pillar mid-fight.

--- a/docs/state.md
+++ b/docs/state.md
@@ -24,7 +24,8 @@ Pure data shapes that every other module operates on. `src/core/state.phel`.
  :soulspheres <vector of {:x :y}>          ; over-cap lives pickup (issue #68)
  :soul-decay-secs <float seconds>          ; over-cap decay clock; decrements lives once per 5s while > max-lives
  :armor-shards <vector of {:x :y}>         ; +1 over-cap armor; banks up to armor-shard-cap (10), no decay
- :backpacks  <vector of {:x :y}>           ; one-shot reserve doubler
+ :backpacks  <vector of {:x :y}>           ; per-level pickup spawn vector (stacks via :backpack-level)
+ :backpack-level <int 0..max-backpacks>    ; 0 = no backpack, 1+ = stacked; effective reserve cap = base * (1 + level)
  :keycards   <vector of {:x :y :colour}>   ; :blue / :red / :boss keycards for locked exits (boss = synthetic, no pickup)
  :held-keys  <set of colour kws>           ; #{:blue :red :boss} collected so far
  :armor      <int 0..max-armor, hits absorbed before lives drop>

--- a/src/commands/play.phel
+++ b/src/commands/play.phel
@@ -1,7 +1,8 @@
 (ns phel-doom.commands.play
   (:require phel.cli :as cli)
   (:require phel.string :as str)
-  (:require phel-doom.core.state    :refer [advance-game-time decay-soul-overcap gain-armor-shard
+  (:require phel-doom.core.state    :refer [advance-game-time at-backpack-cap? backpack-level
+                                            decay-soul-overcap gain-armor-shard gain-backpack
                                             gain-life gain-soulsphere
                                             max-armor max-lives max-stamina
                                             rebuild-pgrid toggle-debug toggle-map toggle-pause toggle-sound])
@@ -213,7 +214,7 @@
             target-sp (or (get weapons target) (weapon-spec world) {})
             per-box   (or (:ammo-per-box target-sp) ammo-per-box)
             base-cap  (or (:reserve-cap target-sp) 0)
-            cap       (if (:backpack? world) (php/* 2 base-cap) base-cap)
+            cap       (php/* base-cap (php/+ 1 (backpack-level world)))
             stash     (or (:weapon-state world) {})
             cur       (or (get-in stash [target :reserve]) 0)
             cur'      (php/min cap (php/+ cur per-box))
@@ -317,20 +318,24 @@
                  (or bs []))))
 
 (defn- pickup-backpacks
-  "One-shot: stepping on a backpack flips `:backpack?` true for the
-   rest of the run. Every weapon's effective reserve cap doubles
-   from that frame on (see weapons/effective-reserve-cap). Pickup
-   carries across levels via build-world's 3-arity."
+  "Stacking pickup (#68 part 3): each step-on bumps `:backpack-level`
+   by 1 up to `max-backpacks`. `weapons/effective-reserve-cap` then
+   returns `base * (1 + level)` so a second backpack expands every
+   weapon's reserve cap from 2x to 3x, a third to 4x. The stack
+   carries across levels via build-world's owned-state argument.
+   At cap the pickup is silently consumed (cell freed) but the
+   level is unchanged."
   [world]
   (let [kept (backpacks-not-at (:backpacks world)
                                (php/intval (:x (:player world)))
                                (php/intval (:y (:player world))))]
     (if (= (count kept) (count (or (:backpacks world) [])))
       world
-      (do (when (:sound-on world) (play-sfx! :door))
-          (assoc world
-                 :backpacks kept
-                 :backpack? true)))))
+      (let [picked (assoc world :backpacks kept)]
+        (when (:sound-on world) (play-sfx! :door))
+        (if (at-backpack-cap? picked)
+          picked
+          (gain-backpack picked))))))
 
 (defn- keycards-not-at [ks px py]
   (apply vector
@@ -563,7 +568,8 @@
    :empty-click-secs (or (:empty-click-secs world) 0.0)
    :berserk-secs (or (:berserk-secs world) 0.0)
    :invuln-secs  (or (:invuln-secs world) 0.0)
-   :backpack?    (boolean (:backpack? world))
+   :backpack?       (php/> (backpack-level world) 0)
+   :backpack-level  (backpack-level world)
    :difficulty   (or (:difficulty world) :normal)
    :god?         (boolean (:god? world))
    :help?        (boolean (:help? world))
@@ -636,8 +642,8 @@
      :level         (php/+ (:level world) 1)
      :kills         (:kills world)
      :lives         (:lives world)
-     :backpack?     (boolean (:backpack? world))
-     :owned-weapons (or (:owned-weapons world) #{:pistol})
+     :backpack-level (backpack-level world)
+     :owned-weapons  (or (:owned-weapons world) #{:pistol})
      :weapon        active
      :weapon-state  stash'
      ;; User-preference toggles also follow the player through the
@@ -810,7 +816,10 @@
          carry-kills 0
          carry-time  0
          seed        (php/mt_rand)
-         backpack?   false
+         ;; Backpack stack carried across levels (0..max-backpacks).
+         ;; Was a boolean before #68 part 3 - swapped to an int so
+         ;; each pickup adds one base's reserve cap.
+         bp-level    0
          owned       (if armory? #{:pistol :shotgun :chaingun} #{:pistol})
          ;; Active weapon + per-weapon mag/reserve stash carried
          ;; across level cuts so the player doesn't get reset to a
@@ -821,7 +830,7 @@
          show-map?   false
          sound-on?   true]
     (php/mt_srand seed)
-    (let [w0     (build-world level lives backpack? diff owned)
+    (let [w0     (build-world level lives bp-level diff owned)
           ;; God mode + carried user toggles + weapon ammo are
           ;; overlaid on the freshly-built world so build-world
           ;; stays purely about the level itself.
@@ -853,7 +862,7 @@
         ;; Lives, weapons, mag/reserve and player toggles do carry.
         (let [[k t] (carry-on carry-kills carry-time result)]
           (recur (:level result) (:lives result) k t (php/mt_rand)
-                 (boolean (:backpack? result))
+                 (backpack-level result)
                  (or (:owned-weapons result) #{:pistol})
                  (or (:weapon result) :pistol)
                  (or (:weapon-state result) {})
@@ -864,8 +873,8 @@
         (let [[k t]           (carry-on carry-kills carry-time result)
               [kind new-seed] (handle-end victory-loop k t result seed true)]
           (cond
-            (= kind :fresh) (recur 1 max-lives 0 0 (php/mt_rand) false #{:pistol} nil nil true true)
-            (= kind :same)  (recur 1 max-lives 0 0 new-seed false #{:pistol} nil nil true true)
+            (= kind :fresh) (recur 1 max-lives 0 0 (php/mt_rand) 0 #{:pistol} nil nil true true)
+            (= kind :same)  (recur 1 max-lives 0 0 new-seed 0 #{:pistol} nil nil true true)
             :else           nil))
 
         (and (map? result) (:game-over result))
@@ -874,10 +883,10 @@
               died-on         (or (:level result) 1)]
           (cond
             ;; r: try the level you died on again with a fresh map.
-            (= kind :fresh) (recur died-on max-lives 0 0 (php/mt_rand) false #{:pistol} nil nil true true)
+            (= kind :fresh) (recur died-on max-lives 0 0 (php/mt_rand) 0 #{:pistol} nil nil true true)
             ;; R: replay the exact level you died on (same seed + same
             ;; level number reproduces identical geometry + enemies).
-            (= kind :same)  (recur died-on max-lives 0 0 new-seed false #{:pistol} nil nil true true)
+            (= kind :same)  (recur died-on max-lives 0 0 new-seed 0 #{:pistol} nil nil true true)
             :else           nil))
 
         :else

--- a/src/core/level.phel
+++ b/src/core/level.phel
@@ -1,5 +1,5 @@
 (ns phel-doom.core.level
-  (:require phel-doom.core.state      :refer [new-player new-world with-enemies max-lives])
+  (:require phel-doom.core.state      :refer [max-backpacks max-lives new-player new-world with-enemies])
   (:require phel-doom.core.map        :refer [cell-door cell-door-blue cell-door-red count-secrets parse-layout random-grid random-spawn seed-doors])
   (:require phel-doom.core.enemy      :refer [spawn-enemies spawn-enemies-mixed])
   (:require phel-doom.core.enemies    :refer [enemy-types type-spec default-lives-for])
@@ -232,15 +232,21 @@
   3)
 
 (defn- maybe-spawn-backpack
-  "One-shot backpack: L2+ only, ~1 in 5 qualifying levels (was 30%).
-   Skipped once owned."
-  [grid level-num backpack-owned?]
-  (if (or backpack-owned?
-          (php/< level-num 2)
-          (php/!== 0 (mod (rand-int 5) 5)))
-    []
-    (let [[bx by] (random-spawn grid)]
-      [{:x bx :y by}])))
+  "Stacking backpack (#68 part 3): L2+ only, ~1 in 5 qualifying
+   levels. Skipped once the player is at `max-backpacks`. `pack`
+   accepts the legacy boolean (true = level 1) or the new integer
+   level for back-compat with old callers."
+  [grid level-num pack]
+  (let [lvl (cond
+              (boolean? pack)   (if pack 1 0)
+              (php/is_int pack) pack
+              :else             0)]
+    (if (or (php/>= lvl max-backpacks)
+            (php/< level-num 2)
+            (php/!== 0 (mod (rand-int 5) 5)))
+      []
+      (let [[bx by] (random-spawn grid)]
+        [{:x bx :y by}]))))
 
 (defn- specs-total-hp
   "Sum `count * lives` across a mixed-spec vector. Used to size the
@@ -406,11 +412,15 @@
    from the previous level. Walls, enemies, doors, player spawn, and
    pickups are randomised by default; a level entry can opt into a
    hand-authored `:layout` for boss arenas. Enemies stamp `:type` so
-   render reads per-enemy visuals from the catalog."
-  ([level-num lives] (build-world level-num lives false :normal #{:pistol}))
-  ([n l pack?] (build-world n l pack? :normal #{:pistol}))
-  ([n l pack? diff] (build-world n l pack? diff #{:pistol}))
-  ([lv life pack? diff owned]
+   render reads per-enemy visuals from the catalog.
+
+   `pack-level` (the 3rd positional) is the player's current backpack
+   stack count (0..max-backpacks). Accepts a legacy boolean for
+   back-compat: true coerces to 1, false to 0."
+  ([level-num lives] (build-world level-num lives 0 :normal #{:pistol}))
+  ([n l pack] (build-world n l pack :normal #{:pistol}))
+  ([n l pack diff] (build-world n l pack diff #{:pistol}))
+  ([lv life pack diff owned]
    (let [diff'                (normalise diff)
          raw                  (config-for lv)
          ;; Resolve :enemy-lives from the catalog BEFORE scale-cfg —
@@ -441,7 +451,10 @@
             :level         lv
             :lives         life
             :difficulty    diff'
-            :backpack?     pack?
+            :backpack-level (cond
+                              (boolean? pack)   (if pack 1 0)
+                              (php/is_int pack) pack
+                              :else             0)
             :owned-weapons (or owned #{:pistol})
             :hearts        (maybe-spawn-heart grid life px py)
             :armors        (maybe-spawn-armor grid)
@@ -449,7 +462,7 @@
             :invulns       (maybe-spawn-invuln grid)
             :soulspheres   (maybe-spawn-soulsphere grid)
             :armor-shards  (spawn-armor-shards grid armor-shards-per-level)
-            :backpacks     (maybe-spawn-backpack grid lv pack?)
+            :backpacks     (maybe-spawn-backpack grid lv pack)
             :keycards      (maybe-spawn-keycard grid lock)
             :weapon-pickups (maybe-spawn-weapon-pickups grid lv (or owned #{:pistol}))
             :door-lock     lock

--- a/src/core/state.phel
+++ b/src/core/state.phel
@@ -52,6 +52,15 @@
    this are silently ignored so the pickup never wastes."
   (php/+ max-armor armor-shard-overcap))
 
+(def max-backpacks
+  "Hard cap on stacked backpack pickups (issue #68 part 3). Each
+   stage adds one base reserve-cap's worth of ammo capacity:
+   level 0 = 1x base, level 1 = 2x, level 2 = 3x, level 3 = 4x.
+   Cap of 3 keeps a long run from approaching infinite ammo while
+   still giving the player a real reason to grab the second / third
+   backpack."
+  3)
+
 (def max-stamina
   "Hard cap on the sprint stamina pool. Fresh runs start at this value
    so the player has a full burst available the moment they spawn.
@@ -128,7 +137,11 @@
    :berserks        []
    :invuln-secs     0.0
    :invulns         []
-   :backpack?       false
+   ;; Backpack stacking (issue #68 part 3). `:backpack-level` 0..N
+   ;; replaces the old boolean. Effective reserve cap is `base * (1 +
+   ;; level)` so each pickup adds one base's worth. Capped at
+   ;; `max-backpacks` so reserve growth has a known ceiling.
+   :backpack-level  0
    :backpacks       []
    ;; Keycards. :held-keys is a set of collected colour kws
    ;; (e.g. #{:blue}). :keycards is the per-level pickup vector.
@@ -187,6 +200,33 @@
   "Add one life to the player, capped at max-lives."
   [world]
   (update world :lives (fn [l] (php/min max-lives (php/+ l 1)))))
+
+(defn backpack-level
+  "Current backpack stack count on `world`. Reads `:backpack-level`
+   directly when present; falls back to translating the legacy
+   `:backpack?` boolean (true = 1, false = 0) so older fixtures /
+   tests / carried-over fields keep working."
+  [world]
+  (let [lvl (:backpack-level world)]
+    (cond
+      (some? lvl)        lvl
+      (:backpack? world) 1
+      :else              0)))
+
+(defn gain-backpack
+  "Increment the player's backpack stack by one (capped at
+   `max-backpacks`). No-op once at the cap so a redundant pickup
+   doesn't waste; callers gate with `at-backpack-cap?`. Used by
+   `pickup-backpacks` in play.phel."
+  [world]
+  (let [lvl  (backpack-level world)
+        lvl' (php/min max-backpacks (php/+ lvl 1))]
+    (assoc world :backpack-level lvl')))
+
+(defn at-backpack-cap?
+  "True when stacking another backpack would be a no-op."
+  [world]
+  (php/>= (backpack-level world) max-backpacks))
 
 (defn gain-armor-shard
   "Stamp +1 armor on the player, capped at `armor-shard-cap` (2x

--- a/src/core/weapons.phel
+++ b/src/core/weapons.phel
@@ -146,13 +146,25 @@
   (get weapons (current-weapon world)))
 
 (defn effective-reserve-cap
-  "Active weapon's reserve cap, doubled when the player owns the
-   backpack pickup. Callers should use this in place of raw
-   `:reserve-cap` so the backpack buff propagates everywhere ammo
-   gets bumped (level pickups, kill drops, swap restores)."
+  "Active weapon's reserve cap scaled by the player's backpack
+   stack: `base * (1 + backpack-level)`. Issue #68 part 3 swapped
+   the old boolean `:backpack?` for a stacking integer
+   `:backpack-level` (0..max-backpacks) so each pickup adds one
+   base's worth of capacity. Callers should use this in place of
+   raw `:reserve-cap` so the buff propagates everywhere ammo gets
+   bumped (level pickups, kill drops, swap restores)."
   [world]
-  (let [base (or (:reserve-cap (weapon-spec world)) 0)]
-    (if (:backpack? world) (php/* 2 base) base)))
+  (let [base   (or (:reserve-cap (weapon-spec world)) 0)
+        ;; `or` would short-circuit on `:backpack-level 0` (zero is
+        ;; truthy in Phel) and skip the legacy `:backpack?` fallback,
+        ;; so an `if`+`nil?` chain is needed to honour the back-compat
+        ;; boolean when the new int field is missing.
+        bp-int (:backpack-level world)
+        lvl    (cond
+                 (some? bp-int)     bp-int
+                 (:backpack? world) 1
+                 :else              0)]
+    (php/* base (php/+ 1 lvl))))
 
 (defn initial-weapon-state
   "Per-weapon ammo state for a brand-new run: starting mag full,

--- a/src/io/render.phel
+++ b/src/io/render.phel
@@ -1563,7 +1563,16 @@
         ;; bare `\e[0m` reset would leak (the +pack chip otherwise
         ;; rendered with white halo spaces around it on iTerm2 /
         ;; Ghostty whose default BG is light).
-        pack     (if (get stats :backpack?) "\e[40m \e[40;33;1m+pack\e[40;97m" "")
+        ;; +pack chip shows the stack count beyond level 1: e.g. a
+        ;; player with 2 backpacks reads `+pack x2`. Issue #68 part 3
+        ;; switched the boolean to a stacking int; the label keeps
+        ;; backward-compatible appearance for the single-pack case.
+        bp-lvl   (or (get stats :backpack-level)
+                     (if (get stats :backpack?) 1 0))
+        pack     (cond
+                   (php/<= bp-lvl 0)  ""
+                   (php/=== bp-lvl 1) "\e[40m \e[40;33;1m+pack\e[40;97m"
+                   :else              (str "\e[40m \e[40;33;1m+pack x" bp-lvl "\e[40;97m"))
         diff     (or (get stats :difficulty) :normal)
         diff-tag (cond
                    (php/=== diff :easy)      "\e[40m \e[40;32;1m[easy]\e[40;97m"

--- a/tests/core/state-test.phel
+++ b/tests/core/state-test.phel
@@ -3,8 +3,10 @@
   (:require phel-doom.core.state :refer [new-player new-world move-player turn-player
                                          rebuild-pgrid
                                          toggle-map toggle-pause toggle-debug with-enemies
-                                         advance-game-time gain-armor-shard gain-life
-                                         gain-soulsphere decay-soul-overcap max-armor max-lives
+                                         advance-game-time at-backpack-cap?
+                                         backpack-level gain-armor-shard gain-backpack
+                                         gain-life gain-soulsphere decay-soul-overcap
+                                         max-armor max-backpacks max-lives
                                          armor-shard-cap soul-overcap-decay-secs
                                          soulsphere-cap]))
 
@@ -174,3 +176,41 @@
   ;; At cap, the pickup is a silent no-op.
   (let [w (gain-armor-shard {:armor armor-shard-cap})]
     (is (= armor-shard-cap (:armor w)))))
+
+;; ---------------------------------------------------------------------
+;; Backpack capacity expansion (issue #68 part 3): backpack pickup
+;; stacks beyond the one-shot boolean into a counter capped at
+;; max-backpacks. Effective reserve cap = base * (1 + level).
+;; ---------------------------------------------------------------------
+
+(deftest test-max-backpacks-is-three
+  (is (= 3 max-backpacks)))
+
+(deftest test-backpack-level-defaults-to-zero
+  (is (= 0 (backpack-level {}))))
+
+(deftest test-backpack-level-translates-legacy-boolean
+  (is (= 1 (backpack-level {:backpack? true})))
+  (is (= 0 (backpack-level {:backpack? false}))))
+
+(deftest test-backpack-level-prefers-int-when-set
+  ;; Both fields set: int wins so a fresh world setting the new field
+  ;; overrides any leftover boolean.
+  (is (= 2 (backpack-level {:backpack? true :backpack-level 2}))))
+
+(deftest test-gain-backpack-increments-and-caps
+  (let [w0 {}
+        w1 (gain-backpack w0)
+        w2 (gain-backpack w1)
+        w3 (gain-backpack w2)
+        w4 (gain-backpack w3)]
+    (is (= 1 (backpack-level w1)))
+    (is (= 2 (backpack-level w2)))
+    (is (= 3 (backpack-level w3)))
+    ;; Past cap: stays at max-backpacks.
+    (is (= max-backpacks (backpack-level w4)))))
+
+(deftest test-at-backpack-cap-true-only-at-max
+  (is (= false (at-backpack-cap? {:backpack-level 0})))
+  (is (= false (at-backpack-cap? {:backpack-level 2})))
+  (is (= true  (at-backpack-cap? {:backpack-level 3}))))

--- a/tests/core/weapons-test.phel
+++ b/tests/core/weapons-test.phel
@@ -1,7 +1,7 @@
 (ns phel-doom-tests.core.weapons-test
   (:require phel.test :refer [deftest is])
   (:require phel-doom.core.state :refer [new-player new-world])
-  (:require phel-doom.core.weapons :refer [current-weapon give-weapon initial-weapon-state owns? switch-weapon weapon-order weapon-spec weapons]))
+  (:require phel-doom.core.weapons :refer [current-weapon effective-reserve-cap give-weapon initial-weapon-state owns? switch-weapon weapon-order weapon-spec weapons]))
 
 (def empty-grid [[1 1 1] [1 0 1] [1 1 1]])
 
@@ -134,3 +134,23 @@
   ;; stay stable so muscle memory survives.
   (is (= [:pistol :shotgun :chaingun :chainsaw] weapon-order))
   (is (= :chainsaw (get weapon-order 3))))
+
+(deftest test-effective-reserve-cap-scales-with-backpack-level
+  ;; Pistol's reserve-cap is 50 from the catalog. Backpack stack scales
+  ;; it linearly: level 0 = 1x, level 1 = 2x, level 2 = 3x, level 3 = 4x.
+  (let [w0 (fresh-world)
+        w1 (assoc w0 :backpack-level 1)
+        w2 (assoc w0 :backpack-level 2)
+        w3 (assoc w0 :backpack-level 3)]
+    (is (= 50  (effective-reserve-cap w0)))
+    (is (= 100 (effective-reserve-cap w1)))
+    (is (= 150 (effective-reserve-cap w2)))
+    (is (= 200 (effective-reserve-cap w3)))))
+
+(deftest test-effective-reserve-cap-back-compat-with-boolean
+  ;; Legacy :backpack? true coerces to level 1 (2x cap) so older
+  ;; fixtures + carried state survive the int migration. Uses a bare
+  ;; map (no :backpack-level slot) to simulate state from before the
+  ;; migration.
+  (let [w {:weapon :pistol :backpack? true}]
+    (is (= 100 (effective-reserve-cap w)))))


### PR DESCRIPTION
## Summary

Final sub-PR of #68 (pickup variety). Backpack pickup now stacks instead of being one-shot - each grabbed backpack bumps \`:backpack-level\` by one up to \`max-backpacks\` (3), and every weapon's effective reserve cap scales linearly as \`base * (1 + backpack-level)\`.

| Level | Reserve cap multiplier |
|------:|:-----------------------|
| 0     | 1x (no backpack)       |
| 1     | 2x (= old one-shot)    |
| 2     | 3x                     |
| 3     | 4x (cap)               |

- New constant: \`max-backpacks\` 3 in \`core/state.phel\`.
- New world slot: \`:backpack-level\` 0 (replaces the old \`:backpack?\` boolean on \`new-world\`).
- New pure helpers: \`backpack-level\` reader (with legacy \`:backpack?\` fallback so older fixtures + carried state survive), \`gain-backpack\` incrementer, \`at-backpack-cap?\` predicate.
- \`weapons/effective-reserve-cap\` scales linearly; legacy boolean still translated.
- \`level/maybe-spawn-backpack\` accepts int level OR legacy bool; skips when at \`max-backpacks\` so no spawn ever wastes.
- \`level/build-world\`'s 3rd positional renamed \`pack-level\` (int with boolean coercion).
- \`commands/play\`: \`pickup-backpacks\` gates on \`at-backpack-cap?\` + bumps via \`gain-backpack\`; stats expose \`:backpack-level\`; run-levels carries the int across level cuts.
- \`io/render\`: \`+pack\` chip now reads \`+pack xN\` while stacked.

## Test plan

- [x] \`composer ci\` green (1110 tests, 0 lint warnings).
- [x] \`tests/core/state-test.phel\`: max-backpacks pinned, level defaults to 0, legacy boolean translation, int field priority, gain-backpack increments + caps, at-backpack-cap? predicate.
- [x] \`tests/core/weapons-test.phel\`: effective-reserve-cap scales linearly across levels 0..3, legacy boolean back-compat preserved.

Closes #68 (third + final sub-PR; soulsphere + armor shards landed earlier).