### PR TITLE
fix: SHIFT+WASD sprint on non-kitty terminals + reload audio polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 ### Fixed
 
 - Grid mutations (#61 secrets, doors, switches) left the raycaster's `:pgrid` stale - player walked through visually solid walls. New `state/rebuild-pgrid` resyncs after every mutation.
+- SHIFT+WASD sprint silently no-op on Terminal.app / xterm / GNOME Terminal (any non-kitty terminal). Capital W/A/S/D bytes now refresh both the matching movement slot AND `:sprint`, so SHIFT+WASD sprints universally instead of being kitty-only.
 
 ## [0.6.0] - 2026-05-27
 

--- a/composer.json
+++ b/composer.json
@@ -24,10 +24,10 @@
   "require": {
     "php": ">=8.4",
     "phel-lang/phel-lang": "dev-main",
-    "symfony/console": "^7.3"
+    "symfony/console": "^7.4"
   },
   "require-dev": {
-    "symfony/var-dumper": "^7.3"
+    "symfony/var-dumper": "^7.4"
   },
   "scripts": {
     "dev": "vendor/bin/phel run phel-doom.main",

--- a/docs/features.md
+++ b/docs/features.md
@@ -115,4 +115,4 @@ See [scores.md](scores.md).
 
 - **WAD parser** (header + lump directory + VERTEXES / LINEDEFS) - toy reader, not wired to render yet. See [wad-parser.md](wad-parser.md).
 - **Keyboard**: kitty protocol for instant release on supported terminals (kitty, WezTerm, Ghostty, Alacritty ≥0.13, iTerm2 ≥3.5); legacy hold-frame fallback on Terminal.app / GNOME Terminal / xterm. See [input.md](input.md).
-- **Sprint**: hold **SHIFT** (kitty) or **`x`** (anywhere) for 1.6× move/strafe speed. Drains a 100-unit `:stamina` pool at 30/s; regenerates at 20/s after a 0.5s cooldown. At empty, sprint stays locked until stamina recovers to 20. HUD shows a 10-cell `STA ████████░░` bar that turns amber under 33% and red at 0.
+- **Sprint**: hold **SHIFT+WASD** or **`x`** (anywhere) for 1.6× move/strafe speed. Drains a 100-unit `:stamina` pool at 30/s; regenerates at 20/s after a 0.5s cooldown. At empty, sprint stays locked until stamina recovers to 20. HUD shows a 10-cell `STA ████████░░` bar that turns amber under 33% and red at 0.

--- a/docs/input.md
+++ b/docs/input.md
@@ -62,11 +62,12 @@ Each byte refreshes its slot's counter on `:moves`. Counter is the only thing ph
 
 ## Sprint
 
-Hold **SHIFT** (kitty terminals) or **`x`** (anywhere) to sprint. Sprint multiplies forward + strafe speed by `sprint-multiplier` (1.6×) and drains the `:stamina` pool (`max-stamina` 100, drain 30/s). Stamina regenerates at 20/s after a 0.5s post-sprint cooldown. Hitting empty latches `:sprint-blocked?` until stamina recovers to `sprint-engage-threshold` (20) - prevents stutter-sprint at zero.
+Hold **SHIFT+WASD** (anywhere) or **`x`** (anywhere) to sprint. Sprint multiplies forward + strafe speed by `sprint-multiplier` (1.6×) and drains the `:stamina` pool (`max-stamina` 100, drain 30/s). Stamina regenerates at 20/s after a 0.5s post-sprint cooldown. Hitting empty latches `:sprint-blocked?` until stamina recovers to `sprint-engage-threshold` (20) - prevents stutter-sprint at zero.
 
-Two input paths:
+Three input paths:
 - **Kitty path**: `apply-kitty-events` / `apply-kitty-arrow-events` parse the `mods` field of `\e[<code>;<mods>(:<event>)?u` / `\e[1;<mods>:<event><letter>`. Mods are encoded as `bits + 1`; bit 0 = SHIFT. Press/repeat events on a movement key (WASD or arrows) with the SHIFT bit set refresh the `:sprint` slot too - so holding SHIFT+W keeps the slot warm. Release events do NOT refresh sprint (player let go).
-- **Legacy path**: `key->slot` maps the plain `"x"` byte to `:sprint` so terminals without kitty (Terminal.app, basic xterm) get a working sprint key too. Under kitty, `"x"` arrives as `\e[120u` and resolves via `ascii->slot` to the same `:sprint` refresh.
+- **Capital-WASD path**: `shift-key->slot` maps `W`/`A`/`S`/`D` bytes to the matching direction slot AND `:sprint`. In cooked raw mode on terminals without kitty CSI-u (Terminal.app, plain xterm, GNOME Terminal) SHIFT just uppercases the byte, so SHIFT+W = `W` (87). This makes SHIFT+WASD sprint work universally, not only on kitty-protocol terminals.
+- **`x` fallback**: `key->slot` maps the plain `"x"` byte to `:sprint` so any terminal gets a dedicated sprint key. Under kitty, `"x"` arrives as `\e[120u` and resolves via `ascii->slot` to the same `:sprint` refresh.
 
 The `:sprint` slot decays alongside the other movement counters in `decay-move-counters`, so sprint intent naturally evaporates the frame the player lets go.
 

--- a/docs/state.md
+++ b/docs/state.md
@@ -107,7 +107,7 @@ Seven time-limited counters drive directional motion + sprint intent:
  :strafe-right <int>
  :turn-left    <int>
  :turn-right   <int>
- :sprint       <int>}    ; SHIFT (kitty) or `x` press refresh
+ :sprint       <int>}    ; SHIFT+WASD or `x` press refresh
 ```
 
 Each input byte from `glue/controls.phel` refreshes the matching counter. Each frame `core/physics.phel` consumes whatever is non-zero (scaled by `dt`) and decays every counter by 1. Counter hits 0 = direction stops.

--- a/src/commands/play.phel
+++ b/src/commands/play.phel
@@ -508,7 +508,7 @@
             w5   (tick-enemies  w4g dt)
             w5b  (if (:reload edges)
                    (do
-                     (when (and (:sound-on w5) (reloading? w5)) (play-sfx! :reload))
+                     (when (and (:sound-on w5) (reloading? w5)) (play-sfx! :reload 0.5))
                      (reload w5))
                    w5)
             w5c  (tick-armory w5b)

--- a/src/glue/controls.phel
+++ b/src/glue/controls.phel
@@ -55,6 +55,18 @@
    "d" :strafe-right
    "x" :sprint})
 
+(def shift-key->slot
+  "Capital-letter equivalents of `key->slot` movement keys. In cooked
+   raw-mode terminals without kitty CSI-u support (Terminal.app, plain
+   xterm, GNOME Terminal) holding SHIFT just uppercases the byte, so
+   SHIFT+W = 'W' (87), SHIFT+A = 'A' (65), etc. Mapping these to the
+   matching direction slot AND :sprint makes SHIFT+WASD sprint work
+   everywhere, not just on kitty-protocol terminals."
+  {"W" :fwd
+   "S" :back
+   "A" :strafe-left
+   "D" :strafe-right})
+
 (def turn-slots
   "Slots that use turn-hold-frames instead of move-hold-frames."
   #{:turn-left :turn-right})
@@ -67,12 +79,22 @@
 
 (defn refresh-move
   "If `byte` maps to a direction slot, refresh that slot's counter on
-   `world`. Anything else (unmapped bytes) leaves the world untouched."
+   `world`. Capital W/A/S/D additionally refresh `:sprint` so SHIFT+WASD
+   sprints on terminals without kitty CSI-u (Terminal.app, xterm).
+   Anything else (unmapped bytes) leaves the world untouched."
   [world byte]
-  (let [slot (get key->slot byte)]
-    (if (nil? slot)
-      world
-      (assoc-in world [:moves slot] (hold-frames-for slot)))))
+  (let [slot       (get key->slot byte)
+        shift-slot (get shift-key->slot byte)]
+    (cond
+      (not (nil? shift-slot))
+      (-> world
+          (assoc-in [:moves shift-slot] (hold-frames-for shift-slot))
+          (assoc-in [:moves :sprint]    (hold-frames-for :sprint)))
+
+      (not (nil? slot))
+      (assoc-in world [:moves slot] (hold-frames-for slot))
+
+      :else                   world)))
 
 (def arrow-escape-keys
   "Search-side PHP array for php/str_replace: arrow-key CSI escapes."

--- a/tests/glue/controls-test.phel
+++ b/tests/glue/controls-test.phel
@@ -269,3 +269,35 @@
   ;; release feels instant.
   (let [w' (refresh-from-keys blank-world "x")]
     (is (php/<= (:sprint (:moves w')) 5))))
+
+;; ---------------------------------------------------------------------
+;; Capital WASD: legacy fallback so SHIFT+WASD sprints on terminals
+;; without kitty CSI-u (Terminal.app, plain xterm, GNOME Terminal).
+;; In cooked raw mode SHIFT just uppercases the byte, so SHIFT+W = 'W'.
+;; ---------------------------------------------------------------------
+
+(deftest test-capital-w-refreshes-fwd-and-sprint
+  (let [w' (refresh-from-keys blank-world "W")]
+    (is (php/> (:fwd    (:moves w')) 0))
+    (is (php/> (:sprint (:moves w')) 0))))
+
+(deftest test-capital-s-refreshes-back-and-sprint
+  (let [w' (refresh-from-keys blank-world "S")]
+    (is (php/> (:back   (:moves w')) 0))
+    (is (php/> (:sprint (:moves w')) 0))))
+
+(deftest test-capital-a-refreshes-strafe-left-and-sprint
+  (let [w' (refresh-from-keys blank-world "A")]
+    (is (php/> (:strafe-left (:moves w')) 0))
+    (is (php/> (:sprint      (:moves w')) 0))))
+
+(deftest test-capital-d-refreshes-strafe-right-and-sprint
+  (let [w' (refresh-from-keys blank-world "D")]
+    (is (php/> (:strafe-right (:moves w')) 0))
+    (is (php/> (:sprint       (:moves w')) 0))))
+
+(deftest test-lowercase-w-does-not-arm-sprint
+  ;; Plain w (no SHIFT) must NOT light up :sprint — only capitals do.
+  (let [w' (refresh-from-keys blank-world "w")]
+    (is (php/> (:fwd    (:moves w')) 0))
+    (is (= 0 (:sprint (:moves w'))))))


### PR DESCRIPTION
## 📚 Description

Three small fixes bundled ahead of the v0.7.0 cut.

## 🔖 Changes

### `fix(controls)`: SHIFT+WASD sprint on non-kitty terminals

Capital W/A/S/D bytes were unmapped. SHIFT+WASD silently no-op'd on Terminal.app, plain xterm, GNOME Terminal — sprint only worked on kitty CSI-u terminals (kitty, WezTerm, Ghostty, iTerm2 with the flag) or via the `x` fallback. Docs claimed "SHIFT (kitty) or `x` anywhere" but users on Terminal.app reasonably expected SHIFT to do something.

New `shift-key->slot` in `src/glue/controls.phel` maps capital letters to the matching direction slot AND `:sprint`. In cooked raw mode SHIFT just uppercases the byte, so `W` (87) now refreshes `:fwd` + `:sprint` universally. Lowercase `w` still arms only `:fwd` (regression test added).

`x` legacy key + kitty CSI-u SHIFT path unchanged.

### `fix(audio)`: lower reload SFX volume

`:reload` (`Funk.aiff` on macOS) sat at full `1.0` — louder than `:shoot`, `:hit`, `:click`. Dropped to `0.5` at `src/commands/play.phel:511`.

### `chore(deps)`: bump symfony to `^7.4`

`symfony/console` + `symfony/var-dumper`: `^7.3` → `^7.4`. Lock file already satisfied, no install delta.

## Test plan

- [x] `composer ci` green (format-check, lint, **1129** tests, build)
- [x] 5 new controls tests cover capital W/A/S/D arming sprint + lowercase regression
- [ ] Manual smoke on Terminal.app: hold SHIFT+W → stamina bar drains, player accelerates
- [ ] Manual smoke on kitty / Ghostty: SHIFT+WASD still works via CSI-u path (regression check)
- [ ] Reload sound clearly quieter than shoot/hit