### PR TITLE
feat(enemy): projectile-firing casters (cacodemon + baron)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 
 ### Added
 
+- Projectile enemies. Cacodemons and barons now fire homing-less fireballs across the room instead of only meleeing: they freeze, telegraph (attack-face windup), then launch an orange bolt at your current position. Bolts travel through doorways but stop at walls, so you dodge by strafing or breaking line of fire with geometry. Impact costs one armor/life unit; i-frames gate a burst to one hit per frame.
 - Wandering idle enemies. Half the freshly spawned monsters start pacing random directions; LOS flips them to chase.
 - Backpack capacity expansion (#68 part 3). Stacks up to 3; reserve cap scales `base * (1 + level)`. HUD shows `+pack xN`.
 - Armor shards (#68 part 2). +1 armor pickup that banks past `max-armor` up to 2x (no decay). Three per level.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -15,6 +15,7 @@ src/
 │   ├── enemy.phel                   ; spawn-enemies, advance, shoot, respawn timer
 │   ├── enemy_ai.phel                ; AI state machine (dormant/wander/aware/hunting/pain/attacking)
 │   ├── enemies.phel                 ; enemy-type catalog (visuals + default HP)
+│   ├── projectile.phel              ; enemy fireballs: spawn + march + player impacts
 │   ├── level.phel                   ; 10-level catalog + build-world factory
 │   ├── weapons.phel                 ; per-weapon stat catalog + switch/reload
 │   ├── perf.phel                    ; big-screen perf-mode predicates
@@ -67,7 +68,8 @@ Tests never need a fake terminal, audio device, or disk: all tests import from `
               │     shards, ammo, berserk,    │
               │     invuln, soul, backpack,   │
               │     keycards, weapon-pickups) │
-              │   tick-enemies / reload       │
+              │   tick-enemies                │
+              │   tick-projectiles / reload   │
               │   tick-armory / tick-shooting │
               │   damage-step + horror layer  │
               │   decay-soul-overcap          │

--- a/docs/combat.md
+++ b/docs/combat.md
@@ -137,6 +137,12 @@ Four gates: i-frame window, invulnerability sphere timer, dev god mode, AND at l
 - 0.05s flash: `render!` paints viewport white. One-frame jolt before the red i-frame wash.
 - Player knockback shove away from the attacker; arms `:hurt-side` (one of `:left` `:right` `:front` `:back`) so the directional red band paints on the matching edge. Front and back use a narrow ±30° wedge around the player's facing / anti-facing vectors; everything else routes to the wider left / right edges. Closes the rear blind spot that the previous left-only / right-only routing left open (issue #66).
 
+Internally `take-damage` and the projectile path share `apply-hit`, which takes an attacker `{:x :y :d2}` (the nearest enemy for contact, the bolt impact point for projectiles).
+
+### hit-player-at + player-immune? (projectile impacts)
+
+`hit-player-at world sx sy` applies the same hit as a contact touch but from an arbitrary world point - an enemy fireball impact (see [monsters.md](monsters.md) ranged casters + `core/projectile.phel`). `player-immune? world` is the projectile-side gate: i-frames, invuln sphere, or dev god mode - the same guards as `vulnerable?` minus the enemy-touch test. `core/projectile/resolve-hits` checks it before calling `hit-player-at`, so a bolt fizzles on the i-frame shield instead of phasing through.
+
 ### Chainsaw
 
 Slot-4 melee weapon. Spec lives in `weapons/weapons :chainsaw` and carries three flags that the combat path branches on:

--- a/docs/features.md
+++ b/docs/features.md
@@ -34,6 +34,7 @@ See [level-system.md](level-system.md), [map.md](map.md).
 - Per-level HP (L1 imp 1, L2 demon 2, L3 caco 3, L4 baron 4, L5 cyber 5; L10 boss cyber 50). Wounded body shades darker as HP drops; a yellow HP digit floats above the head for 1.2s after each hit
 - Shot knockback: every wounding hit shoves the enemy ~1 cell back along the shot direction (wall-clamped; killing blow skips push so corpse lands on death cell)
 - Pain chance per type (`cyber 0.05`, `imp 0.35`, etc.) - heavier bosses ignore most hits; fragile monsters flinch on nearly every shot
+- Projectile casters: cacodemons + barons fire dodgeable fireballs (long-range telegraphed windup, then an orange bolt aimed at your position). Bolts pass doorways, stop at walls, cost one armor/life on impact (i-frames gate a burst to one hit). Strafe or break line of fire to dodge. See `core/projectile.phel`.
 - Cyberdemon chase speed scaled to 0.55× for playability
 - Hitscan combat: distance-attenuated kill/wound sfx, blood splatter, muzzle flash, 5-stage death anim, 3-6s respawn cooldown
 - 4-slot loadout (1/2/3/4), DPS-balanced niches. Pistol on every run; rest must be found.

--- a/docs/game-loop.md
+++ b/docs/game-loop.md
@@ -82,6 +82,7 @@ Four lifecycle layers:
           (pickup-berserks) (pickup-invulns) (pickup-soulspheres)
           (pickup-backpacks) (pickup-keycards) (pickup-weapon-pickups)
           (tick-enemies dt)
+          (tick-projectiles dt)
           (maybe-reload edges)
           (tick-armory)
           (tick-shooting (:fire edges) (:fire-held edges))
@@ -102,6 +103,7 @@ Four lifecycle layers:
 | `tick-stamina` + `apply-physics` | Drain sprint pool, then rotate + translate + decay counters | `core/physics` |
 | `pickup-*` | Hearts, armor + shards, ammo, berserk, invuln, soulsphere, backpack, keycards, weapon pickups | `commands/play` |
 | `tick-enemies` | Step alive enemies; tick respawn + AI + hit-flash | `core/enemy`, `enemy_ai` |
+| `tick-projectiles` | Spawn caster fireballs, march + cull bolts, resolve player impacts | `core/projectile` |
 | `reload` | R edge: drain `:ammo-reserve` into `:mag`, arm cooldown + anim | `core/combat` |
 | `tick-armory` | `--armory` flag: refill reserves to `armory-reserve` per frame | `core/combat` |
 | `tick-shooting` | Fire edge: resolve hitscan; empty mag arms CLICK prompt | `core/combat` |

--- a/docs/monsters.md
+++ b/docs/monsters.md
@@ -55,6 +55,18 @@ Each enemy carries a `:state` keyword + an optional `:lkp` (last-known player po
 - **`:attacking`** - telegraphed strike window. When an `:aware` enemy is inside its per-type `attack-spec` `:range` AND its `:attack-cooldown-secs` has fully decayed, `maybe-start-attack` flips state to `:attacking` and arms `:attack-windup-secs`. While `:attacking` the enemy stops moving (visible telegraph) but `:attacks?` stays true so contact damage still applies. `tick-attack` decays the windup; on expiry state reverts to `:aware` and the per-type `:cooldown` arms so the enemy chases for at least one cooldown window before the next telegraphed strike. Cooldown ticks every frame regardless of state so a brief `:pain` interrupt doesn't leave a stale cooldown armed.
 - **`:wander`** - opt-in random patrol. `start-wander` promotes a `:dormant` enemy to `:wander` with a fresh random `:wander-angle` and `:wander-secs` timer. `target-pos` projects `wander-step-dist` units ahead in the current angle so `step-toward` walks the enemy in that direction. `tick-wander` rolls a new angle every `wander-step-secs`. `:wander` reacts to LOS / noise the same way `:dormant` does (LOS → `:aware`, noise → `:hunting`). Real-game spawns stay `:dormant` by default to preserve the sneak feel; levels / types opt in by mapping `start-wander` over fresh batches.
 
+### Ranged casters (projectiles)
+
+Cacodemons (`:caco`) and barons (`:baron`) are casters: instead of meleeing on windup-release they launch a fireball. `enemy_ai/caster-spec` gives them a much longer `:range` (caco 7.0, baron 8.0) so they commit to an attack from across the room, plus a bolt `:speed`. `attack-spec-of` prefers `caster-spec` over the melee `attack-spec`, so the `:attacking` rhythm above drives them unchanged: freeze, telegraph the windup, release. On release `tick-attack` raises `:fire-now` on the enemy (melee types leave it `false`).
+
+The projectile pipeline lives in `core/projectile.phel` and runs once per frame between `tick-enemies` and `damage-step` in `play/tick-world`:
+
+- `spawn-from-enemies` harvests every `:fire-now` enemy, aims one bolt at the player's current position, then clears the flag. Bolt = `{:x :y :vx :vy :ttl :type :fireball}` in world `:projectiles`.
+- `step` marches each bolt along its velocity; a bolt that crosses into a solid cell (`map/wall?` - walls/secrets/switches; doors pass) or whose `projectile-ttl` (4s) runs out is dropped.
+- `resolve-hits` consumes any bolt within `hit-radius` (0.6) of the player and lands one hit via `combat/hit-player-at` unless `combat/player-immune?` (i-frames / invuln / god). The hit's i-frames absorb the rest of a burst the same frame, so a wall of bolts costs at most one unit. Running before `damage-step` means a bolt hit and a contact hit can't both land in one frame.
+
+A caster still melees on contact - the touch test ignores range - so cornering one is still dangerous. Dodge bolts by strafing or breaking line of fire around a corner. Render draws each bolt as a white-hot core on an orange glow via the shared `project-enemy` pipeline (`io/render.phel` `paint-projectiles-into`), occluded by walls only so it always reads in front of its caster.
+
 ### Wake / transition triggers
 
 - **LOS** - every tick, `enemy-ai/observe` casts one ray from each alive enemy to the player via `engine/cast-ray`. Ray hits a wall before reaching the player cell → no LOS. Player closer than the wall → LOS clear. Capped at `max-depth` (12 units) - long sectors read as "too far to see" (DOOM sight cutoff).

--- a/docs/state.md
+++ b/docs/state.md
@@ -15,7 +15,8 @@ Pure data shapes that every other module operates on. `src/core/state.phel`.
  :show-map   <bool>     ; minimap toggle (default OFF, M toggles)
  :paused     <bool>     ; P toggle
  :sound-on   <bool>     ; N toggle
- :enemies    <vector of {:x :y :alive :lives :max-lives :type :hit-flash-secs [:respawn-after] [:max-concurrent]}>
+ :enemies    <vector of {:x :y :alive :lives :max-lives :type :hit-flash-secs [:respawn-after] [:max-concurrent] [:fire-now]}>
+ :projectiles <vector of {:x :y :vx :vy :ttl :type}>  ; enemy fireballs (core/projectile)
  :hearts     <vector of {:x :y}>
  :armors     <vector of {:x :y}>
  :ammo-boxes <vector of {:x :y}>

--- a/src/commands/play.phel
+++ b/src/commands/play.phel
@@ -13,6 +13,7 @@
   (:require phel-doom.core.engine   :refer [mark-visible-cells])
   (:require phel-doom.core.combat   :refer [ammo-per-box arm-berserk berserk-seconds damage-step fire-anim-seconds invuln-seconds max-reserve reload reloading? reload-cooldown-seconds tick-armory tick-shooting])
   (:require phel-doom.core.enemy    :refer [advance tick-scare rear-attacker?])
+  (:require phel-doom.core.projectile :refer [tick-projectiles])
   (:require phel-doom.core.weapons  :refer [effective-reserve-cap give-weapon switch-weapon weapon-spec weapon-order weapons])
   (:require phel-doom.io.sound    :refer [play-sfx! mute-for!])
   (:require phel-doom.core.level    :refer [build-world num-levels])
@@ -506,11 +507,17 @@
             w4f  (pickup-keycards w4e)
             w4g  (pickup-weapon-pickups w4f)
             w5   (tick-enemies  w4g dt)
+            ;; Casters that released this frame have :fire-now set;
+            ;; spawn + march their bolts and resolve player impacts
+            ;; before damage-step so a bolt hit and a contact hit can't
+            ;; both land in one frame (the bolt's i-frames gate the
+            ;; touch test).
+            wp   (tick-projectiles w5 dt)
             w5b  (if (:reload edges)
                    (do
-                     (when (and (:sound-on w5) (reloading? w5)) (play-sfx! :reload 0.3))
-                     (reload w5))
-                   w5)
+                     (when (and (:sound-on wp) (reloading? wp)) (play-sfx! :reload 0.3))
+                     (reload wp))
+                   wp)
             w5c  (tick-armory w5b)
             w6   (tick-shooting w5c (:fire edges) (:fire-held edges))
             w7   (damage-step   w6 dt)

--- a/src/core/combat.phel
+++ b/src/core/combat.phel
@@ -321,33 +321,59 @@
   [^float dist]
   (php/max 0.1 (php/- 1.0 (php/min 1.0 (php// dist shot-max-range)))))
 
-(defn- take-damage [world]
+(defn- apply-hit
+  "Land one hit on the player from attacker `att` ({:x :y :d2} or nil),
+   `vol`-scaled pain sfx included. Armor absorbs the hit (drop a unit
+   instead of a life) but still triggers i-frames + the white flash so
+   the player sees the armor consumed. Knockback shoves away from the
+   attacker first, then the timers + hurt-side stamp onto the shoved
+   world so render reads the new position next frame. Shared by the
+   contact path (`take-damage`) and the projectile path
+   (`hit-player-at`)."
+  [world att ^float vol]
   (let [p       (:player world)
-        att     (closest-attacker (:enemies world) (:x p) (:y p))
         armor   (or (:armor world) 0)
-        ;; Distance-attenuate the player-pain sfx the same way `:kill`
-        ;; / `:wound` are scaled: a far enemy chipping a life off
-        ;; should sound as quiet as the final hit that drops a far
-        ;; enemy, not blast at full volume from across the map.
-        ;; closest-attacker already cached squared distance, no extra
-        ;; pass over the enemies vector.
-        vol     (if att
-                  (distance-volume (php/sqrt (or (:d2 att) 0.0)))
-                  1.0)
-        ;; Armor absorbs the hit: drop the unit instead of a life. Still
-        ;; trigger i-frames + the visual flash so the player sees the
-        ;; armor consumed.
         damaged (if (php/> armor 0)
                   (assoc world :armor (php/- armor 1))
                   (update world :lives (fn [l] (php/max 0 (php/- l 1)))))]
     (when (:sound-on world) (play-sfx! :hit vol))
-    ;; Knockback first, then stamp the timers + hurt-side on the
-    ;; shoved world so render reads the new player position next
-    ;; frame.
     (assoc (knockback damaged att)
            :iframes    iframe-seconds
            :flash-secs flash-seconds
            :hurt-side  (attacker-side att (:x p) (:y p) (:angle p)))))
+
+(defn player-immune?
+  "True when an incoming hit can't land: i-frames still ticking, an
+   invuln powerup is up, or dev god mode. Mirrors `vulnerable?`'s
+   guards minus the enemy-touch test so the projectile path
+   (core/projectile) shares the exact immunity rule."
+  [world]
+  (or (php/> (:iframes world) 0.0)
+      (php/> (or (:invuln-secs world) 0.0) 0.0)
+      (:god? world)))
+
+(defn hit-player-at
+  "Apply one hit from a point source at world `(sx, sy)` — a projectile
+   impact. Same effect as a contact hit (armor/life, i-frames, flash,
+   distance-scaled sfx, knockback + hurt-side away from the source) but
+   the attacker is an arbitrary point rather than the nearest enemy.
+   Caller must gate on `player-immune?` first."
+  [world ^float sx ^float sy]
+  (let [p  (:player world)
+        dx (php/- sx (:x p))
+        dy (php/- sy (:y p))
+        d2 (php/+ (php/* dx dx) (php/* dy dy))]
+    (apply-hit world {:x sx :y sy :d2 d2} (distance-volume (php/sqrt d2)))))
+
+(defn- take-damage [world]
+  (let [p   (:player world)
+        att (closest-attacker (:enemies world) (:x p) (:y p))
+        ;; Distance-attenuate the player-pain sfx the same way `:kill`
+        ;; / `:wound` are scaled: a far enemy chipping a life off
+        ;; should sound as quiet as the final hit that drops a far
+        ;; enemy. closest-attacker already cached squared distance.
+        vol (if att (distance-volume (php/sqrt (or (:d2 att) 0.0))) 1.0)]
+    (apply-hit world att vol)))
 
 (defn damage-step
   "Per-frame: decay every timer, then apply a touch hit if i-frames

--- a/src/core/combat.phel
+++ b/src/core/combat.phel
@@ -238,14 +238,20 @@
            :streak        (if (php/<= streak-secs' 0.0) 0 (or (:streak world) 0))
            :fx            (decay-fx (:fx world) dt))))
 
+(defn player-immune?
+  "True when an incoming hit can't land: i-frames still ticking, an
+   invuln powerup is up, or dev god mode (--god, which suppresses damage
+   entirely so the player can roam every room — reload + ammo + AI still
+   run so the rest of the loop is exercised). Shared by the contact path
+   (`vulnerable?`) and the projectile path (core/projectile) so the
+   immunity rule lives in one place."
+  [world]
+  (or (php/> (:iframes world) 0.0)
+      (php/> (or (:invuln-secs world) 0.0) 0.0)
+      (:god? world)))
+
 (defn- vulnerable? [world]
-  (and (php/<= (:iframes world) 0.0)
-       (php/<= (or (:invuln-secs world) 0.0) 0.0)
-       ;; Dev god mode (--god): contact damage is
-       ;; suppressed entirely so the player can roam every room
-       ;; without dying. Reload + ammo + AI all still run so the
-       ;; rest of the loop is exercised normally.
-       (not (:god? world))
+  (and (not (player-immune? world))
        (enemies-touching? (:enemies world)
                           (:x (:player world))
                           (:y (:player world)))))
@@ -341,16 +347,6 @@
            :iframes    iframe-seconds
            :flash-secs flash-seconds
            :hurt-side  (attacker-side att (:x p) (:y p) (:angle p)))))
-
-(defn player-immune?
-  "True when an incoming hit can't land: i-frames still ticking, an
-   invuln powerup is up, or dev god mode. Mirrors `vulnerable?`'s
-   guards minus the enemy-touch test so the projectile path
-   (core/projectile) shares the exact immunity rule."
-  [world]
-  (or (php/> (:iframes world) 0.0)
-      (php/> (or (:invuln-secs world) 0.0) 0.0)
-      (:god? world)))
 
 (defn hit-player-at
   "Apply one hit from a point source at world `(sx, sy)` — a projectile

--- a/src/core/enemy_ai.phel
+++ b/src/core/enemy_ai.phel
@@ -342,8 +342,10 @@
    is the seconds spent in :aware afterwards before the next attack
    can arm. Bosses telegraph slower and rest longer; fragile fast
    enemies (pinky) chain hits."
+  ;; Melee profiles only. Ranged casters (caco, baron) live in
+  ;; `caster-spec`, which `attack-spec-of` consults first — keep them
+  ;; OUT of this map so there's no shadowed/dead entry to drift.
   {:imp      {:range 1.4 :windup 0.4 :cooldown 1.0}
-   :baron    {:range 1.6 :windup 0.6 :cooldown 1.4}
    :cyber    {:range 1.8 :windup 0.8 :cooldown 1.8}
    :pinky    {:range 1.4 :windup 0.3 :cooldown 0.8}
    :mancubus {:range 1.6 :windup 0.5 :cooldown 1.3}})
@@ -368,9 +370,10 @@
    :baron {:range 8.0 :windup 0.7 :cooldown 2.0 :speed 5.5}})
 
 (defn caster?
-  "True when this enemy type fires projectiles rather than meleeing on
-   windup-release. Drives both the spec lookup and the `:fire-now`
-   flag `tick-attack` raises for the projectile-spawn pass."
+  "True when this enemy's `:type` fires projectiles rather than meleeing
+   on windup-release (i.e. has a `caster-spec` entry). Takes the enemy
+   map, not a bare type keyword. Drives both the spec lookup and the
+   `:fire-now` flag `tick-attack` raises for the projectile-spawn pass."
   [enemy]
   (contains? caster-spec (:type enemy)))
 

--- a/src/core/enemy_ai.phel
+++ b/src/core/enemy_ai.phel
@@ -355,12 +355,34 @@
    delay."
   {:range 1.4 :windup 0.4 :cooldown 1.0})
 
-(defn attack-spec-of
-  "Pull the per-type spec or fall back to the default. Pure lookup —
-   `maybe-start-attack` + `tick-attack` consult it on every alive
-   enemy."
+(def caster-spec
+  "Ranged casters: instead of a melee strike on windup-release they
+   launch a projectile (see core/projectile) toward the player's
+   position at fire time. `:range` is much longer so they commit from
+   across the room; `:windup` is the telegraph (frozen, face flips to
+   the attack glyph) before the bolt leaves; `:speed` is the bolt's
+   world-units/sec. Impact costs one life/armor unit, same as a contact
+   hit. A caster still melees on contact (the touch test in combat
+   ignores range), so cornering one is still dangerous."
+  {:caco  {:range 7.0 :windup 0.5 :cooldown 1.6 :speed 4.5}
+   :baron {:range 8.0 :windup 0.7 :cooldown 2.0 :speed 5.5}})
+
+(defn caster?
+  "True when this enemy type fires projectiles rather than meleeing on
+   windup-release. Drives both the spec lookup and the `:fire-now`
+   flag `tick-attack` raises for the projectile-spawn pass."
   [enemy]
-  (or (get attack-spec (:type enemy)) default-attack-spec))
+  (contains? caster-spec (:type enemy)))
+
+(defn attack-spec-of
+  "Pull the per-type spec or fall back to the default. Casters use
+   their long-range projectile profile so `maybe-start-attack` +
+   `tick-attack` commit them from across the room. Pure lookup —
+   consulted on every alive enemy each frame."
+  [enemy]
+  (or (get caster-spec (:type enemy))
+      (get attack-spec (:type enemy))
+      default-attack-spec))
 
 (defn in-attack-range?
   "True when the player is within this enemy's attack `:range`.
@@ -414,7 +436,13 @@
           (assoc enemy
                  :state                :aware
                  :attack-windup-secs   0.0
-                 :attack-cooldown-secs (:cooldown (attack-spec-of enemy)))
+                 :attack-cooldown-secs (:cooldown (attack-spec-of enemy))
+                 ;; Casters release a projectile on windup-expiry. The
+                 ;; spawn pass (core/projectile) harvests this flag,
+                 ;; aims a bolt at the player, then clears it. Melee
+                 ;; enemies leave it false — their hit already landed
+                 ;; via the contact test during the windup window.
+                 :fire-now             (caster? enemy))
           (assoc enemy
                  :attack-windup-secs   w'
                  :attack-cooldown-secs cd')))

--- a/src/core/projectile.phel
+++ b/src/core/projectile.phel
@@ -34,6 +34,18 @@
    normal speeds."
   0.6)
 
+(defn- any-firing?
+  "True if any enemy in the vector has `:fire-now` set. Short-circuits
+   on the first match so the common no-fire frame pays a partial scan,
+   not a full one. Lets `spawn-from-enemies` skip all allocation when
+   nobody fired this frame."
+  [enemies]
+  (loop [es enemies]
+    (cond
+      (nil? es)              false
+      (:fire-now (first es)) true
+      :else                  (recur (next es)))))
+
 (defn spawn-from-enemies
   "Harvest every enemy whose `:fire-now` flag is set (raised by
    enemy-ai/tick-attack on a caster's windup-release): launch one bolt
@@ -41,36 +53,45 @@
    world with the new bolts appended to `:projectiles` and the enemies
    un-flagged. No-op (and no allocation) on a frame where nobody fired."
   [world]
-  (let [enemies (or (:enemies world) [])
-        firing  (apply vector (filter (fn [e] (:fire-now e)) enemies))]
-    (if (empty? firing)
+  (let [enemies (or (:enemies world) [])]
+    (if (not (any-firing? enemies))
+      ;; Hot path: most frames nobody fires. Short-circuit before any
+      ;; allocation so the per-frame call costs one scan, not a rebuild
+      ;; of the enemies + projectiles vectors.
       world
-      (let [p         (:player world)
-            px        (:x p)
-            py        (:y p)
-            new-bolts
-            (apply vector
-                   (map (fn [e]
-                          (let [spec (get caster-spec (:type e))
-                                spd  (or (:speed spec) 4.0)
-                                ang  (php/atan2 (php/- py (:y e))
-                                                (php/- px (:x e)))
-                                ca   (php/cos ang)
-                                sa   (php/sin ang)]
-                            {:x    (php/+ (:x e) (php/* ca spawn-offset))
-                             :y    (php/+ (:y e) (php/* sa spawn-offset))
-                             :vx   (php/* spd ca)
-                             :vy   (php/* spd sa)
-                             :ttl  projectile-ttl
-                             :type :fireball}))
-                        firing))
-            cleared
-            (apply vector
-                   (map (fn [e] (if (:fire-now e) (assoc e :fire-now false) e))
-                        enemies))]
+      (let [p   (:player world)
+            px  (:x p)
+            py  (:y p)
+            ;; One walk produces both the new bolts and the un-flagged
+            ;; enemies — no second pass to clear :fire-now. :speed is
+            ;; read straight from caster-spec (no fallback): only a
+            ;; caster ever carries :fire-now, so the entry always
+            ;; exists, and a future type that fires without a spec
+            ;; should fail loudly rather than spawn a default bolt.
+            acc (reduce
+                 (fn [a e]
+                   (if (:fire-now e)
+                     (let [spec (get caster-spec (:type e))
+                           spd  (:speed spec)
+                           ang  (php/atan2 (php/- py (:y e))
+                                           (php/- px (:x e)))
+                           ca   (php/cos ang)
+                           sa   (php/sin ang)
+                           bolt {:x    (php/+ (:x e) (php/* ca spawn-offset))
+                                 :y    (php/+ (:y e) (php/* sa spawn-offset))
+                                 :vx   (php/* spd ca)
+                                 :vy   (php/* spd sa)
+                                 :ttl  projectile-ttl
+                                 :type :fireball}]
+                       {:bolts   (conj (:bolts a) bolt)
+                        :enemies (conj (:enemies a) (assoc e :fire-now false))})
+                     {:bolts   (:bolts a)
+                      :enemies (conj (:enemies a) e)}))
+                 {:bolts [] :enemies []}
+                 enemies)]
         (-> world
-            (assoc :enemies cleared)
-            (update :projectiles (fn [ps] (into (or ps []) new-bolts))))))))
+            (assoc :enemies (:enemies acc))
+            (update :projectiles (fn [ps] (into (or ps []) (:bolts acc)))))))))
 
 (defn step
   "March each bolt one dt-scaled frame along its velocity. Drop a bolt
@@ -99,18 +120,26 @@
    whether or not they dealt damage (they fizzle on the i-frame shield
    rather than phasing through)."
   [world]
-  (let [p         (:player world)
-        px        (:x p)
-        py        (:y p)
-        r2        (php/* hit-radius hit-radius)
-        projs     (or (:projectiles world) [])
-        hit?      (fn [pr]
-                    (let [dx (php/- (:x pr) px)
-                          dy (php/- (:y pr) py)]
-                      (php/<= (php/+ (php/* dx dx) (php/* dy dy)) r2)))
-        struck    (apply vector (filter hit? projs))
-        remaining (apply vector (filter (fn [pr] (not (hit? pr))) projs))
-        w'        (assoc world :projectiles remaining)]
+  (let [p      (:player world)
+        px     (:x p)
+        py     (:y p)
+        r2     (php/* hit-radius hit-radius)
+        projs  (or (:projectiles world) [])
+        hit?   (fn [pr]
+                 (let [dx (php/- (:x pr) px)
+                       dy (php/- (:y pr) py)]
+                   (php/<= (php/+ (php/* dx dx) (php/* dy dy)) r2)))
+        ;; One walk partitions into struck (consumed) vs remaining so
+        ;; `hit?` is evaluated once per bolt, not twice.
+        parts  (reduce
+                (fn [a pr]
+                  (if (hit? pr)
+                    {:struck (conj (:struck a) pr) :rest (:rest a)}
+                    {:struck (:struck a) :rest (conj (:rest a) pr)}))
+                {:struck [] :rest []}
+                projs)
+        struck (:struck parts)
+        w'     (assoc world :projectiles (:rest parts))]
     (if (and (not (empty? struck))
              (not (player-immune? world)))
       (let [b (first struck)]
@@ -122,9 +151,7 @@
    them, then resolve player impacts. Single entry point for the game
    loop."
   [world ^float dt]
-  ;; Sequential lets, not `->`: the lint pass doesn't macro-expand the
-  ;; thread macro and false-positives arity on the trailing
-  ;; (resolve-hits) call. Same convention as play/tick-world.
+  ;; Sequential lets, not `->` — same lint workaround as play/tick-world.
   (let [spawned (spawn-from-enemies world)
         marched (update spawned :projectiles step (:grid spawned) dt)]
     (resolve-hits marched)))

--- a/src/core/projectile.phel
+++ b/src/core/projectile.phel
@@ -1,0 +1,130 @@
+(ns phel-doom.core.projectile
+  (:require phel-doom.core.map      :refer [wall?])
+  (:require phel-doom.core.enemy-ai :refer [caster-spec])
+  (:require phel-doom.core.combat   :refer [hit-player-at player-immune?]))
+
+;; ---------------------------------------------------------------------
+;; Enemy projectiles (fireballs). Ranged casters (caco, baron) launch a
+;; bolt on attack windup-release instead of meleeing — see
+;; enemy-ai/caster-spec + tick-attack, which raise an enemy's :fire-now
+;; flag on the firing frame. The pipeline here is pure data: harvest
+;; those flags into world :projectiles, march each bolt along its
+;; velocity, cull on wall / lifetime, and resolve player impacts
+;; through combat/hit-player-at. Bolts pass through doorways (doors
+;; aren't walls) but stop at solid cells, so the player can break line
+;; of fire with geometry.
+;; ---------------------------------------------------------------------
+
+(def projectile-ttl
+  "Seconds a bolt lives before it despawns even if it never hits a wall
+   or the player. A safety net so a bolt fired down a long corridor the
+   player has left can't accumulate forever."
+  4.0)
+
+(def spawn-offset
+  "World-units to nudge the spawn point out from the enemy centre toward
+   the player, so a freshly launched bolt clears the caster's own cell
+   instead of self-colliding on frame one."
+  0.6)
+
+(def hit-radius
+  "World-units proximity at which a bolt is considered to strike the
+   player. A touch wider than the contact-damage distance so a
+   fast-moving bolt can't tunnel past the player point between frames at
+   normal speeds."
+  0.6)
+
+(defn spawn-from-enemies
+  "Harvest every enemy whose `:fire-now` flag is set (raised by
+   enemy-ai/tick-attack on a caster's windup-release): launch one bolt
+   aimed at the player's current cell, then clear the flag. Returns the
+   world with the new bolts appended to `:projectiles` and the enemies
+   un-flagged. No-op (and no allocation) on a frame where nobody fired."
+  [world]
+  (let [enemies (or (:enemies world) [])
+        firing  (apply vector (filter (fn [e] (:fire-now e)) enemies))]
+    (if (empty? firing)
+      world
+      (let [p         (:player world)
+            px        (:x p)
+            py        (:y p)
+            new-bolts
+            (apply vector
+                   (map (fn [e]
+                          (let [spec (get caster-spec (:type e))
+                                spd  (or (:speed spec) 4.0)
+                                ang  (php/atan2 (php/- py (:y e))
+                                                (php/- px (:x e)))
+                                ca   (php/cos ang)
+                                sa   (php/sin ang)]
+                            {:x    (php/+ (:x e) (php/* ca spawn-offset))
+                             :y    (php/+ (:y e) (php/* sa spawn-offset))
+                             :vx   (php/* spd ca)
+                             :vy   (php/* spd sa)
+                             :ttl  projectile-ttl
+                             :type :fireball}))
+                        firing))
+            cleared
+            (apply vector
+                   (map (fn [e] (if (:fire-now e) (assoc e :fire-now false) e))
+                        enemies))]
+        (-> world
+            (assoc :enemies cleared)
+            (update :projectiles (fn [ps] (into (or ps []) new-bolts))))))))
+
+(defn step
+  "March each bolt one dt-scaled frame along its velocity. Drop a bolt
+   that crosses into a solid cell (walls + secrets + switches; doors
+   pass) or whose lifetime expired. Pure: takes + returns the bolt
+   vector, no world / player. `grid` is the Phel cell grid."
+  [projectiles grid ^float dt]
+  (apply vector
+         (filter some?
+                 (map (fn [pr]
+                        (let [nx   (php/+ (:x pr) (php/* (:vx pr) dt))
+                              ny   (php/+ (:y pr) (php/* (:vy pr) dt))
+                              ttl' (php/- (:ttl pr) dt)]
+                          (if (or (php/<= ttl' 0.0)
+                                  (wall? grid (php/intval nx) (php/intval ny)))
+                            nil
+                            (assoc pr :x nx :y ny :ttl ttl'))))
+                      (or projectiles [])))))
+
+(defn resolve-hits
+  "Consume every bolt within `hit-radius` of the player. If the player
+   isn't immune (i-frames / invuln / god — see combat/player-immune?)
+   the first such bolt lands one hit via combat/hit-player-at; i-frames
+   from that hit then absorb any others the same frame, so a burst can't
+   drain multiple lives at once. Bolts that reach the player are removed
+   whether or not they dealt damage (they fizzle on the i-frame shield
+   rather than phasing through)."
+  [world]
+  (let [p         (:player world)
+        px        (:x p)
+        py        (:y p)
+        r2        (php/* hit-radius hit-radius)
+        projs     (or (:projectiles world) [])
+        hit?      (fn [pr]
+                    (let [dx (php/- (:x pr) px)
+                          dy (php/- (:y pr) py)]
+                      (php/<= (php/+ (php/* dx dx) (php/* dy dy)) r2)))
+        struck    (apply vector (filter hit? projs))
+        remaining (apply vector (filter (fn [pr] (not (hit? pr))) projs))
+        w'        (assoc world :projectiles remaining)]
+    (if (and (not (empty? struck))
+             (not (player-immune? world)))
+      (let [b (first struck)]
+        (hit-player-at w' (:x b) (:y b)))
+      w')))
+
+(defn tick-projectiles
+  "One full projectile frame: spawn freshly fired bolts, march + cull
+   them, then resolve player impacts. Single entry point for the game
+   loop."
+  [world ^float dt]
+  ;; Sequential lets, not `->`: the lint pass doesn't macro-expand the
+  ;; thread macro and false-positives arity on the trailing
+  ;; (resolve-hits) call. Same convention as play/tick-world.
+  (let [spawned (spawn-from-enemies world)
+        marched (update spawned :projectiles step (:grid spawned) dt)]
+    (resolve-hits marched)))

--- a/src/core/state.phel
+++ b/src/core/state.phel
@@ -114,6 +114,7 @@
    :debug?    false
    :sound-on  true
    :enemies   []
+   :projectiles []
    :hearts    []
    :armors    []
    :ammo-boxes []

--- a/src/io/render.phel
+++ b/src/io/render.phel
@@ -2283,16 +2283,19 @@
 
 (defn- paint-projectiles-into
   "Project each enemy fireball to screen and write its orange glow plus
-   a white-hot core glyph into `blood-paint`. Same projection pipeline
-   as enemies / pickups; occlusion checks walls only (`dists`) so a
-   bolt always reads in front of the monster that fired it as it closes
-   on the player. The glow is a tight square (half the projected
-   half-width, a few rows tall) so a bolt stays a compact dot rather
-   than a wall-sized blob up close.
+   a white-hot core glyph into `blood-paint`. Same projection +
+   visibility pipeline as pickups: `pickup-visible-at?` occludes the
+   bolt behind both walls (`dists`) AND nearer enemies (`edists`), so a
+   bolt flying past a closer monster is hidden by it instead of bleeding
+   through. The firing caster never hides its own bolt — the bolt
+   spawns ahead of the caster and only moves closer, so its depth stays
+   under the caster's at every column. The glow is a tight square (half
+   the projected half-width, a few rows tall) so a bolt stays a compact
+   dot rather than a wall-sized blob up close.
 
    Returns the mutated buffer — PHP arrays pass by value, so the caller
    must rebind to see the writes."
-  [blood-paint projectiles player dists vw vh]
+  [blood-paint projectiles player dists edists vw vh]
   (doseq [pr (or projectiles [])]
          (let [proj (project-enemy pr player vw)]
            (when proj
@@ -2308,7 +2311,7 @@
                    r-bot  (php/min vh (php/+ mid (php/intdiv h 6) 1))]
                (loop [c c-from]
                  (when (php/<= c c-to)
-                   (when (php/< d (buf-get dists c))
+                   (when (pickup-visible-at? d c dists edists)
                      (loop [r r-top]
                        (when (php/< r r-bot)
                          (buf-set blood-paint (php/+ (php/* r vw) c) fireball-shade)
@@ -2318,7 +2321,7 @@
                           (php/< col vw)
                           (php/>= mid 0)
                           (php/< mid vh)
-                          (php/< d (buf-get dists col)))
+                          (pickup-visible-at? d col dists edists))
                  (buf-set blood-paint
                           (php/+ (php/* mid vw) col)
                           fireball-glyph))))))
@@ -2712,7 +2715,7 @@
           ;; Fireballs paint last into the overlay so an incoming bolt
           ;; sits on top of every pickup glow it crosses.
           bp-proj   (paint-projectiles-into bp-wc (or (:projectiles world) [])
-                                            (:player world) dists vw vh)
+                                            (:player world) dists edists vw vh)
           parts     (buf-mk)]
       (dotimes [row vh]
                (loop [col 0 prev nil run 0]

--- a/src/io/render.phel
+++ b/src/io/render.phel
@@ -197,6 +197,17 @@
    with the shade swap."
   "\e[48;5;220;38;5;52;1m◉")
 
+(def fireball-shade
+  "Enemy fireball glow BG: saturated orange so an incoming bolt reads
+   as a hot threat against any wall / floor palette."
+  "\e[48;5;208m ")
+
+(def fireball-glyph
+  "Bright white-hot core ● on the orange glow — a small dense dot the
+   eye tracks as it crosses the viewport, distinct from the round ammo
+   pickup (which sits still on a brown crate BG)."
+  "\e[48;5;208;38;5;231;1m●")
+
 (def berserk-shade
   "Berserk sphere idle BG: dark blood-red so it reads as 'rage' from
    across the room, distinct from the dim heart red (52)."
@@ -2270,6 +2281,49 @@
                           glyph-now))))))
   blood-paint)
 
+(defn- paint-projectiles-into
+  "Project each enemy fireball to screen and write its orange glow plus
+   a white-hot core glyph into `blood-paint`. Same projection pipeline
+   as enemies / pickups; occlusion checks walls only (`dists`) so a
+   bolt always reads in front of the monster that fired it as it closes
+   on the player. The glow is a tight square (half the projected
+   half-width, a few rows tall) so a bolt stays a compact dot rather
+   than a wall-sized blob up close.
+
+   Returns the mutated buffer — PHP arrays pass by value, so the caller
+   must rebind to see the writes."
+  [blood-paint projectiles player dists vw vh]
+  (doseq [pr (or projectiles [])]
+         (let [proj (project-enemy pr player vw)]
+           (when proj
+             (let [col    (:col proj)
+                   hw     (php/max 1 (php/intdiv (:half-width proj) 2))
+                   d      (:dist proj)
+                   c-from (php/max 0 (php/- col hw))
+                   c-to   (php/min (php/- vw 1) (php/+ col hw))
+                   h      (php/min vh (php/intval (php// proj-dist
+                                                         (php/* (php/max 0.5 d) char-aspect))))
+                   mid    (php/+ (php/intdiv (php/- vh h) 2) (php/intdiv h 2))
+                   r-top  (php/max 0 (php/- mid (php/intdiv h 6)))
+                   r-bot  (php/min vh (php/+ mid (php/intdiv h 6) 1))]
+               (loop [c c-from]
+                 (when (php/<= c c-to)
+                   (when (php/< d (buf-get dists c))
+                     (loop [r r-top]
+                       (when (php/< r r-bot)
+                         (buf-set blood-paint (php/+ (php/* r vw) c) fireball-shade)
+                         (recur (php/+ r 1)))))
+                   (recur (php/+ c 1))))
+               (when (and (php/>= col 0)
+                          (php/< col vw)
+                          (php/>= mid 0)
+                          (php/< mid vh)
+                          (php/< d (buf-get dists col)))
+                 (buf-set blood-paint
+                          (php/+ (php/* mid vw) col)
+                          fireball-glyph))))))
+  blood-paint)
+
 (defn build-blood-cols
   "Directional blood mask: per-column intensity in [0, 1]. Non-zero
    only when iframes active AND a hurt-side is set. Fades from 1.0
@@ -2655,6 +2709,10 @@
                                                         (or (:weapon-pickups world) [])))
                                          (:player world) dists edists vw vh
                                          chaingun-pickup-shade-now chaingun-pickup-glyph-now)
+          ;; Fireballs paint last into the overlay so an incoming bolt
+          ;; sits on top of every pickup glow it crosses.
+          bp-proj   (paint-projectiles-into bp-wc (or (:projectiles world) [])
+                                            (:player world) dists vw vh)
           parts     (buf-mk)]
       (dotimes [row vh]
                (loop [col 0 prev nil run 0]
@@ -2673,7 +2731,7 @@
                          flr-row   (buf-get (if in-blood? blood-floor-gradient floor-gradient) row)
                          c         (if (and (php/< row visible-mh) (php/>= col mini-col0))
                                      sky-row
-                                     (or (buf-get bp-wc (php/+ (php/* row vw) col))
+                                     (or (buf-get bp-proj (php/+ (php/* row vw) col))
                                          (cond
                                            (php/< row (buf-get tops col))             sky-row
                                            (php/>= row (buf-get bots col))            flr-row
@@ -2722,7 +2780,7 @@
             c-row       (php/+ (php/intdiv vh 2) (if firing? -1 0))
             top-col     (buf-get tops c-col)
             bot-col     (buf-get bots c-col)
-            center-cell (or (buf-get bp-wc (php/+ (php/* c-row vw) c-col))
+            center-cell (or (buf-get bp-proj (php/+ (php/* c-row vw) c-col))
                             (cond
                               (php/< c-row top-col)             (buf-get sky-gradient c-row)
                               (php/>= c-row bot-col)            (buf-get floor-gradient c-row)

--- a/tests/core/enemy_ai_test.phel
+++ b/tests/core/enemy_ai_test.phel
@@ -9,6 +9,7 @@
                                             pain-stagger-secs default-pain-chance
                                             type-pain-chance
                                             attack-spec default-attack-spec
+                                            caster-spec caster?
                                             attack-spec-of in-attack-range?
                                             maybe-start-attack tick-attack
                                             start-wander tick-wander
@@ -485,6 +486,40 @@
     (is (= :aware (:state e')))
     (is (= 0.0 (:attack-windup-secs e')))
     (is (= 1.0 (:attack-cooldown-secs e')))))
+
+;; ---------------------------------------------------------------------
+;; Casters: ranged types (caco, baron) commit from their long
+;; projectile range and raise :fire-now on windup-release so the
+;; projectile-spawn pass can launch a bolt. Melee types leave it false.
+;; ---------------------------------------------------------------------
+
+(deftest test-caster-predicate
+  (is (= true  (caster? {:type :caco})))
+  (is (= true  (caster? {:type :baron})))
+  (is (= false (caster? {:type :imp})))
+  (is (= false (caster? {:type :unknown}))))
+
+(deftest test-attack-spec-of-prefers-caster-spec
+  ;; Caco resolves to its long-range caster profile, not melee.
+  (let [s (attack-spec-of {:type :caco})]
+    (is (= 7.0 (:range s)))
+    (is (= (get-in caster-spec [:caco :speed]) (:speed s)))))
+
+(deftest test-caster-in-attack-range-uses-long-range
+  ;; Player 5 units east of a caco — out of melee range but inside the
+  ;; caco's 7.0 caster range, so it still commits.
+  (is (= true (in-attack-range? {:type :caco :x 5.0 :y 5.0} 10.0 5.0))))
+
+(deftest test-tick-attack-caster-raises-fire-now-on-release
+  (let [e  {:type :caco :state :attacking :attack-windup-secs 0.05}
+        e' (tick-attack e 0.1)]
+    (is (= :aware (:state e')))
+    (is (= true (:fire-now e')) "caster flags a bolt to spawn on release")))
+
+(deftest test-tick-attack-melee-leaves-fire-now-false
+  (let [e  {:type :imp :state :attacking :attack-windup-secs 0.05}
+        e' (tick-attack e 0.1)]
+    (is (= false (:fire-now e')) "melee enemy never flags a bolt")))
 
 ;; ---------------------------------------------------------------------
 ;; Wander: opt-in random patrol. `start-wander` promotes :dormant →

--- a/tests/core/projectile-test.phel
+++ b/tests/core/projectile-test.phel
@@ -2,7 +2,7 @@
   (:require phel.test :refer [deftest is])
   (:require phel-doom.core.state :refer [new-world new-player])
   (:require phel-doom.core.projectile
-            :refer [spawn-from-enemies step resolve-hits tick-projectiles hit-radius projectile-ttl]))
+            :refer [spawn-from-enemies step resolve-hits tick-projectiles hit-radius projectile-ttl spawn-offset]))
 
 ;; A roomy open arena so bolts have floor to travel across. Wall ring,
 ;; floor interior.
@@ -63,6 +63,18 @@
     (is (php/> (:vx (first (:projectiles w'))) 0.0) "bolt aimed toward the player (+x)")
     (is (= projectile-ttl (:ttl (first (:projectiles w')))) "fresh bolt full ttl")))
 
+(deftest test-spawn-nudges-bolt-out-by-spawn-offset
+  ;; Caster at (2,3), player due east -> bolt spawns spawn-offset units
+  ;; ahead so it clears the caster's own cell on frame one.
+  (let [w    (assoc (new-world open-grid (new-player 5.0 3.0 0.0))
+                    :enemies [{:x 2.0 :y 3.0 :type :caco :alive true :fire-now true}])
+        bolt (first (:projectiles (spawn-from-enemies w)))
+        dx   (php/- (:x bolt) 2.0)
+        dy   (php/- (:y bolt) 3.0)
+        dist (php/sqrt (php/+ (php/* dx dx) (php/* dy dy)))]
+    (is (php/< (php/abs (php/- dist spawn-offset)) 0.0001)
+        "bolt spawns spawn-offset from the caster centre")))
+
 ;; ---------------------------------------------------------------------
 ;; resolve-hits: player impact + immunity.
 ;; ---------------------------------------------------------------------
@@ -89,6 +101,28 @@
 (deftest test-resolve-hits-respects-god
   (let [w' (resolve-hits (world-with-bolt-on-player {:god? true}))]
     (is (= 5 (:lives w')) "god mode takes no damage")))
+
+(deftest test-resolve-hits-respects-invuln-sphere
+  (let [w' (resolve-hits (world-with-bolt-on-player {:invuln-secs 2.0}))]
+    (is (= 5 (:lives w')) "invuln sphere absorbs the hit")
+    (is (= 0 (count (:projectiles w'))) "bolt still fizzles")))
+
+(deftest test-resolve-hits-armor-absorbs-before-life
+  (let [w' (resolve-hits (world-with-bolt-on-player {:armor 2}))]
+    (is (= 1 (:armor w')) "armor drops a unit")
+    (is (= 5 (:lives w')) "life untouched while armor remains")))
+
+(deftest test-resolve-hits-burst-costs-one-life
+  ;; Two bolts land on the player the same frame. The first arms
+  ;; i-frames; the second must NOT drain a second life — but both are
+  ;; consumed (neither phases through the shield).
+  (let [w  (assoc (new-world open-grid (new-player 3.5 3.5 0.0))
+                  :sound-on false :lives 5 :armor 0 :iframes 0.0
+                  :projectiles [{:x 3.5 :y 3.5 :vx 1.0 :vy 0.0 :ttl 4.0 :type :fireball}
+                                {:x 3.6 :y 3.5 :vx 1.0 :vy 0.0 :ttl 4.0 :type :fireball}])
+        w' (resolve-hits w)]
+    (is (= 4 (:lives w')) "a burst costs exactly one life")
+    (is (= 0 (count (:projectiles w'))) "both bolts consumed")))
 
 (deftest test-resolve-hits-misses-far-bolt
   (let [w  (assoc (new-world open-grid (new-player 3.5 3.5 0.0))

--- a/tests/core/projectile-test.phel
+++ b/tests/core/projectile-test.phel
@@ -1,0 +1,111 @@
+(ns phel-doom-tests.core.projectile-test
+  (:require phel.test :refer [deftest is])
+  (:require phel-doom.core.state :refer [new-world new-player])
+  (:require phel-doom.core.projectile
+            :refer [spawn-from-enemies step resolve-hits tick-projectiles hit-radius projectile-ttl]))
+
+;; A roomy open arena so bolts have floor to travel across. Wall ring,
+;; floor interior.
+(def open-grid
+  [[1 1 1 1 1 1 1]
+   [1 0 0 0 0 0 1]
+   [1 0 0 0 0 0 1]
+   [1 0 0 0 0 0 1]
+   [1 0 0 0 0 0 1]
+   [1 0 0 0 0 0 1]
+   [1 1 1 1 1 1 1]])
+
+;; ---------------------------------------------------------------------
+;; step: march + cull.
+;; ---------------------------------------------------------------------
+
+(deftest test-step-advances-position
+  (let [out (step [{:x 3.0 :y 3.0 :vx 2.0 :vy 0.0 :ttl 4.0 :type :fireball}]
+                  open-grid 0.5)]
+    (is (= 1 (count out)) "bolt in open floor survives")
+    (is (= 4.0 (:x (first out))) "x advanced by vx*dt")
+    (is (= 3.0 (:y (first out))) "y unchanged")
+    (is (= 3.5 (:ttl (first out))) "ttl decayed by dt")))
+
+(deftest test-step-culls-on-wall
+  (let [out (step [{:x 5.5 :y 3.0 :vx 4.0 :vy 0.0 :ttl 4.0 :type :fireball}]
+                  open-grid 0.5)]
+    (is (= 0 (count out)) "bolt crossing into the east wall column is dropped")))
+
+(deftest test-step-culls-on-ttl-expiry
+  (let [out (step [{:x 3.0 :y 3.0 :vx 0.0 :vy 0.0 :ttl 0.1 :type :fireball}]
+                  open-grid 0.5)]
+    (is (= 0 (count out)) "bolt whose lifetime ran out is dropped")))
+
+(deftest test-step-keeps-multiple
+  (let [out (step [{:x 2.0 :y 2.0 :vx 1.0 :vy 0.0 :ttl 4.0 :type :fireball}
+                   {:x 4.0 :y 4.0 :vx 0.0 :vy 1.0 :ttl 4.0 :type :fireball}]
+                  open-grid 0.5)]
+    (is (= 2 (count out)) "both live bolts survive a step")))
+
+;; ---------------------------------------------------------------------
+;; spawn-from-enemies: harvest :fire-now flags into bolts.
+;; ---------------------------------------------------------------------
+
+(deftest test-spawn-noop-without-fire
+  (let [w  (assoc (new-world open-grid (new-player 3.5 3.5 0.0))
+                  :enemies [{:x 2.0 :y 2.0 :type :caco :alive true}])
+        w' (spawn-from-enemies w)]
+    (is (= 0 (count (:projectiles w'))) "no :fire-now -> no bolts")))
+
+(deftest test-spawn-creates-bolt-and-clears-flag
+  (let [w  (assoc (new-world open-grid (new-player 5.0 3.0 0.0))
+                  :enemies [{:x 2.0 :y 3.0 :type :caco :alive true :fire-now true}])
+        w' (spawn-from-enemies w)]
+    (is (= 1 (count (:projectiles w'))) "one caster fired -> one bolt")
+    (is (= false (:fire-now (first (:enemies w')))) ":fire-now cleared after harvest")
+    ;; player is due east of the caster -> bolt travels +x.
+    (is (php/> (:vx (first (:projectiles w'))) 0.0) "bolt aimed toward the player (+x)")
+    (is (= projectile-ttl (:ttl (first (:projectiles w')))) "fresh bolt full ttl")))
+
+;; ---------------------------------------------------------------------
+;; resolve-hits: player impact + immunity.
+;; ---------------------------------------------------------------------
+
+(defn- world-with-bolt-on-player [extra]
+  ;; Bolt sitting on the player's cell so the proximity test fires.
+  (merge (assoc (new-world open-grid (new-player 3.5 3.5 0.0))
+                :sound-on false
+                :lives 5 :armor 0 :iframes 0.0
+                :projectiles [{:x 3.5 :y 3.5 :vx 1.0 :vy 0.0 :ttl 4.0 :type :fireball}])
+         extra))
+
+(deftest test-resolve-hits-damages-player
+  (let [w' (resolve-hits (world-with-bolt-on-player {}))]
+    (is (= 4 (:lives w')) "bolt on the player costs one life")
+    (is (= 0 (count (:projectiles w'))) "the struck bolt is consumed")
+    (is (php/> (:iframes w') 0.0) "impact arms i-frames")))
+
+(deftest test-resolve-hits-respects-iframes
+  (let [w' (resolve-hits (world-with-bolt-on-player {:iframes 0.5}))]
+    (is (= 5 (:lives w')) "i-frames absorb the hit")
+    (is (= 0 (count (:projectiles w'))) "bolt still fizzles on the shield")))
+
+(deftest test-resolve-hits-respects-god
+  (let [w' (resolve-hits (world-with-bolt-on-player {:god? true}))]
+    (is (= 5 (:lives w')) "god mode takes no damage")))
+
+(deftest test-resolve-hits-misses-far-bolt
+  (let [w  (assoc (new-world open-grid (new-player 3.5 3.5 0.0))
+                  :sound-on false :lives 5
+                  :projectiles [{:x 1.2 :y 1.2 :vx 1.0 :vy 0.0 :ttl 4.0 :type :fireball}])
+        w' (resolve-hits w)]
+    (is (= 5 (:lives w')) "a far bolt deals no damage")
+    (is (= 1 (count (:projectiles w'))) "and is not consumed")))
+
+;; ---------------------------------------------------------------------
+;; tick-projectiles: full frame integration.
+;; ---------------------------------------------------------------------
+
+(deftest test-tick-spawns-then-marches
+  (let [w  (assoc (new-world open-grid (new-player 5.0 3.0 0.0))
+                  :sound-on false
+                  :enemies [{:x 2.0 :y 3.0 :type :caco :alive true :fire-now true}])
+        w' (tick-projectiles w 0.1)]
+    (is (= 1 (count (:projectiles w'))) "bolt spawned and survived the frame")
+    (is (php/> (:x (first (:projectiles w'))) 2.0) "bolt moved east toward the player")))


### PR DESCRIPTION
## 📚 Description

Adds **dodgeable enemy fireballs**, the highest-leverage gameplay-depth win for the current build: until now every monster was hitscan/contact, so there was nothing to dodge. Cacodemons and barons are now **casters**: they commit from a long range, freeze to telegraph the windup (attack-face), then launch an orange bolt aimed at the player's position. You break the shot by strafing or putting a wall between you and the caster.

Bolts travel through doorways but stop at walls. Impact costs one armor/life unit; i-frames from the hit gate a burst to a single hit per frame. A caster still melees on contact, so cornering one is still dangerous.

## 🔖 Changes

- **`core/enemy_ai`**: new `caster-spec` (caco range 7.0 / baron 8.0 + bolt speed) + `caster?`. `attack-spec-of` prefers it so the existing `:attacking` telegraph rhythm drives ranged fire unchanged. `tick-attack` raises `:fire-now` on a caster's windup-release (melee types leave it `false`).
- **`core/projectile`** (new module): `spawn-from-enemies` harvests `:fire-now` enemies into world `:projectiles` aimed at the player; `step` marches + culls bolts on wall (`map/wall?`) / lifetime; `resolve-hits` consumes bolts within `hit-radius` and lands one hit via `combat/hit-player-at`, gated by `combat/player-immune?`. `tick-projectiles` composes the frame.
- **`core/combat`**: extracted `apply-hit`; exposed `hit-player-at` + `player-immune?` so the projectile path reuses the exact contact-damage rule (armor absorb, i-frames, white flash, knockback, `:hurt-side`).
- **`core/state`**: `:projectiles []` added to `new-world`.
- **`commands/play`**: `tick-projectiles` runs in `tick-world` between `tick-enemies` and `damage-step`, so a bolt hit and a contact hit can't both land in one frame.
- **`io/render`**: `paint-projectiles-into` draws a white-hot core (`●`) on an orange glow via the shared `project-enemy` projection, occluded by walls only so a bolt always reads in front of its caster. New `fireball-shade` / `fireball-glyph`.
- **Tests**: `tests/core/projectile-test.phel` (step / spawn / resolve-hits + immunity / full tick) and caster cases in `enemy_ai_test`. Suite 1151 → 1161, all green.
- **Docs**: synced `monsters`, `combat`, `features`, `architecture`, `game-loop`, `state` + `CHANGELOG` Unreleased.

## ✅ Verification

- `composer ci` clean: format-check, lint, 1161 tests, build.
- Headless render smoke (L4, fireball in viewport) confirmed `frame->string` paints the bolt glyph without crashing.