### PR TITLE
feat(audio): ambient drone loop under gameplay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 
 ### Added
 
+- Ambient drone loop. A low, slow-pulsing background bed now runs under the whole gameplay session for dread. Synthesised at runtime (no shipped audio asset), looped by a crash-safe background process that self-terminates if the game dies, and gated by the N sound toggle.
 - Projectile enemies. Cacodemons and barons now fire homing-less fireballs across the room instead of only meleeing: they freeze, telegraph (attack-face windup), then launch an orange bolt at your current position. Bolts travel through doorways but stop at walls, so you dodge by strafing or breaking line of fire with geometry. Impact costs one armor/life unit; i-frames gate a burst to one hit per frame.
 - Wandering idle enemies. Half the freshly spawned monsters start pacing random directions; LOS flips them to chase.
 - Backpack capacity expansion (#68 part 3). Stacks up to 3; reserve cap scales `base * (1 + level)`. HUD shows `+pack xN`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -25,7 +25,8 @@ src/
 └── io/                              ; effects, touch the OS
     ├── input.phel                   ; raw STDIN, alt screen buffer
     ├── render.phel                  ; ANSI escape composition + flush
-    ├── sound.phel                   ; afplay/paplay/aplay shell-out
+    ├── sound.phel                   ; afplay/paplay/aplay shell-out (one-shot sfx)
+    ├── ambient.phel                 ; synthesised drone loop (crash-safe bg process)
     ├── scores.phel                  ; JSON in $HOME
     └── wad.phel                     ; .wad file format parser
 ```

--- a/docs/audio.md
+++ b/docs/audio.md
@@ -62,6 +62,30 @@ N key toggles `:sound-on`. Mute is instant; in-flight sfx finish on their own.
 
 `distance-volume` scales `:wound` / `:kill` sfx by distance to the hit so crowded fights don't drown the channel.
 
+## Ambient drone loop
+
+`src/io/ambient.phel`. A low, slow-pulsing background drone runs under the whole gameplay session for dread.
+
+No asset is shipped. `drone-wav-bytes` synthesises a seamless `loop-seconds` (2s) clip of 16-bit mono PCM at 22050 Hz: three low partials (55 / 82 / 110 Hz, all integer cycles in the window so the loop has no click) under a 0.5 Hz tremolo, scaled to a quiet `gain`. It's a pure function (same args -> same bytes), unit-tested in `tests/io/ambient-test.phel`. The bytes are written once to `sys_get_temp_dir()/phel-doom-ambient.wav` and reused.
+
+`start-ambient!` backgrounds a shell that re-plays the clip forever:
+
+```bash
+sh -c 'while kill -0 <game-pid> 2>/dev/null; do afplay -v 0.30 <wav> >/dev/null 2>&1; done' & echo $!
+```
+
+The `kill -0 <game-pid>` guard is the orphan safety net: if the game crashes or is SIGKILLed without a clean stop, the loop self-terminates within one clip instead of looping forever. `echo $!` returns the shell PID, tracked in the `proc` atom.
+
+`stop-ambient!` kills the loop shell first (so no new clip spawns) then `pkill -f`s the temp path (matches only the drone, never the per-event sfx playing system sounds).
+
+Lifecycle is driven from `commands/play`:
+
+- `start-ambient!` when gameplay begins (after the start menu).
+- `sync-ambient!` on the N (sound) toggle, comparing `:sound-on` across the frame.
+- `stop-ambient!` on every teardown path.
+
+All entry points are no-ops under `PHEL_DOOM_SILENT` and on hosts with no audio player (no bell fallback - a once-a-clip bell would be worse than silence).
+
 ## Why under `io/`
 
-Calls `exec`, talks to OS. Pure side effect. Integration-tested by running the game.
+Calls `exec`, talks to OS. Pure side effect. Integration-tested by running the game. (The drone synthesis is pure and unit-tested; only the loop process is IO.)

--- a/docs/features.md
+++ b/docs/features.md
@@ -90,6 +90,10 @@ Triggered as the player's lives drop or enemies cross thresholds:
 
 - OS audio via `afplay` (macOS) / `paplay` / `aplay` / `play`
   (Linux) with terminal-bell fallback on bare systems
+- Ambient drone loop: a low, slow-pulsing background bed runs the whole
+  session for dread. Synthesised at runtime (no shipped asset), looped
+  by a crash-safe background process, gated by the N toggle. See
+  `io/ambient.phel`.
 - Distance-scaled kill volume
 - All sfx gated by sound-on toggle (`n`)
 - Tests run with `PHEL_DOOM_SILENT=1` - no audio during the suite

--- a/src/commands/play.phel
+++ b/src/commands/play.phel
@@ -16,6 +16,7 @@
   (:require phel-doom.core.projectile :refer [tick-projectiles])
   (:require phel-doom.core.weapons  :refer [effective-reserve-cap give-weapon switch-weapon weapon-spec weapon-order weapons])
   (:require phel-doom.io.sound    :refer [play-sfx! mute-for!])
+  (:require phel-doom.io.ambient  :refer [start-ambient! stop-ambient! sync-ambient!])
   (:require phel-doom.core.level    :refer [build-world num-levels])
   (:require phel-doom.core.perf     :refer [target-frame-us])
   (:require phel-doom.io.scores   :refer [update-scores!])
@@ -722,6 +723,11 @@
             (play-sfx! :heartbeat 0.35))
           (when (and (:silence-tick? world') (:sound-on world'))
             (mute-for! 0.4))
+          ;; N toggled sound this frame: start / stop the ambient drone
+          ;; to match. Comparing the flag (not the edge) also catches
+          ;; any other path that flips :sound-on.
+          (when (php/!== (:sound-on world) (:sound-on world'))
+            (sync-ambient! (:sound-on world')))
           (cond
             (str/contains? keys "q")   :quit
             (php/<= (:lives world') 0) (result-game-over world' t-start now)
@@ -937,7 +943,12 @@
           (clear-screen)
           0)
       (do (clear-screen)
+          ;; Ambient drone runs for the whole gameplay session (across
+          ;; levels + end screens). N-toggle starts/stops it mid-run;
+          ;; teardown always stops it so no loop process is orphaned.
+          (start-ambient!)
           (run-levels diff god? armory? full-map? lv)
+          (stop-ambient!)
           (restore!)
           (clear-screen)
           (cli/success ctx "Thanks for playing.")

--- a/src/io/ambient.phel
+++ b/src/io/ambient.phel
@@ -1,0 +1,153 @@
+(ns phel-doom.io.ambient
+  (:require phel-doom.io.sound :refer [audio-player]))
+
+;; ---------------------------------------------------------------------
+;; Ambient drone loop.
+;;
+;; A low, slow-pulsing drone under the whole run for dread. No asset is
+;; shipped: a few seconds of seamless PCM are synthesised once into a
+;; temp WAV (drone-wav-bytes, pure), then looped by a backgrounded
+;; `sh` that re-runs the player binary forever. The loop guards on
+;; `kill -0 <game-pid>` each iteration, so if the game crashes / is
+;; SIGKILLed without a clean stop, the drone self-terminates within one
+;; clip instead of orphaning a forever-looping afplay.
+;;
+;; Lifecycle is driven from commands/play: start-ambient! when gameplay
+;; begins, stop-ambient! on teardown, sync-ambient! on the N (sound)
+;; toggle. All entry points are no-ops under PHEL_DOOM_SILENT and on
+;; hosts with no audio player (no bell fallback — a once-a-clip bell
+;; would be worse than silence).
+;; ---------------------------------------------------------------------
+
+(def sample-rate 22050)
+
+(def loop-seconds
+  "Drone clip length. Frequencies + tremolo are chosen to complete a
+   whole number of cycles in this window so the loop is seamless (no
+   click at the wrap)."
+  2.0)
+
+(def gain
+  "Peak amplitude as a fraction of full scale. Low — this sits under
+   the sfx, not over them."
+  0.18)
+
+(def afplay-volume
+  "Playback volume passed to afplay's -v (other players ignore it).
+   Quieter than the synthesised gain so the bed never masks footsteps
+   / shots."
+  "0.30")
+
+(def proc
+  "Session state for the loop process: `:pid` of the backgrounded
+   shell, or nil when not running."
+  (atom {:pid nil}))
+
+(defn- silent? []
+  (php/=== "1" (php/getenv "PHEL_DOOM_SILENT")))
+
+(defn drone-wav-bytes
+  "Synthesise `secs` seconds of a seamless low drone as a complete
+   16-bit mono PCM WAV (header + data) at `sr` Hz. Pure: same args →
+   same bytes, no IO. Three low partials (55 / 82 / 110 Hz — all
+   integer cycles in `loop-seconds`) under a slow 0.5 Hz tremolo, scaled
+   by `gain`. Exposed for unit tests (header + length pins)."
+  [^int sr ^float secs]
+  (let [n      (php/intval (php/* sr secs))
+        two-pi (php/* 2.0 php/M_PI)
+        buf    (php/array)]
+    (dotimes [i n]
+             (let [t   (php// i sr)
+                   sig (php/+ (php/* 1.0 (php/sin (php/* two-pi 55.0 t)))
+                              (php/* 0.4 (php/sin (php/* two-pi 82.0 t)))
+                              (php/* 0.3 (php/sin (php/* two-pi 110.0 t))))
+                   ;; 0.5 Hz tremolo → exactly one cycle per 2s window.
+                   lfo (php/+ 0.85 (php/* 0.15 (php/sin (php/* two-pi 0.5 t))))
+                   amp (php// gain 1.7)
+                   v   (php/intval (php/round (php/* (php/* sig lfo) amp 32767.0)))
+                   ;; Clamp into signed-16 range, then to unsigned for
+                   ;; little-endian 'v' packing.
+                   c   (php/max -32767 (php/min 32767 v))
+                   u   (if (php/< c 0) (php/+ 65536 c) c)]
+               (php/array_push buf (php/pack "v" u))))
+    (let [data     (php/implode "" buf)
+          data-len (php/strlen data)]
+      (str "RIFF"
+           (php/pack "V" (php/+ 36 data-len))
+           "WAVE"
+           "fmt "
+           (php/pack "V" 16)
+           (php/pack "v" 1)               ; PCM
+           (php/pack "v" 1)               ; mono
+           (php/pack "V" sr)
+           (php/pack "V" (php/* sr 2))    ; byte rate (1ch * 2 bytes)
+           (php/pack "v" 2)               ; block align
+           (php/pack "v" 16)              ; bits per sample
+           "data"
+           (php/pack "V" data-len)
+           data))))
+
+(defn- drone-path []
+  (str (php/sys_get_temp_dir) "/phel-doom-ambient.wav"))
+
+(defn- ensure-wav!
+  "Write the drone WAV to the temp path once per host (content is
+   fixed, so an existing file is reused). Returns the path, or nil if
+   the write failed."
+  []
+  (let [path (drone-path)]
+    (if (php/file_exists path)
+      path
+      (let [ok (php/file_put_contents path (drone-wav-bytes sample-rate loop-seconds))]
+        (if (php/=== false ok) nil path)))))
+
+(defn- loop-command
+  "The backgrounded shell that re-plays `path` forever while the game
+   process (`ppid`) is alive. afplay gets a -v volume; others just play
+   the file. `& echo $!` prints the shell's PID so the caller can track
+   + kill it."
+  [player path ^int ppid]
+  (let [vol (if (php/=== player "afplay") (str " -v " afplay-volume) "")]
+    (str "sh -c 'while kill -0 " ppid " 2>/dev/null; do "
+         player vol " " (php/escapeshellarg path) " >/dev/null 2>&1; "
+         "done' >/dev/null 2>&1 & echo $!")))
+
+(defn start-ambient!
+  "Begin the drone loop if it isn't already running. No-op under
+   PHEL_DOOM_SILENT, when no audio player is on PATH, or when the WAV
+   can't be written. Idempotent: a second call while running does
+   nothing."
+  []
+  (when (and (not (silent?))
+             (nil? (:pid @proc)))
+    (let [player (audio-player)]
+      (when player
+        (let [path (ensure-wav!)]
+          (when path
+            (let [out (php/array)]
+              (php/exec (loop-command player path (php/getmypid)) out)
+              (let [pid (php/intval (or (php/aget out 0) 0))]
+                (when (php/> pid 0)
+                  (swap! proc assoc :pid pid))))))))))
+
+(defn stop-ambient!
+  "Stop the drone loop immediately: kill the loop shell (so it can't
+   relaunch) then any player still playing our temp file. No-op when
+   nothing is running. Safe to call on every teardown path."
+  []
+  (let [pid (:pid @proc)]
+    (when pid
+      ;; Kill the loop shell first so no new clip spawns, then the
+      ;; in-flight player. pkill -f matches only our unique temp path,
+      ;; so per-event sfx (system sounds) are untouched.
+      (php/exec (str "kill " pid " 2>/dev/null"))
+      (php/exec (str "pkill -f " (php/escapeshellarg (drone-path)) " 2>/dev/null"))
+      (swap! proc assoc :pid nil))))
+
+(defn sync-ambient!
+  "Start or stop the drone to match the sound-on flag. Called when the
+   player toggles sound (N)."
+  [sound-on?]
+  (if sound-on?
+    (start-ambient!)
+    (stop-ambient!)))

--- a/src/io/sound.phel
+++ b/src/io/sound.phel
@@ -103,6 +103,15 @@
   []
   (php/=== "1" (php/getenv "PHEL_DOOM_SILENT")))
 
+(defn audio-player
+  "Resolved audio-player binary for this host (afplay / paplay / aplay /
+   play), or nil if none is on PATH. Probes once and memoises. Exposed
+   so the ambient loop (io/ambient) reuses the same resolution instead
+   of duplicating the PATH probe."
+  []
+  (ensure-probed!)
+  (:player @state))
+
 (defn mute-for!
   "Stamp an absolute mute-until timestamp on the sound state atom so
    play-sfx! short-circuits for the next `seconds`. Stacks against an

--- a/tests/io/ambient-test.phel
+++ b/tests/io/ambient-test.phel
@@ -1,0 +1,37 @@
+(ns phel-doom-tests.io.ambient-test
+  (:require phel.test :refer [deftest is])
+  (:require phel-doom.io.ambient :refer [drone-wav-bytes sync-ambient! proc]))
+
+;; ---------------------------------------------------------------------
+;; drone-wav-bytes: pure PCM WAV synthesis. No IO — safe to assert on
+;; the raw bytes. (The loop process itself can't be unit-tested; it is
+;; gated off entirely by PHEL_DOOM_SILENT during the suite.)
+;; ---------------------------------------------------------------------
+
+(deftest test-wav-has-riff-wave-header
+  (let [b (drone-wav-bytes 8000 0.1)]
+    (is (= "RIFF" (php/substr b 0 4)) "starts with the RIFF tag")
+    (is (= "WAVE" (php/substr b 8 4)) "WAVE format tag at offset 8")
+    (is (= "data" (php/substr b 36 4)) "data chunk tag at offset 36")))
+
+(deftest test-wav-length-matches-sample-count
+  ;; 8000 Hz * 0.1s = 800 mono 16-bit samples = 1600 data bytes,
+  ;; plus the 44-byte canonical PCM header.
+  (let [b (drone-wav-bytes 8000 0.1)]
+    (is (= (php/+ 44 1600) (php/strlen b)) "header + 2 bytes per sample")))
+
+(deftest test-wav-deterministic
+  (is (= (drone-wav-bytes 8000 0.1) (drone-wav-bytes 8000 0.1))
+      "same args -> identical bytes (pure)"))
+
+;; ---------------------------------------------------------------------
+;; sync-ambient!: under PHEL_DOOM_SILENT (set by the test runner) every
+;; entry point is a no-op, so the process atom never gets a pid. Pins
+;; that the suite can drive the toggle without spawning audio.
+;; ---------------------------------------------------------------------
+
+(deftest test-sync-is-noop-when-silent
+  (sync-ambient! true)
+  (is (nil? (:pid @proc)) "no loop process spawned while silent")
+  (sync-ambient! false)
+  (is (nil? (:pid @proc)) "stop stays a no-op too"))


### PR DESCRIPTION
## 📚 Description

Adds a **low, slow-pulsing ambient drone** under the whole gameplay session - the dread bed the game was missing. Until now audio was only one-shot sfx; there was nothing holding tension between events.

No audio asset is shipped (keeps with the existing "use what's on the host" policy). The drone is **synthesised at runtime** into a temp WAV and looped by a crash-safe background process. Gated by the existing N sound toggle.

## 🔖 Changes

- **`io/ambient`** (new):
  - `drone-wav-bytes` - pure synth of a seamless 2s 16-bit mono PCM drone (three low partials 55 / 82 / 110 Hz under a 0.5 Hz tremolo; all integer cycles in the window so the loop has no click). Same args -> same bytes.
  - Written once to `sys_get_temp_dir()/phel-doom-ambient.wav` and reused.
  - `start-ambient!` backgrounds `sh -c 'while kill -0 <game-pid>; do afplay -v 0.30 <wav>; done'`. The `kill -0` guard self-terminates the loop within one clip if the game crashes / is SIGKILLed - no orphaned forever-looping player. Shell PID tracked in an atom.
  - `stop-ambient!` kills the loop shell first (no relaunch) then `pkill -f`s the temp path (matches only the drone, never per-event sfx playing system sounds).
  - All entry points no-op under `PHEL_DOOM_SILENT` and when no audio binary is on PATH (no bell fallback - a once-a-clip bell beats nothing here, so we stay silent).
- **`io/sound`**: expose `audio-player` so ambient reuses the existing PATH probe instead of duplicating it.
- **`commands/play`**: `start-ambient!` when gameplay begins, `sync-ambient!` on the N toggle (compares `:sound-on` across the frame), `stop-ambient!` on every teardown path.
- **Tests** (`tests/io/ambient-test.phel`): pure `drone-wav-bytes` (RIFF/WAVE/data header, sample-count length, determinism) + silent no-op of the toggle. 1168 -> 1175, all green.
- **Docs**: `audio`, `features`, `architecture` + `CHANGELOG` Unreleased.

## ✅ Verification

- `composer ci` clean: format-check, lint, 1175 tests, build (55 files).
- Real process smoke (non-silent): `start-ambient!` spawns the loop (2 procs: shell + player), `stop-ambient!` kills cleanly (pid -> nil, 0 procs), no orphans left behind.