### PR TITLE
fix(render): stop rear enemy shadow bleeding over closer sprites

### DIFF
--- a/docs/rendering.md
+++ b/docs/rendering.md
@@ -116,6 +116,12 @@ Iterates visible enemies after the main frame composes; paints one face glyph (`
 
 Blood splatters from kills + heart pickups paint into a PHP array `blood-paint` indexed by `row * vw + col`. Inner loop reads first via `(or (php/aget blood-paint ...) main-cond)` so overlays override wall/floor/enemy paint.
 
+### Enemy grounding shadows (two-pass, issue #86)
+
+Each enemy drops a dark `sprite-shadow` cell into `blood-paint` at its foot row to read as grounded. Because `blood-paint` is the top-priority layer, the shadow can NOT be written inline during the back-to-front enemy zone pass: a farther enemy's foot-row shadow would sit over a nearer enemy's body (which lives in the lower-priority enemy-zone layer) and bleed through.
+
+So shadows are deferred to a second pass after the zone pass, once `edists` (nearest enemy depth per column) is complete. `enemy-shadow-visible-at?` gates each shadow cell on wall depth (`d < dists[c]`) AND front-most-enemy depth (`d <= edists[c]`, inclusive so the column's own front enemy still grounds). Only the nearest enemy at a column drops its shadow; farther ones skip. Enemies are projected + depth-sorted once (`enemy-projs`) and reused across both passes.
+
 ## Run-length encoding
 
 Consecutive cells with the same ANSI escape coalesce into one paint + N spaces:

--- a/src/io/render.phel
+++ b/src/io/render.phel
@@ -2237,6 +2237,22 @@
     (and (php/< d wd)
          (or (php/=== ed nil) (php/< d ed)))))
 
+(defn enemy-shadow-visible-at?
+  "True when an enemy at depth `d` may ground its shadow at screen
+   column `c`: in front of the wall (dists) AND the front-most enemy
+   there (`d <= edists[c]`, where edists holds the nearest enemy depth
+   per column after the zone pass). Unlike `pickup-visible-at?` the
+   enemy compare is inclusive (`<=`) so the column's own front enemy —
+   whose depth equals the stored nearest — still draws; only enemies
+   strictly behind it skip. Keeps one farther sprite's shadow row from
+   bleeding over a nearer sprite's body (issue #86). Exported for
+   tests."
+  [^float d c dists edists]
+  (let [wd (buf-get dists c)
+        ed (buf-get edists c)]
+    (and (php/< d wd)
+         (or (php/=== ed nil) (php/<= d ed)))))
+
 (defn- paint-pickups-into
   "Project each pickup (heart / armor) to screen and write its
    coloured BG glow into `blood-paint`, then drop the icon glyph at
@@ -2542,6 +2558,10 @@
         ;; way `dists` occludes them behind walls.
         edists                             (buf-mk)
         blood-paint                        (buf-mk)
+        ;; Project + depth-sort enemies once: the zone pass paints them
+        ;; back-to-front, then a second pass grounds the shadows reading
+        ;; the completed `edists` (see below).
+        enemy-projs                        (collect-enemy-projs (:enemies world) (:player world) vw)
         ;; Pulse the minimap door glyph on the same beat as the 3D
         ;; door shade so the exit catches the eye both in first-person
         ;; and on the overhead map.
@@ -2558,7 +2578,7 @@
         mini-col0                          (if (php/> visible-mh 0)
                                              (php/max 0 (php/- map-col 1))
                                              vw)]
-    (doseq [proj (collect-enemy-projs (:enemies world) (:player world) vw)]
+    (doseq [proj enemy-projs]
            (let [col (:col proj)
                  hw  (:half-width proj)
                  d   (:dist proj)
@@ -2647,17 +2667,39 @@
                          ;; Track nearest enemy distance for this col so
                          ;; pickups behind it occlude properly. Multiple
                          ;; enemies on the same col → keep the closest.
+                         ;; The shadow pass below also reads this to keep
+                         ;; only the front enemy's grounding shadow.
                          (let [prev (buf-get edists c)]
                            (when (or (php/=== prev nil) (php/< d prev))
-                             (buf-set edists c d)))
-                         ;; Grounding shadow: write one dark cell into
-                         ;; the blood-paint overlay at the row beneath
-                         ;; the sprite. Skips if outside the viewport.
-                         (when (php/< e-bot vh)
-                           (buf-set blood-paint
-                                    (php/+ (php/* e-bot vw) c)
-                                    sprite-shadow)))
+                             (buf-set edists c d))))
                        (recur (php/+ c 1)))))))))
+    ;; Grounding shadows, second pass. The shadow goes into blood-paint
+    ;; (top-priority overlay), so it can't be painted inline during the
+    ;; back-to-front zone pass: a FAR enemy's shadow row would sit over a
+    ;; NEAR enemy's body (which lives in the lower-priority enemy-zone
+    ;; layer) and bleed through. Deferring until `edists` holds the
+    ;; nearest dist per column lets us drop a shadow cell only for the
+    ;; column's front-most enemy (d <= edists[c]); farther enemies skip
+    ;; it. Still wall-gated (d < dists[c]). (issue #86)
+    (doseq [proj enemy-projs]
+           (let [col    (:col proj)
+                 hw     (:half-width proj)
+                 d      (:dist proj)
+                 sc     (or (:scale proj) 1.0)
+                 h      (php/min vh (php/intval (php/* sc
+                                                       (php// proj-dist
+                                                              (php/* (php/max 0.5 d) char-aspect)))))
+                 e-bot  (php/+ (php/intdiv (php/- vh h) 2) h)
+                 c-from (php/max 0 (php/- col hw))
+                 c-to   (php/min (php/- vw 1) (php/+ col hw))]
+             (when (php/< e-bot vh)
+               (loop [c c-from]
+                 (when (php/<= c c-to)
+                   (when (enemy-shadow-visible-at? d c dists edists)
+                     (buf-set blood-paint
+                              (php/+ (php/* e-bot vw) c)
+                              sprite-shadow))
+                   (recur (php/+ c 1)))))))
     ;; Chain the fx + pickup painters: each one takes the current
     ;; blood-paint, returns a new buffer (PHP arrays pass by value, so
     ;; the helper owns the allocation). Rename per step to keep phel

--- a/tests/io/render-test.phel
+++ b/tests/io/render-test.phel
@@ -1,6 +1,6 @@
 (ns phel-doom-tests.io.render-test
   (:require phel.test :refer [deftest is])
-  (:require phel-doom.io.render :refer [direction-char project-enemy]))
+  (:require phel-doom.io.render :refer [direction-char project-enemy enemy-shadow-visible-at?]))
 
 (deftest test-direction-char-cardinal
   (is (= "→" (direction-char 0.0)))
@@ -44,3 +44,40 @@
                             {:x 3.0 :y 3.0 :angle 0.0}
                             80)]
     (is (> (:col proj) 40))))
+
+;; ---------------------------------------------------------------------
+;; enemy-shadow-visible-at?: grounding-shadow occlusion gate (issue #86).
+;; Only the front-most enemy at a column drops its shadow; farther ones
+;; and wall-occluded ones skip, so a rear shadow can't bleed over a
+;; nearer sprite.
+;; ---------------------------------------------------------------------
+
+(deftest test-enemy-shadow-hidden-behind-wall
+  (let [dists  (php/array 3.0)
+        edists (php/array 4.0)]
+    (is (= false (enemy-shadow-visible-at? 6.0 0 dists edists))
+        "behind a closer wall -> no shadow")))
+
+(deftest test-enemy-shadow-front-enemy-grounds
+  ;; This enemy IS the nearest at the column (d == edists). Inclusive
+  ;; compare keeps its own shadow.
+  (let [dists  (php/array 10.0)
+        edists (php/array 4.0)]
+    (is (= true (enemy-shadow-visible-at? 4.0 0 dists edists))
+        "front enemy grounds its shadow")))
+
+(deftest test-enemy-shadow-rear-enemy-skips
+  ;; A farther enemy sharing the column with a nearer one (edists=4):
+  ;; its shadow must NOT draw (would bleed over the front sprite).
+  (let [dists  (php/array 10.0)
+        edists (php/array 4.0)]
+    (is (= false (enemy-shadow-visible-at? 6.0 0 dists edists))
+        "rear enemy's shadow is suppressed")))
+
+(deftest test-enemy-shadow-no-enemy-recorded-at-column
+  ;; edists empty at this column (no sprite painted there) -> the
+  ;; enemy's own shadow may draw, still wall-gated.
+  (let [dists  (php/array 10.0)
+        edists (php/array)]
+    (is (= true (enemy-shadow-visible-at? 4.0 0 dists edists))
+        "no nearer enemy -> shadow allowed")))


### PR DESCRIPTION
## 📚 Description

Fixes #86. An enemy's dark grounding shadow could paint **over** a sprite standing in front of it (see the issue screenshot: a black band bleeding across a closer enemy).

## 🔖 Changes

- **Root cause**: the grounding shadow writes into `blood-paint`, the **top-priority** overlay layer. Painting it inline during the back-to-front enemy zone pass meant a FAR enemy's foot-row shadow sat over a NEAR enemy's body (which lives in the lower-priority enemy-zone layer) and bled through. The zones themselves were already correct (back-to-front sort); only the shadow layer raced.
- **Fix**: defer shadows to a **second pass** after the zone pass, once `edists` (nearest enemy depth per column) is fully built. New `enemy-shadow-visible-at?` gates each shadow cell on wall depth (`d < dists[c]`) AND front-most depth (`d <= edists[c]`, inclusive so the column's own front enemy still grounds). Only the nearest enemy at a column drops its shadow; farther ones skip.
- Enemies are projected + depth-sorted **once** (`enemy-projs`) and reused across both passes - no extra `collect-enemy-projs` call.
- **Tests**: `enemy-shadow-visible-at?` - wall-occluded / front-grounds / rear-skips / no-enemy-recorded. 1175 -> 1179.
- **Docs**: `docs/rendering.md` (new two-pass shadow section).

## ✅ Verification

- `composer ci` clean: format-check, lint, 1179 tests, build (55 files).
- Headless render smoke: two imps stacked on one bearing (front d~3, rear d~6, fully overlapping columns) -> exactly one grounding-shadow row (the front sprite's, 4 cells); the rear's is suppressed instead of bleeding through.

Closes #86