### PR TITLE
feat(level): secret reward passages with trophy stashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 
 ### Added
 
+- Secret reward passages. Every non-locked procgen level now hides up to 2 secret walls; revealing one (bump + `F`) drops a reward stash: an ammo box, an armor shard, and a rotating trophy powerup (soulsphere / berserk / invuln). Locked levels are skipped so a secret shortcut can't bypass a keycard door. Makes exploration pay off and turns the rare powerups into a reliable find.
 - Hit-stop on meaty kills. Killing a tough enemy (caco / baron, ~70ms) or the boss (~160ms) briefly freezes the gameplay step so the blow lands with weight. Trash mobs (imps / demons) kill clean with no freeze, so chaingun spray stays fast.
 - Ambient drone loop. A low, slow-pulsing background bed now runs under the whole gameplay session for dread. Synthesised at runtime (no shipped audio asset), looped by a crash-safe background process that self-terminates if the game dies, and gated by the N sound toggle.
 - Projectile enemies. Cacodemons and barons now fire homing-less fireballs across the room instead of only meleeing: they freeze, telegraph (attack-face windup), then launch an orange bolt at your current position. Bolts travel through doorways but stop at walls, so you dodge by strafing or breaking line of fire with geometry. Impact costs one armor/life unit; i-frames gate a burst to one hit per frame.

--- a/docs/features.md
+++ b/docs/features.md
@@ -22,6 +22,7 @@ See [rendering.md](rendering.md), [raycaster.md](raycaster.md), [performance.md]
 - Per-level wall + sky + floor palette
 - Pickups: hearts (cap 5), armor (cap 5, absorbs one hit each), armor shards (+1 over-cap up to 10, no decay), soulsphere (+1 life over-cap, decays back to cap), ammo boxes (per-weapon `:ammo-per-box`), berserk (20s ×2 dmg), invuln (10s immune), stacking backpack (L2+, each pickup adds one tier of reserve cap, up to `max-backpacks`)
 - Keycards + locked exits on L4 (blue) / L5 (red). Intro splash adds a `FIND THE <COLOUR> KEY` subtitle on locked levels; compass top-centre tints the E/S/W/N letter pointing at the un-picked card in the lock colour; bumping the door without the matching key pulses `⚿ NEED <COLOUR> KEY ⚿` for 1.5s. L10 boss door unlocks via synthetic `:boss` keycard granted on cyberdemon kill (no physical pickup); intro splash: `KILL THE BOSS TO ESCAPE`, door pulse: `☠ KILL THE BOSS ☠`
+- Secret reward passages: every non-locked procgen level hides up to 2 secret walls (plus L10's hand-authored pair). Bump one with `F` to reveal a reward stash - ammo + armor shard + a rotating trophy powerup (soulsphere / berserk / invuln). Locked levels are skipped so a secret can't bypass a keycard door.
 - Walk-into-door auto-advance; pulsing minimap door + bright 3D door glyph
 - Cross-level carry: lives, kills, time, owned-weapons, **active weapon**, **per-weapon mag/reserve**, backpack, minimap + sound toggles. Retry/restart resets to fresh defaults.
 

--- a/docs/level-system.md
+++ b/docs/level-system.md
@@ -21,6 +21,8 @@
 
 L1-L5 are single-type procgen rooms. L6-L9 are mixed-monster procgen rooms. L10 is a hand-authored boss arena with secret walls + switches (see source in `src/core/level.phel`).
 
+Every non-locked procgen level also seeds up to 2 hidden secret passages (`map/seed-secrets`); revealing one drops a reward stash (ammo + armor shard + a rotating trophy powerup) via `place-secret-reward`. Locked levels (L4/L5) are skipped so a secret shortcut can't bypass the keycard door. See [map.md](map.md) secret walls.
+
 ```phel
 (def levels
   [{:size [22 16] :walls 12 :enemy :imp   :enemies 4 :chase 0.8 :name "imps"}

--- a/docs/map.md
+++ b/docs/map.md
@@ -73,7 +73,10 @@ Picks until it finds a `cell-floor`. Bordered grid guarantees one exists; loop t
 
 ## Secret walls
 
-Hand-authored only - `cell-secret` is never placed by `random-grid` / `seed-doors`. Author opts a cell in by writing `S` in a `:layout` row; `parse-layout` resolves it to `cell-secret`.
+Two sources:
+
+- **Hand-authored**: write `S` in a `:layout` row; `parse-layout` resolves it to `cell-secret` (L10's pillar secrets).
+- **Procgen-seeded**: `seed-secrets grid n` converts up to `n` *divider walls* (`divider-wall?`: a 1-cell-thick interior wall with floor on both horizontal OR both vertical sides) into `cell-secret`. Deterministic top-left-first scan (testable; the random grid itself varies the spots). `build-world` calls it on non-`:layout` levels, but **skips locked levels** - a secret shortcut there could bypass the keycard door. `secrets-per-level` (level.phel) = 2.
 
 ```phel
 (wall?    grid x y)  ; true for secret cells - the raycaster paints them like normal walls
@@ -81,9 +84,10 @@ Hand-authored only - `cell-secret` is never placed by `random-grid` / `seed-door
 (secret?  grid x y)  ; true only for cell-secret
 (reveal-secret grid x y)  ; swap cell-secret → cell-floor (no-op on non-secret)
 (count-secrets grid)      ; per-level total, stamped at build time
+(seed-secrets grid n)     ; convert up to n divider walls to cell-secret
 ```
 
-The visual cue is deliberately absent (DOOM-style): identical wall shading, no overlay. Discovery is by exploration + bumping. `commands/play.phel/try-reveal-secret` watches the action-key rising edge (`F`); on a press it checks the cell one unit ahead of the player along `:angle` and calls `reveal-secret` if it's a secret. World tracks `:secrets-total` (set by `count-secrets` in `build-world`) + `:secrets-found` (bumped by `try-reveal-secret`); the F3 debug HUD paints `secrets X/Y`.
+The visual cue is deliberately absent (DOOM-style): identical wall shading, no overlay. Discovery is by exploration + bumping. `commands/play.phel/try-reveal-secret` watches the action-key rising edge (`F`); on a press it checks the cell one unit ahead of the player along `:angle`, calls `reveal-secret` if it's a secret, and drops a reward stash via `level/place-secret-reward`: an ammo box + armor shard plus one rotating trophy powerup (soulsphere / berserk / invuln, by reveal index - the rare pickups become a reliable exploration payoff). World tracks `:secrets-total` (set by `count-secrets` in `build-world`) + `:secrets-found` (bumped by `try-reveal-secret`); the F3 debug HUD paints `secrets X/Y`.
 
 ## Switches
 

--- a/src/commands/play.phel
+++ b/src/commands/play.phel
@@ -17,7 +17,7 @@
   (:require phel-doom.core.weapons  :refer [effective-reserve-cap give-weapon switch-weapon weapon-spec weapon-order weapons])
   (:require phel-doom.io.sound    :refer [play-sfx! mute-for!])
   (:require phel-doom.io.ambient  :refer [start-ambient! stop-ambient! sync-ambient!])
-  (:require phel-doom.core.level    :refer [build-world num-levels])
+  (:require phel-doom.core.level    :refer [build-world num-levels place-secret-reward])
   (:require phel-doom.core.perf     :refer [target-frame-us])
   (:require phel-doom.io.scores   :refer [update-scores!])
   (:require phel-doom.io.render   :refer [render! clear-screen
@@ -417,7 +417,8 @@
 (defn- try-reveal-secret
   "Action-key handler: when F was just pressed AND the cell directly
    in front of the player is an unrevealed secret wall, swap that
-   cell to floor on the world's grid and bump `:secrets-found`.
+   cell to floor on the world's grid, drop a reward stash at the
+   revealed cell (level/place-secret-reward), and bump `:secrets-found`.
    Plays the door sfx so the reveal is audibly distinct from a wall
    bump. No-op otherwise so other action-bound features (switches,
    etc) chain off the same edge without conflict."
@@ -426,11 +427,13 @@
     world
     (let [[cx cy] (cell-ahead world)]
       (if (secret? (:grid world) cx cy)
-        (do (when (:sound-on world) (play-sfx! :door))
-            (-> world
-                (assoc :grid (reveal-secret (:grid world) cx cy))
-                (rebuild-pgrid)
-                (update :secrets-found (fn [n] (php/+ (or n 0) 1)))))
+        (let [idx (or (:secrets-found world) 0)]
+          (when (:sound-on world) (play-sfx! :door))
+          (-> world
+              (assoc :grid (reveal-secret (:grid world) cx cy))
+              (rebuild-pgrid)
+              (place-secret-reward cx cy idx)
+              (update :secrets-found (fn [n] (php/+ (or n 0) 1)))))
         world))))
 
 (defn- try-toggle-switch

--- a/src/core/level.phel
+++ b/src/core/level.phel
@@ -1,6 +1,6 @@
 (ns phel-doom.core.level
   (:require phel-doom.core.state      :refer [max-backpacks max-lives new-player new-world with-enemies])
-  (:require phel-doom.core.map        :refer [cell-door cell-door-blue cell-door-red count-secrets parse-layout random-grid random-spawn seed-doors])
+  (:require phel-doom.core.map        :refer [cell-door cell-door-blue cell-door-red count-secrets parse-layout random-grid random-spawn seed-doors seed-secrets])
   (:require phel-doom.core.enemy      :refer [default-wander-fraction promote-wanderers spawn-enemies spawn-enemies-mixed])
   (:require phel-doom.core.enemies    :refer [enemy-types type-spec default-lives-for])
   (:require phel-doom.core.difficulty :refer [normalise scale-cfg]))
@@ -231,6 +231,37 @@
    the heart / armor / ammo balance."
   3)
 
+(def secrets-per-level
+  "Procgen levels seed up to this many secret passages (map/seed-secrets).
+   Two gives the explorer a reason to bump suspicious walls without
+   carving the map into swiss cheese. Hand-authored layouts (L10) keep
+   their own secrets and are NOT auto-seeded."
+  2)
+
+(def secret-trophies
+  "Trophy powerup dropped behind a revealed secret, picked by reveal
+   order so each secret hands out a different rare prize before
+   cycling. These are exactly the powerups that are otherwise low-odds
+   random spawns — secrets become the reliable way to earn them."
+  [:soulspheres :berserks :invulns])
+
+(defn place-secret-reward
+  "Drop a reward stash at a just-revealed secret cell `(cx, cy)`: an
+   ammo box + an armor shard (always) plus one rotating trophy powerup
+   (soulsphere / berserk / invuln, chosen by `idx` = the count of
+   secrets already found). Pure — conj's onto the world's pickup
+   vectors at the cell centre so the normal pickup-* passes collect
+   them when the player steps in. `idx` 0-based."
+  [world ^int cx ^int cy ^int idx]
+  (let [x      (php/+ 0.5 cx)
+        y      (php/+ 0.5 cy)
+        trophy (get secret-trophies (mod idx (count secret-trophies)))
+        at     {:x x :y y}]
+    (-> world
+        (update :ammo-boxes (fn [v] (conj (or v []) at)))
+        (update :armor-shards (fn [v] (conj (or v []) at)))
+        (update trophy (fn [v] (conj (or v []) at))))))
+
 (defn- maybe-spawn-backpack
   "Stacking backpack (#68 part 3): L2+ only, ~1 in 5 qualifying
    levels. Skipped once the player is at `max-backpacks`. `pack`
@@ -421,39 +452,47 @@
   ([n l pack] (build-world n l pack :normal #{:pistol}))
   ([n l pack diff] (build-world n l pack diff #{:pistol}))
   ([lv life pack diff owned]
-   (let [diff'                (normalise diff)
-         raw                  (config-for lv)
+   (let [diff'       (normalise diff)
+         raw         (config-for lv)
          ;; Resolve :enemy-lives from the catalog BEFORE scale-cfg —
          ;; otherwise scale-cfg's missing-field default of 1 masks
          ;; the catalog default and every monster spawns with 1 HP.
-         primed               (if (or (vector? (:enemies raw)) (:enemy-lives raw))
-                                raw
-                                (assoc raw :enemy-lives
-                                       (default-lives-for (or (:enemy raw) :imp))))
-         cfg                  (scale-cfg primed diff')
-         lock                 (:door-lock cfg)
-         {:keys [grid spawn]} (build-grid cfg)
-         [px py]              spawn
-         specs                (normalise-enemies cfg)
-         world                (new-world grid (new-player px py (php/* (rand-int 360)
-                                                                       (php// php/M_PI 180.0))))
-         spawned              (spawn-enemies-mixed grid specs
-                                                   enemy-min-spawn-dist px py)
+         primed      (if (or (vector? (:enemies raw)) (:enemy-lives raw))
+                       raw
+                       (assoc raw :enemy-lives
+                              (default-lives-for (or (:enemy raw) :imp))))
+         cfg         (scale-cfg primed diff')
+         lock        (:door-lock cfg)
+         built       (build-grid cfg)
+         spawn       (:spawn built)
+         ;; Seed hidden reward passages into procgen levels. Skipped on
+         ;; hand-authored layouts (they pin their own secrets) and on
+         ;; locked levels — a secret shortcut there could bypass the
+         ;; keycard door and break the lock gating.
+         grid        (if (and (not (:layout cfg)) (not lock))
+                       (seed-secrets (:grid built) secrets-per-level)
+                       (:grid built))
+         [px py]     spawn
+         specs       (normalise-enemies cfg)
+         world       (new-world grid (new-player px py (php/* (rand-int 360)
+                                                              (php// php/M_PI 180.0))))
+         spawned     (spawn-enemies-mixed grid specs
+                                          enemy-min-spawn-dist px py)
          ;; Nightmare: stamp every spawned enemy so respawn picks the
          ;; shorter delay range AND the :max-concurrent cap is bypassed
          ;; (see core/enemy.phel/tick-one). Other difficulties get no
          ;; stamp -> default respawn behaviour.
-         tagged-foes          (if (php/=== :nightmare diff')
-                                (apply vector (map (fn [e] (assoc e :nightmare? true)) spawned))
-                                spawned)
+         tagged-foes (if (php/=== :nightmare diff')
+                       (apply vector (map (fn [e] (assoc e :nightmare? true)) spawned))
+                       spawned)
          ;; Half the freshly-spawned dormant enemies start pacing
          ;; instead of sleeping. Wanderers can stumble into the
          ;; player's LOS by accident — that's the "rooms feel alive"
          ;; cue. Tests opting out pass through 0.0 via fixtures that
          ;; never run through build-world (they construct enemies
          ;; directly).
-         lively-foes          (promote-wanderers tagged-foes default-wander-fraction)
-         with-foes            (with-enemies world lively-foes)]
+         lively-foes (promote-wanderers tagged-foes default-wander-fraction)
+         with-foes   (with-enemies world lively-foes)]
      (assoc with-foes
             :level         lv
             :lives         life

--- a/src/core/map.phel
+++ b/src/core/map.phel
@@ -265,6 +265,46 @@
                     (recur (php/+ x 1) n))))]
           (recur (php/+ y 1) (php/+ acc row-secrets)))))))
 
+(defn- divider-wall?
+  "True when the interior wall at (x, y) is a 1-cell-thick divider
+   between two floors — floor on both horizontal OR both vertical
+   sides. Such a wall is bump-reachable from a floor side and opens a
+   hidden shortcut when revealed."
+  [grid x y]
+  (and (= cell-wall (cell grid x y))
+       (or (and (= cell-floor (cell grid (php/- x 1) y))
+                (= cell-floor (cell grid (php/+ x 1) y)))
+           (and (= cell-floor (cell grid x (php/- y 1)))
+                (= cell-floor (cell grid x (php/+ y 1)))))))
+
+(defn seed-secrets
+  "Convert up to `n` divider walls (see `divider-wall?`) into
+   `cell-secret`, turning them into bump-reachable secret passages
+   where the reward stash drops on reveal (level/place-secret-reward).
+   Deterministic top-left-first scan so it's testable; with procgen
+   the grid itself varies per seed, so secret spots still differ run
+   to run. Skips the border, never converts a cell adjacent to an
+   already-placed secret (so reveals stay distinct). Returns the grid,
+   possibly fewer than `n` if too few walls qualify."
+  [grid ^int n]
+  (let [h (count grid)
+        w (count (first grid))]
+    (loop [y 1 g grid placed 0]
+      (if (or (php/>= placed n) (php/>= y (php/- h 1)))
+        g
+        (let [[g' placed']
+              (loop [x 1 gg g p placed]
+                (if (or (php/>= p n) (php/>= x (php/- w 1)))
+                  [gg p]
+                  (if (and (divider-wall? gg x y)
+                           ;; keep secrets non-adjacent so each reveal
+                           ;; opens a separate spot
+                           (not (= cell-secret (cell gg (php/- x 1) y)))
+                           (not (= cell-secret (cell gg x (php/- y 1)))))
+                    (recur (php/+ x 1) (assoc-in gg [y x] cell-secret) (php/+ p 1))
+                    (recur (php/+ x 1) gg p))))]
+          (recur (php/+ y 1) g' placed'))))))
+
 (defn missing-key-for
   "Lock colour kw that's blocking the player at (x, y), or nil. Used
    by physics/try-move to differentiate a 'bounced off a wall' bump

--- a/tests/commands/play-test.phel
+++ b/tests/commands/play-test.phel
@@ -94,6 +94,23 @@
     (is (= 1 (:kills w')))
     (is (= 0.0 (or (:hit-stop-secs w') 0.0)) "trash kill: no freeze")))
 
+(deftest test-tick-world-reveal-secret-grants-reward
+  ;; Player at (1.5,1.5) facing east; cell (2,1) is a secret wall (6).
+  ;; Pressing the action key reveals it, bumps :secrets-found, and
+  ;; drops a reward stash (ammo + shard + the idx-0 trophy soulsphere)
+  ;; at the revealed cell.
+  (let [secret-grid [[1 1 1 1]
+                     [1 0 6 1]
+                     [1 1 1 1]]
+        w'          (tick-world (new-world secret-grid (new-player 1.5 1.5 0.0))
+                                "" 0.016 (assoc no-edges :action true))]
+    (is (= 1 (:secrets-found w')) "secret revealed + counted")
+    (is (>= (count (:ammo-boxes w')) 1) "ammo dropped")
+    (is (>= (count (:armor-shards w')) 1) "shard dropped")
+    (is (= 1 (count (:soulspheres w'))) "idx-0 trophy is a soulsphere")
+    ;; reward sits at the revealed cell centre (2.5, 1.5).
+    (is (= 2.5 (:x (first (:soulspheres w')))))))
+
 (deftest test-tick-world-toggle-map-edge-flips-show-map
   (let [w' (tick-world (new-world open-grid (new-player 5.0 5.0 0.0))
                        "" 0.016 (assoc no-edges :toggle-map true))]

--- a/tests/core/level-test.phel
+++ b/tests/core/level-test.phel
@@ -1,6 +1,6 @@
 (ns phel-doom-tests.core.level-test
   (:require phel.test :refer [deftest is])
-  (:require phel-doom.core.level :refer [config-for num-levels build-world]))
+  (:require phel-doom.core.level :refer [config-for num-levels build-world place-secret-reward secret-trophies]))
 
 (deftest test-config-for-returns-each-level
   (is (= "imps"        (:name (config-for 1))))
@@ -146,3 +146,36 @@
       ;; respawn step never doubles up minion pressure.
       (is (= 2 (count imps)))
       (is (every? (fn [e] (= 1 (:max-concurrent e))) imps)))))
+
+;; ---------------------------------------------------------------------
+;; place-secret-reward: stash dropped at a revealed secret cell.
+;; Always an ammo box + armor shard; plus one rotating trophy powerup
+;; chosen by reveal index.
+;; ---------------------------------------------------------------------
+
+(def empty-pickups
+  {:ammo-boxes [] :armor-shards [] :soulspheres [] :berserks [] :invulns []})
+
+(deftest test-place-secret-reward-always-ammo-and-shard
+  (let [w (place-secret-reward empty-pickups 5 7 0)]
+    (is (= 1 (count (:ammo-boxes w))) "ammo box dropped")
+    (is (= 1 (count (:armor-shards w))) "armor shard dropped")
+    ;; Cell centre coords.
+    (is (= 5.5 (:x (first (:ammo-boxes w)))))
+    (is (= 7.5 (:y (first (:ammo-boxes w)))))))
+
+(deftest test-place-secret-reward-trophy-rotates-by-index
+  ;; idx 0 -> soulsphere, 1 -> berserk, 2 -> invuln, 3 -> wraps to soul.
+  (is (= 1 (count (:soulspheres (place-secret-reward empty-pickups 1 1 0)))))
+  (is (= 1 (count (:berserks    (place-secret-reward empty-pickups 1 1 1)))))
+  (is (= 1 (count (:invulns     (place-secret-reward empty-pickups 1 1 2)))))
+  (is (= 1 (count (:soulspheres (place-secret-reward empty-pickups 1 1 3))))
+      "index wraps modulo trophy count"))
+
+(deftest test-place-secret-reward-conjs-onto-existing
+  (let [seeded (assoc empty-pickups :ammo-boxes [{:x 0.5 :y 0.5}])
+        w      (place-secret-reward seeded 2 2 0)]
+    (is (= 2 (count (:ammo-boxes w))) "appends, doesn't clobber existing")))
+
+(deftest test-secret-trophies-are-the-rare-powerups
+  (is (= [:soulspheres :berserks :invulns] secret-trophies)))

--- a/tests/core/map-test.phel
+++ b/tests/core/map-test.phel
@@ -9,7 +9,7 @@
                                        switch-on? toggle-switch
                                        toggle-switch-cell toggle-target-cell
                                        parse-layout
-                                       random-grid random-spawn seed-doors]))
+                                       random-grid random-spawn seed-doors seed-secrets]))
 
 (deftest test-walls-on-perimeter
   (is (wall? default-grid 0 0))
@@ -322,3 +322,47 @@
                            "####"])
         g   (:grid out)]
     (is (= cell-switch-off (get-in g [1 1])))))
+
+;; ---------------------------------------------------------------------
+;; seed-secrets: convert 1-thick divider walls into secret passages.
+;; Deterministic top-left-first scan.
+;; ---------------------------------------------------------------------
+
+(deftest test-seed-secrets-converts-divider-wall
+  ;; Middle column is a 1-thick wall with floor on both horizontal
+  ;; sides at row 1 -> qualifies, becomes a secret.
+  (let [g  [[1 1 1 1 1]
+            [1 0 1 0 1]
+            [1 1 1 1 1]]
+        g' (seed-secrets g 1)]
+    (is (= cell-secret (get-in g' [1 2])) "divider wall converted")
+    (is (= 1 (count-secrets g')))))
+
+(deftest test-seed-secrets-respects-count
+  ;; Two separate dividers; ask for only one -> first (top-left) wins.
+  (let [g  [[1 1 1 1 1]
+            [1 0 1 0 1]
+            [1 1 1 1 1]
+            [1 0 1 0 1]
+            [1 1 1 1 1]]
+        g' (seed-secrets g 1)]
+    (is (= 1 (count-secrets g')) "stops at the requested count")
+    (is (= cell-secret (get-in g' [1 2])) "top-most divider chosen")))
+
+(deftest test-seed-secrets-skips-solid-walls
+  ;; A thick wall (no floor on opposite sides) never converts.
+  (let [g  [[1 1 1]
+            [1 1 1]
+            [1 1 1]]
+        g' (seed-secrets g 2)]
+    (is (= 0 (count-secrets g')) "no divider -> no secret")))
+
+(deftest test-seed-secrets-vertical-divider
+  ;; Floor above + below a wall row also qualifies.
+  (let [g  [[1 1 1]
+            [1 0 1]
+            [1 1 1]
+            [1 0 1]
+            [1 1 1]]
+        g' (seed-secrets g 2)]
+    (is (= cell-secret (get-in g' [2 1])) "vertical divider converted")))


### PR DESCRIPTION
## 📚 Description

Makes secrets worth hunting, and puts them across the whole game instead of only the L10 pillar. Finding a secret wall (bump + `F`) now reveals a **reward stash**, and every non-locked procgen level seeds its own hidden passages.

## 🔖 Changes

- **`map/seed-secrets`**: converts up to `n` *divider walls* (1-cell-thick interior wall with floor on both horizontal OR both vertical sides - bump-reachable, opens a shortcut) into `cell-secret`. Deterministic top-left-first scan (testable; the random grid itself varies where they land), non-adjacent so reveals stay distinct.
- **`level/build-world`**: seeds procgen levels (`secrets-per-level` = 2). **Skips** hand-authored layouts (they pin their own secrets) and **locked levels (L4/L5)** - a secret shortcut there could bypass the keycard door and break lock gating.
- **`level/place-secret-reward`**: drops a stash at the revealed cell - an ammo box + armor shard (always) + one **rotating trophy powerup** (soulsphere → berserk → invuln by reveal index). These are exactly the otherwise-rare random spawns, so secrets become the reliable way to earn them.
- **`play/try-reveal-secret`**: calls `place-secret-reward` on reveal (before bumping `:secrets-found`, so the trophy index is 0-based).
- **Tests**: `seed-secrets` (horizontal/vertical divider, count cap, skips solid walls), `place-secret-reward` (always ammo+shard, trophy rotation + modulo wrap, conj onto existing), and a `tick-world` reveal→reward integration. 1192 → 1213.
- **Docs**: `map`, `level-system`, `features` + `CHANGELOG`.

## ✅ Verification

- `composer ci` clean: format-check, lint, 1213 tests, build (55 files).
- Headless smoke: L1-3 + L6-9 each seed 2 secrets across 5 builds; **L4/L5 (locked) seed 0**; L10 keeps its 2 authored. Confirms gating + that divider walls are plentiful in random grids.