### PR TITLE
fix(render): occlude enemy face/eyes behind closer sprites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 
 ### Fixed
 
+- Enemy face / eyes glyph drew over closer sprites (#91). The face overlay was gated only by walls, not by nearer enemies, so a far enemy's eyes floated on top of one in front. Now gated by the same front-most-enemy check as the grounding shadow.
 - Grid mutations (#61 secrets, doors, switches) left the raycaster's `:pgrid` stale - player walked through visually solid walls. New `state/rebuild-pgrid` resyncs after every mutation.
 - SHIFT+WASD sprint silently no-op on Terminal.app / xterm / GNOME Terminal (any non-kitty terminal). Capital W/A/S/D bytes now refresh both the matching movement slot AND `:sprint`, so SHIFT+WASD sprints universally instead of being kitty-only.
 

--- a/docs/rendering.md
+++ b/docs/rendering.md
@@ -116,11 +116,14 @@ Iterates visible enemies after the main frame composes; paints one face glyph (`
 
 Blood splatters from kills + heart pickups paint into a PHP array `blood-paint` indexed by `row * vw + col`. Inner loop reads first via `(or (php/aget blood-paint ...) main-cond)` so overlays override wall/floor/enemy paint.
 
-### Enemy grounding shadows (two-pass, issue #86)
+### Front-most-enemy gate (shadows + faces, issues #86 / #91)
 
-Each enemy drops a dark `sprite-shadow` cell into `blood-paint` at its foot row to read as grounded. Because `blood-paint` is the top-priority layer, the shadow can NOT be written inline during the back-to-front enemy zone pass: a farther enemy's foot-row shadow would sit over a nearer enemy's body (which lives in the lower-priority enemy-zone layer) and bleed through.
+Two per-enemy overlays paint into top-priority layers and so can't be depth-resolved by the back-to-front zone pass alone:
 
-So shadows are deferred to a second pass after the zone pass, once `edists` (nearest enemy depth per column) is complete. `enemy-shadow-visible-at?` gates each shadow cell on wall depth (`d < dists[c]`) AND front-most-enemy depth (`d <= edists[c]`, inclusive so the column's own front enemy still grounds). Only the nearest enemy at a column drops its shadow; farther ones skip. Enemies are projected + depth-sorted once (`enemy-projs`) and reused across both passes.
+- **Grounding shadow** - a dark `sprite-shadow` cell at the foot row, written into `blood-paint` (top layer). Painted inline, a farther enemy's foot-row shadow would sit over a nearer enemy's body (lower-priority enemy-zone layer) and bleed through.
+- **Face / eyes glyph** (`paint-face-overlay`) - a cursor-positioned glyph appended after the frame, so it draws over everything unless gated.
+
+Both reuse `enemy-front-visible-at?`: a column draws the overlay only when the enemy is in front of the wall (`d < dists[c]`) AND the front-most enemy there (`d <= edists[c]`, inclusive so the column's own front enemy still draws; farther ones skip). `edists` (nearest enemy depth per column) is built during the zone pass. The shadow runs as a deferred second pass once `edists` is complete; the face overlay reads the same `edists` in the post-frame overlay chain. Enemies are projected + depth-sorted once (`enemy-projs`).
 
 ## Run-length encoding
 

--- a/src/io/render.phel
+++ b/src/io/render.phel
@@ -1244,14 +1244,37 @@
       (get enemy-types (or (get stats :enemy) :imp))
       (get enemy-types :imp)))
 
+(defn enemy-front-visible-at?
+  "True when an enemy at depth `d` is the front-most thing to draw at
+   screen column `c`: in front of the wall (dists) AND the front-most
+   enemy there (`d <= edists[c]`, where edists holds the nearest enemy
+   depth per column after the zone pass). Unlike `pickup-visible-at?`
+   the enemy compare is inclusive (`<=`) so the column's own front
+   enemy — whose depth equals the stored nearest — still draws; only
+   enemies strictly behind it skip.
+
+   Shared by the per-enemy overlays that paint OVER the zone layer and
+   would otherwise bleed through a nearer sprite: the grounding shadow
+   (issue #86) and the face / eyes glyph (issue #91). Exported for
+   tests."
+  [^float d c dists edists]
+  (let [wd (buf-get dists c)
+        ed (buf-get edists c)]
+    (and (php/< d wd)
+         (or (php/=== ed nil) (php/<= d ed)))))
+
 (defn- paint-face-overlay
   "At each visible alive enemy's centre column paint that enemy's
    catalog face glyph at the upper-third of the sprite. Three modes:
      - scare-secs active  → wide-eyed scare glyph (one-shot beat)
      - d < aggro-distance → :face-attack telegraph
      - else               → resting :face (alternates with :face-alt
-                            on the global face-phase beat)"
-  [parts world stats vw vh dists face-phase]
+                            on the global face-phase beat)
+
+   `edists` (nearest enemy depth per column, built during the zone
+   pass) gates the glyph so a face behind a closer sprite doesn't bleed
+   through — same fix as the grounding shadow (issue #91)."
+  [parts world stats vw vh dists edists face-phase]
   (let [scare? (php/> (or (get stats :scare-secs) 0.0) 0.0)]
     (doseq [proj (collect-enemy-projs (:enemies world) (:player world) vw)]
            (let [col         (:col proj)
@@ -1268,7 +1291,7 @@
              (when (and glyph
                         (php/>= col 0)
                         (php/< col vw)
-                        (php/< d (buf-get dists col)))
+                        (enemy-front-visible-at? d col dists edists))
                (let [h        (php/min vh (php/intval (php// proj-dist
                                                              (php/* (php/max 0.5 d) char-aspect))))
                      face-row (php/+ (php/intdiv (php/- vh h) 2) (php/intdiv h 6))]
@@ -2237,22 +2260,6 @@
     (and (php/< d wd)
          (or (php/=== ed nil) (php/< d ed)))))
 
-(defn enemy-shadow-visible-at?
-  "True when an enemy at depth `d` may ground its shadow at screen
-   column `c`: in front of the wall (dists) AND the front-most enemy
-   there (`d <= edists[c]`, where edists holds the nearest enemy depth
-   per column after the zone pass). Unlike `pickup-visible-at?` the
-   enemy compare is inclusive (`<=`) so the column's own front enemy —
-   whose depth equals the stored nearest — still draws; only enemies
-   strictly behind it skip. Keeps one farther sprite's shadow row from
-   bleeding over a nearer sprite's body (issue #86). Exported for
-   tests."
-  [^float d c dists edists]
-  (let [wd (buf-get dists c)
-        ed (buf-get edists c)]
-    (and (php/< d wd)
-         (or (php/=== ed nil) (php/<= d ed)))))
-
 (defn- paint-pickups-into
   "Project each pickup (heart / armor) to screen and write its
    coloured BG glow into `blood-paint`, then drop the icon glyph at
@@ -2695,7 +2702,7 @@
              (when (php/< e-bot vh)
                (loop [c c-from]
                  (when (php/<= c c-to)
-                   (when (enemy-shadow-visible-at? d c dists edists)
+                   (when (enemy-front-visible-at? d c dists edists)
                      (buf-set blood-paint
                               (php/+ (php/* e-bot vw) c)
                               sprite-shadow))
@@ -2846,7 +2853,7 @@
             ;; Numbered rebinds so phel lint's shadowed-binding stays
             ;; quiet without changing semantics. Threading (->) would
             ;; be cleaner but trips arity-mismatch lint.
-            p1          (paint-face-overlay       parts world stats vw vh dists face-phase)
+            p1          (paint-face-overlay       parts world stats vw vh dists edists face-phase)
             p2          (paint-wall-lights        p1 t vw vh hits hxs hys tops)
             p3          (paint-door-face          p2 stats vw vh hits tops bots)
             p4          (paint-crosshair          p3 stats vw vh center-bg)

--- a/tests/io/render-test.phel
+++ b/tests/io/render-test.phel
@@ -1,6 +1,6 @@
 (ns phel-doom-tests.io.render-test
   (:require phel.test :refer [deftest is])
-  (:require phel-doom.io.render :refer [direction-char project-enemy enemy-shadow-visible-at?]))
+  (:require phel-doom.io.render :refer [direction-char project-enemy enemy-front-visible-at?]))
 
 (deftest test-direction-char-cardinal
   (is (= "→" (direction-char 0.0)))
@@ -46,16 +46,17 @@
     (is (> (:col proj) 40))))
 
 ;; ---------------------------------------------------------------------
-;; enemy-shadow-visible-at?: grounding-shadow occlusion gate (issue #86).
-;; Only the front-most enemy at a column drops its shadow; farther ones
-;; and wall-occluded ones skip, so a rear shadow can't bleed over a
-;; nearer sprite.
+;; enemy-front-visible-at?: per-column "front-most enemy" gate shared by
+;; the grounding shadow (issue #86) and the face / eyes glyph (issue
+;; #91). Only the front-most enemy at a column draws its overlay;
+;; farther ones and wall-occluded ones skip, so a rear shadow / face
+;; can't bleed over a nearer sprite.
 ;; ---------------------------------------------------------------------
 
 (deftest test-enemy-shadow-hidden-behind-wall
   (let [dists  (php/array 3.0)
         edists (php/array 4.0)]
-    (is (= false (enemy-shadow-visible-at? 6.0 0 dists edists))
+    (is (= false (enemy-front-visible-at? 6.0 0 dists edists))
         "behind a closer wall -> no shadow")))
 
 (deftest test-enemy-shadow-front-enemy-grounds
@@ -63,7 +64,7 @@
   ;; compare keeps its own shadow.
   (let [dists  (php/array 10.0)
         edists (php/array 4.0)]
-    (is (= true (enemy-shadow-visible-at? 4.0 0 dists edists))
+    (is (= true (enemy-front-visible-at? 4.0 0 dists edists))
         "front enemy grounds its shadow")))
 
 (deftest test-enemy-shadow-rear-enemy-skips
@@ -71,7 +72,7 @@
   ;; its shadow must NOT draw (would bleed over the front sprite).
   (let [dists  (php/array 10.0)
         edists (php/array 4.0)]
-    (is (= false (enemy-shadow-visible-at? 6.0 0 dists edists))
+    (is (= false (enemy-front-visible-at? 6.0 0 dists edists))
         "rear enemy's shadow is suppressed")))
 
 (deftest test-enemy-shadow-no-enemy-recorded-at-column
@@ -79,5 +80,5 @@
   ;; enemy's own shadow may draw, still wall-gated.
   (let [dists  (php/array 10.0)
         edists (php/array)]
-    (is (= true (enemy-shadow-visible-at? 4.0 0 dists edists))
+    (is (= true (enemy-front-visible-at? 4.0 0 dists edists))
         "no nearer enemy -> shadow allowed")))


### PR DESCRIPTION
## 📚 Description

Fixes #91. The enemy face / eyes glyph was painted gated **only** by wall depth, never by nearer enemies - so a far enemy's eyes floated on top of one standing in front of it. Same class of bug as the grounding-shadow bleed (#86 / #88).

## 🔖 Changes

- Generalize the shadow gate `enemy-shadow-visible-at?` → **`enemy-front-visible-at?`** (identical logic: in front of the wall `d < dists[c]` AND the front-most enemy at the column `d <= edists[c]`). It now serves both overlays. Moved above `paint-face-overlay` so the forward reference resolves.
- **`paint-face-overlay`**: takes `edists`, gates the glyph on `enemy-front-visible-at?` instead of the wall-only check; call site passes `edists` (already in scope from the zone pass).
- **Tests**: renamed the gate tests; comment notes they now cover both shadow (#86) and face (#91). The 4 cases (wall-occluded / front-grounds / rear-skips / no-enemy) pin the shared logic.

## ✅ Verification

- `composer ci` clean: format-check, lint, 1192 tests, build (55 files).
- The change is provably safe for the front enemy: at its own column `edists[c] == d`, so `d <= edists[c]` holds and the face still draws - only a face whose column is owned by a **strictly nearer** enemy is suppressed. Same proven gate the shadow fix uses.

Closes #91