### PR TITLE
fix(audio): per-weapon fire report, gun no longer silent on a hit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 
 ### Fixed
 
+- Weapon felt silent when a shot connected (esp. the shotgun): a hit swapped the gun report for the enemy reaction, so you only heard a quiet thud. Every trigger pull now plays the active weapon's own fire sound, hit or miss, with the kill cue layered on top. Each weapon gets a distinct report (pistol Pop, shotgun Blow, chaingun Morse, chainsaw Purr) via a data-driven `:fire-sfx` spec key.
 - Enemy face / eyes glyph drew over closer sprites (#91). The face overlay was gated only by walls, not by nearer enemies, so a far enemy's eyes floated on top of one in front. Now gated by the same front-most-enemy check as the grounding shadow.
 - Grid mutations (#61 secrets, doors, switches) left the raycaster's `:pgrid` stale - player walked through visually solid walls. New `state/rebuild-pgrid` resyncs after every mutation.
 - SHIFT+WASD sprint silently no-op on Terminal.app / xterm / GNOME Terminal (any non-kitty terminal). Capital W/A/S/D bytes now refresh both the matching movement slot AND `:sprint`, so SHIFT+WASD sprints universally instead of being kitty-only.

--- a/docs/audio.md
+++ b/docs/audio.md
@@ -23,18 +23,26 @@ PHP has no portable in-process audio. Lowest-dependency path: call `afplay` / `p
 Combat and other modules raise events by name, not by file:
 
 ```phel
-(play-sfx! :hit)        ; player took damage
-(play-sfx! :shoot)      ; trigger pulled, no hit
-(play-sfx! :kill)       ; trigger pulled, enemy died
-(play-sfx! :wound)      ; trigger pulled, enemy survived (multi-life HP)
-(play-sfx! :reload)     ; reload animation started
-(play-sfx! :click)      ; trigger pulled on empty mag (dry-fire deny)
-(play-sfx! :door)       ; level transition or heart/armor/ammo pickup
-(play-sfx! :heartbeat)  ; low-life pulse
-(play-sfx! :berserk)    ; rage sphere picked up
+(play-sfx! :hit)             ; player took damage
+(play-sfx! :shoot)           ; pistol fire (default fire report)
+(play-sfx! :shoot-shotgun)   ; shotgun fire
+(play-sfx! :shoot-chaingun)  ; chaingun fire
+(play-sfx! :shoot-chainsaw)  ; chainsaw rev
+(play-sfx! :kill)            ; killing blow (layered over the fire report)
+(play-sfx! :reload)          ; reload animation started
+(play-sfx! :click)           ; trigger pulled on empty mag (dry-fire deny)
+(play-sfx! :door)            ; level transition or heart/armor/ammo pickup
+(play-sfx! :heartbeat)       ; low-life pulse
+(play-sfx! :berserk)         ; rage sphere picked up
 ```
 
-`macos-sounds` and Linux equivalents map each tag to a file. Current mapping picks distinct semantic families: `Pop` for shoot + kill, `Submarine` for wound (muted, so it doesn't compete with the floating HP digit), `Sosumi` for player-hurt, `Basso` for empty-click deny, `Funk` for reload, `Tink` for door / pickup, `Bottle` for heartbeat, `Hero` for berserk.
+`macos-sounds` and Linux equivalents map each tag to a file: `Pop` for pistol-fire + kill, `Blow` for shotgun, `Morse` for chaingun, `Purr` for chainsaw, `Sosumi` for player-hurt, `Basso` for empty-click deny, `Funk` for reload, `Tink` for door / pickup, `Bottle` for heartbeat, `Hero` for berserk.
+
+## Per-weapon fire report
+
+Every trigger pull plays the ACTIVE weapon's own fire sound, hit or miss. The event comes from the weapon spec's `:fire-sfx` (weapons.phel), so combat is data-driven: `(play-sfx! (or (:fire-sfx (w-spec world)) :shoot) 1.0)`. On a kill the `:kill` cue is layered on top (distance-attenuated); wounds ride on the fire report plus the floating HP digit + blood, with no separate sound.
+
+Previously a shot that connected swapped the gun sound for the enemy reaction, so a weapon felt silent when you actually hit something (the shotgun especially). Playing the fire report unconditionally fixes that and gives each weapon a distinct voice.
 
 ## Async firing
 

--- a/src/core/combat.phel
+++ b/src/core/combat.phel
@@ -565,21 +565,24 @@
 (defn- on-shot-miss [world]
   (assoc world :fire-anim fire-anim-seconds))
 
-(defn- play-shot-sfx [world hit? killed? hit-pos]
+(defn- play-shot-sfx [world killed? hit-pos]
   (when (:sound-on world)
-    (cond
-      killed? (let [p  (:player world)
-                    dx (php/- (:x hit-pos) (:x p))
-                    dy (php/- (:y hit-pos) (:y p))
-                    d  (php/sqrt (php/+ (php/* dx dx) (php/* dy dy)))]
-                (play-sfx! :kill (distance-volume d)))
-      ;; Wounded but alive: distinct `:wound` event so the player can
-      ;; tell a shot landed without mistaking it for the `:hit` sound
-      ;; that `take-damage` uses when the PLAYER is the one struck.
-      ;; Lower vol (0.4) keeps it as a soft 'thud' under the kill +
-      ;; shoot sfx; the floating HP digit is the primary signal.
-      hit?    (play-sfx! :wound 0.4)
-      :else   (play-sfx! :shoot 1.0))))
+    ;; Always fire the ACTIVE weapon's own report so every trigger pull
+    ;; sounds like the gun going off — hit or miss. Earlier this only
+    ;; played a gun sound on a MISS; a shot that connected swapped in the
+    ;; enemy reaction, so the weapon (esp. the shotgun) felt silent when
+    ;; you actually hit something. Per-weapon `:fire-sfx` (weapons spec)
+    ;; gives each gun a distinct voice; falls back to :shoot.
+    (play-sfx! (or (:fire-sfx (w-spec world)) :shoot) 1.0)
+    ;; Layer the kill cue ON TOP of the fire report so a kill keeps its
+    ;; punch, distance-attenuated. Wounds ride on the fire sound plus
+    ;; the floating HP digit + blood splatter — no separate thud.
+    (when killed?
+      (let [p  (:player world)
+            dx (php/- (:x hit-pos) (:x p))
+            dy (php/- (:y hit-pos) (:y p))
+            d  (php/sqrt (php/+ (php/* dx dx) (php/* dy dy)))]
+        (play-sfx! :kill (distance-volume d))))))
 
 (defn can-fire?
   "True when the active weapon is ready: cooldown elapsed, not jammed,
@@ -675,7 +678,7 @@
         woken                       (noise-wake enemies' (:grid world) (:x p) (:y p))
         killed?                     (and hit?
                                          (false? (:alive (get woken idx))))]
-    (play-shot-sfx world hit? killed? hit-pos)
+    (play-shot-sfx world killed? hit-pos)
     (apply-heat (if hit?
                   (on-shot-hit world woken hit-pos idx)
                   (on-shot-miss (assoc world :enemies woken))))))

--- a/src/core/weapons.phel
+++ b/src/core/weapons.phel
@@ -38,6 +38,7 @@
               :damage          1
               :damage-type     :ballistic
               :auto-fire?      true
+              :fire-sfx        :shoot
               ;; Pistol is the only overheating weapon. Trade-off
               ;; for its 0.12s cd + auto-fire: hold space too long
               ;; and the slide jams for jam-seconds. Chaingun has
@@ -59,6 +60,7 @@
               :reload-duration 2.0
               :damage          3
               :damage-type     :ballistic
+              :fire-sfx        :shoot-shotgun
               ;; Shotgun is single-action: each space press = one
               ;; shell. Holding the trigger does NOT auto-fire — the
               ;; player has to re-pull for every shot. Matches DOOM2's
@@ -89,6 +91,7 @@
               :damage          1
               :damage-type     :melee
               :auto-fire?      true
+              :fire-sfx        :shoot-chainsaw
               :max-range       1.5
               ;; Movement multiplier applied while the saw is ticking
               ;; (`:fire-cooldown > 0`). Locks the player to a slow walk
@@ -112,6 +115,7 @@
               :reload-duration 1.8
               :damage          1
               :damage-type     :ballistic
+              :fire-sfx        :shoot-chaingun
               ;; Auto-fire: holding space sprays at the 0.05s cd
               ;; until mag empties or trigger releases. This is what
               ;; makes the 20 dps niche real — without it the player

--- a/src/io/sound.phel
+++ b/src/io/sound.phel
@@ -27,7 +27,14 @@
   "macOS ships these .aiff files in every install. Map game events to
    short, distinctive ones. One kill sound for all monsters: makes
    the death beat read the same across the run."
-  {:shoot     "/System/Library/Sounds/Pop.aiff"
+  {:shoot          "/System/Library/Sounds/Pop.aiff"
+   ;; Per-weapon fire reports (weapons spec :fire-sfx). Distinct files
+   ;; so each gun sounds different: pistol snaps (Pop, shared with
+   ;; :shoot), shotgun booms (Blow), chaingun rattles (Morse), chainsaw
+   ;; buzzes (Purr).
+   :shoot-shotgun  "/System/Library/Sounds/Blow.aiff"
+   :shoot-chaingun "/System/Library/Sounds/Morse.aiff"
+   :shoot-chainsaw "/System/Library/Sounds/Purr.aiff"
    :kill      "/System/Library/Sounds/Pop.aiff"
    :hit       "/System/Library/Sounds/Sosumi.aiff"
    :wound     "/System/Library/Sounds/Submarine.aiff"

--- a/tests/core/weapons-test.phel
+++ b/tests/core/weapons-test.phel
@@ -154,3 +154,24 @@
   ;; migration.
   (let [w {:weapon :pistol :backpack? true}]
     (is (= 100 (effective-reserve-cap w)))))
+
+;; ---------------------------------------------------------------------
+;; Per-weapon fire sfx: each weapon carries a :fire-sfx event so the
+;; combat layer can play a distinct report per gun (issue: shotgun felt
+;; silent on hits because only the enemy reaction played).
+;; ---------------------------------------------------------------------
+
+(deftest test-every-weapon-has-a-fire-sfx
+  (is (every? (fn [kw] (some? (:fire-sfx (get weapons kw)))) weapon-order)
+      "all four weapons carry a :fire-sfx event"))
+
+(deftest test-fire-sfx-distinct-per-weapon
+  (let [sfx (map (fn [kw] (:fire-sfx (get weapons kw))) weapon-order)]
+    (is (= (count weapon-order) (count (distinct sfx)))
+        "no two weapons share a fire report")))
+
+(deftest test-fire-sfx-values-pinned
+  (is (= :shoot          (:fire-sfx (get weapons :pistol))))
+  (is (= :shoot-shotgun  (:fire-sfx (get weapons :shotgun))))
+  (is (= :shoot-chaingun (:fire-sfx (get weapons :chaingun))))
+  (is (= :shoot-chainsaw (:fire-sfx (get weapons :chainsaw)))))

--- a/tests/io/sound-test.phel
+++ b/tests/io/sound-test.phel
@@ -25,3 +25,10 @@
   ;; and the other sound tests above would only pass by accident.
   ;; Guards the whole muting contract.
   (is (= "1" (php/getenv "PHEL_DOOM_SILENT"))))
+
+(deftest test-per-weapon-fire-events-are-silent-under-test-env
+  ;; New per-weapon fire events (weapons :fire-sfx) must gate the same
+  ;; way as every other event.
+  (is (= nil (play-sfx! :shoot-shotgun)))
+  (is (= nil (play-sfx! :shoot-chaingun)))
+  (is (= nil (play-sfx! :shoot-chainsaw))))


### PR DESCRIPTION
## 📚 Description

Fixes the "shotgun sound is broken" report. The root cause: `play-shot-sfx` played the gun's sound **only on a miss** - a shot that connected swapped in the enemy reaction (`:kill` / `:wound`), so when you actually hit something the weapon felt silent (just a quiet thud). Most obvious on the shotgun, but it affected every weapon.

Also adds the requested **distinct fire sound per weapon**.

## 🔖 Changes

- Every trigger pull now plays the **active weapon's own fire report**, hit or miss. On a killing blow the `:kill` cue is layered on top (distance-attenuated). Wounds ride on the fire report + the floating HP digit + blood splatter - the separate quiet `:wound` thud is gone.
- **Data-driven `:fire-sfx`** per weapon spec (`weapons.phel`): pistol `:shoot` (Pop), shotgun `:shoot-shotgun` (Blow), chaingun `:shoot-chaingun` (Morse), chainsaw `:shoot-chainsaw` (Purr). `sound.phel` maps the new events to distinct macOS system files (Linux falls back to the bell like every other event).
- `play-shot-sfx` reads `(:fire-sfx (w-spec world))`, defaulting to `:shoot`.
- **Tests**: every weapon carries a distinct `:fire-sfx` (pinned values); new events stay silent under `PHEL_DOOM_SILENT`. 1213 → 1222.
- **Docs**: `audio.md` (event tags + per-weapon section) + `CHANGELOG`.

## ✅ Verification

- `composer ci` clean: format-check, lint, 1222 tests, build (55 files).
- Resolution smoke: each weapon's `:fire-sfx` → event → file resolves to an existing system sound (Pop / Blow / Morse / Purr all present).