### PR TITLE
feat(enemy): slow + telegraph caster fireballs so they're dodgeable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 - Soulsphere pickup (#68 part 1). Rare cyan sphere; pushes lives 2 over cap, decays back at 1 life / 5s.
 - Switches that toggle remote cells (#62). `F` on a switch flips linked target cells (wall <-> floor). L10 uses two.
 
+### Changed
+
+- Enemy fireballs (cacodemon / baron) fly slower and telegraph a touch longer (#94), so they read as a dodge-able threat you can strafe out of instead of a near-hitscan hit.
+
 ### Fixed
 
 - Weapon felt silent when a shot connected (esp. the shotgun): a hit swapped the gun report for the enemy reaction, so you only heard a quiet thud. Every trigger pull now plays the active weapon's own fire sound, hit or miss, with the kill cue layered on top. Each weapon gets a distinct report (pistol Pop, shotgun Blow, chaingun Morse, chainsaw Purr) via a data-driven `:fire-sfx` spec key.

--- a/docs/monsters.md
+++ b/docs/monsters.md
@@ -57,7 +57,7 @@ Each enemy carries a `:state` keyword + an optional `:lkp` (last-known player po
 
 ### Ranged casters (projectiles)
 
-Cacodemons (`:caco`) and barons (`:baron`) are casters: instead of meleeing on windup-release they launch a fireball. `enemy_ai/caster-spec` gives them a much longer `:range` (caco 7.0, baron 8.0) so they commit to an attack from across the room, plus a bolt `:speed`. `attack-spec-of` prefers `caster-spec` over the melee `attack-spec`, so the `:attacking` rhythm above drives them unchanged: freeze, telegraph the windup, release. On release `tick-attack` raises `:fire-now` on the enemy (melee types leave it `false`).
+Cacodemons (`:caco`) and barons (`:baron`) are casters: instead of meleeing on windup-release they launch a fireball. `enemy_ai/caster-spec` gives them a much longer `:range` (caco 7.0, baron 8.0) so they commit to an attack from across the room, plus a deliberately slow bolt `:speed` (caco 2.5, baron 3.0 world-units/sec) so the fireball is dodge-able rather than near-hitscan, and a slightly longer `:windup` than the melee profiles for a clear telegraph (issue #94). `attack-spec-of` prefers `caster-spec` over the melee `attack-spec`, so the `:attacking` rhythm above drives them unchanged: freeze, telegraph the windup, release. On release `tick-attack` raises `:fire-now` on the enemy (melee types leave it `false`).
 
 The projectile pipeline lives in `core/projectile.phel` and runs once per frame between `tick-enemies` and `damage-step` in `play/tick-world`:
 

--- a/src/core/enemy_ai.phel
+++ b/src/core/enemy_ai.phel
@@ -366,8 +366,13 @@
    world-units/sec. Impact costs one life/armor unit, same as a contact
    hit. A caster still melees on contact (the touch test in combat
    ignores range), so cornering one is still dangerous."
-  {:caco  {:range 7.0 :windup 0.5 :cooldown 1.6 :speed 4.5}
-   :baron {:range 8.0 :windup 0.7 :cooldown 2.0 :speed 5.5}})
+  ;; Bolt :speed kept low (world-units/sec) so a fireball reads as a
+  ;; dodge-able threat, not a near-hitscan — the player can strafe out
+  ;; of the line or duck behind geometry. Windup is a touch longer than
+  ;; the melee profiles so there's a clear telegraph before launch
+  ;; (issue #94).
+  {:caco  {:range 7.0 :windup 0.6 :cooldown 1.6 :speed 2.5}
+   :baron {:range 8.0 :windup 0.8 :cooldown 2.0 :speed 3.0}})
 
 (defn caster?
   "True when this enemy's `:type` fires projectiles rather than meleeing

--- a/tests/core/enemy_ai_test.phel
+++ b/tests/core/enemy_ai_test.phel
@@ -505,6 +505,15 @@
     (is (= 7.0 (:range s)))
     (is (= (get-in caster-spec [:caco :speed]) (:speed s)))))
 
+(deftest test-caster-bolt-speeds-are-dodgeable
+  ;; Pin the tuned-low bolt speeds (issue #94) so a refactor can't
+  ;; silently restore near-hitscan fireballs. Heavier baron bolt is a
+  ;; touch faster than the caco's.
+  (is (= 2.5 (get-in caster-spec [:caco :speed])))
+  (is (= 3.0 (get-in caster-spec [:baron :speed])))
+  (is (php/> (get-in caster-spec [:baron :speed])
+             (get-in caster-spec [:caco :speed]))))
+
 (deftest test-caster-in-attack-range-uses-long-range
   ;; Player 5 units east of a caco — out of melee range but inside the
   ;; caco's 7.0 caster range, so it still commits.


### PR DESCRIPTION
## 📚 Description

Closes #94. Cacodemon / baron fireballs travelled too fast to react to - effectively near-hitscan. This tunes them into a proper dodge-able threat.

## 🔖 Changes

- `enemy_ai/caster-spec`: lower bolt `:speed` (caco 4.5 → 2.5, baron 5.5 → 3.0 world-units/sec) and lengthen `:windup` a touch (caco 0.5 → 0.6, baron 0.7 → 0.8) for a clearer telegraph before launch. Baron's bolt stays a bit faster + hits from longer range than the caco's.
- Tests pin the new speeds so a refactor can't silently restore the fast bolts. 1222 → 1225.
- `docs/monsters.md` + `CHANGELOG`.

## ✅ Verification

- `composer ci` clean: format-check, lint, 1225 tests, build.
- Existing projectile tests (spawn direction, wall/ttl cull, player-hit) read `:speed` from the spec, so they stay green with the new values.

Closes #94