### PR TITLE
feat(combat): BFG splash weapon (slot 5, radius AoE)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 
 ### Added
 
+- BFG splash weapon (#58). Slot 5, found on L7. A heavy `:plasma` shot: the beam lands on the nearest enemy or wall, then a 3-cell-radius blast damages every enemy around the impact - a multi-kill room-clearer that also bypasses the fire-resistant caco / baron / archvile / mancubus. Single-action, slow cadence, expensive cells. Distinct green plasma report (Glass).
 - Secret reward passages. Every non-locked procgen level now hides up to 2 secret walls; revealing one (bump + `F`) drops a reward stash: an ammo box, an armor shard, and a rotating trophy powerup (soulsphere / berserk / invuln). Locked levels are skipped so a secret shortcut can't bypass a keycard door. Makes exploration pay off and turns the rare powerups into a reliable find.
 - Hit-stop on meaty kills. Killing a tough enemy (caco / baron, ~70ms) or the boss (~160ms) briefly freezes the gameplay step so the blow lands with weight. Trash mobs (imps / demons) kill clean with no freeze, so chaingun spray stays fast.
 - Ambient drone loop. A low, slow-pulsing background bed now runs under the whole gameplay session for dread. Synthesised at runtime (no shipped audio asset), looped by a crash-safe background process that self-terminates if the game dies, and gated by the N sound toggle.

--- a/docs/audio.md
+++ b/docs/audio.md
@@ -28,6 +28,7 @@ Combat and other modules raise events by name, not by file:
 (play-sfx! :shoot-shotgun)   ; shotgun fire
 (play-sfx! :shoot-chaingun)  ; chaingun fire
 (play-sfx! :shoot-chainsaw)  ; chainsaw rev
+(play-sfx! :shoot-bfg)       ; BFG plasma discharge
 (play-sfx! :kill)            ; killing blow (layered over the fire report)
 (play-sfx! :reload)          ; reload animation started
 (play-sfx! :click)           ; trigger pulled on empty mag (dry-fire deny)
@@ -36,7 +37,7 @@ Combat and other modules raise events by name, not by file:
 (play-sfx! :berserk)         ; rage sphere picked up
 ```
 
-`macos-sounds` and Linux equivalents map each tag to a file: `Pop` for pistol-fire + kill, `Blow` for shotgun, `Morse` for chaingun, `Purr` for chainsaw, `Sosumi` for player-hurt, `Basso` for empty-click deny, `Funk` for reload, `Tink` for door / pickup, `Bottle` for heartbeat, `Hero` for berserk.
+`macos-sounds` and Linux equivalents map each tag to a file: `Pop` for pistol-fire + kill, `Blow` for shotgun, `Morse` for chaingun, `Purr` for chainsaw, `Glass` for BFG, `Sosumi` for player-hurt, `Basso` for empty-click deny, `Funk` for reload, `Tink` for door / pickup, `Bottle` for heartbeat, `Hero` for berserk.
 
 ## Per-weapon fire report
 

--- a/docs/combat.md
+++ b/docs/combat.md
@@ -167,6 +167,16 @@ Slot-4 melee weapon. Spec lives in `weapons/weapons :chainsaw` and carries three
 
 Damage type is `:melee` so future enemy resistances can target the saw without affecting ranged weapons. The 1-per-tick damage stacks with the berserk multiplier for a 2-per-tick swing during the rage window.
 
+### BFG (splash weapon, issue #58)
+
+Slot-5 area weapon, found on L7. The spec carries `:splash-radius` + `:splash-damage`; `fire-shot` branches on `:splash-radius` and routes to `bfg-fire` instead of the single-target hitscan:
+
+1. `enemy/beam-impact` finds where the beam lands - the nearest alive enemy along the player's ray, else the wall (both capped at range). Pure projection scan, no mutation.
+2. `enemy/splash` damages every alive enemy within `:splash-radius` of that impact point, returning `[new-enemies killed-count]`. Survivors wake (`:aware`) + take a hit-flash; no pain roll (a room-clear shouldn't stagger-lock the survivors).
+3. `bfg-fire` bumps `:kills` by the body count, chains the streak, arms hit-stop (boss-length if a cyber died), and unlocks the boss door if the blast killed the cyberdemon. No per-enemy loot - the blast is its own reward.
+
+Damage type is `:plasma`, NOT `:fire`, so the BFG bypasses the fire-resistant caco / baron / archvile / mancubus - it's the intended answer to grouped late-game mobs. Single-action (one deliberate shot per pull), slow 1.2s cooldown, expensive cells (mag 1, reserve cap 20).
+
 ### Berserk pickup
 
 A berserk sphere (`:berserks` vector on the world, `Ω` glyph in the viewport + minimap) sits in 1-in-8 levels. Stepping on the cell drives:

--- a/docs/features.md
+++ b/docs/features.md
@@ -39,7 +39,7 @@ See [level-system.md](level-system.md), [map.md](map.md).
 - Projectile casters: cacodemons + barons fire dodgeable fireballs (long-range telegraphed windup, then an orange bolt aimed at your position). Bolts pass doorways, stop at walls, cost one armor/life on impact (i-frames gate a burst to one hit). Strafe or break line of fire to dodge. See `core/projectile.phel`.
 - Cyberdemon chase speed scaled to 0.55× for playability
 - Hitscan combat: distance-attenuated kill/wound sfx, blood splatter, muzzle flash, 5-stage death anim, 3-6s respawn cooldown
-- 4-slot loadout (1/2/3/4), DPS-balanced niches. Pistol on every run; rest must be found.
+- 5-slot loadout (1/2/3/4/5), DPS-balanced niches. Pistol on every run; rest must be found.
 
   | Slot | Weapon | Dmg | Cd | Mag | DPS | Tier |
   |---|---|---|---|---|---|---|
@@ -47,8 +47,11 @@ See [level-system.md](level-system.md), [map.md](map.md).
   | 2 | shotgun | 3 | 0.6s | 4 | 5 | L2 (single-action) |
   | 3 | chaingun | 1 | 0.05s | 30 | 20 | L3 (auto-fire) |
   | 4 | chainsaw | 1 (`:melee`) | 0.10s | ∞ | 10 | melee 1.5-cell range, halves movement while ticking |
+  | 5 | BFG | 10 + 6 splash | 1.2s | 1 | - | L7 rare; `:plasma` AoE (3-cell radius), bypasses fire-resist mobs |
 
-  Pistol + chaingun + chainsaw spray while space is held; shotgun needs a fresh pull per shell. Pistol is the only weapon that overheats / jams. Distinct silhouette + palette per slot. Per-weapon mag/reserve persists across switches. First-time pickup auto-switches. Drop/refill/raise reload anim; sprite recoils 2 rows per shot.
+  The BFG (slot 5, found on L7) fires a heavy `:plasma` shot: a beam lands on the nearest enemy or wall, then a 3-cell-radius blast damages every enemy around the impact - a multi-kill room-clearer that also bypasses the fire-resistant caco/baron/archvile/mancubus. Expensive cells, slow cadence.
+
+  Pistol + chaingun + chainsaw spray while space is held; shotgun + BFG need a fresh pull per shot. Pistol is the only weapon that overheats / jams. Distinct silhouette + palette per slot. Per-weapon mag/reserve persists across switches. First-time pickup auto-switches. Drop/refill/raise reload anim; sprite recoils 2 rows per shot.
 - Kill-loot ammo skips the pistol when other weapons are owned - biases toward the scarce shotgun + chaingun the player had to hunt for. Level-spawn boxes still refill the active weapon.
 - 5 lives, 1s i-frame, 4-way directional red hurt-side band (left / right edge bar OR top / bottom row depending on attacker bearing), knockback shove on contact damage.
 

--- a/docs/input.md
+++ b/docs/input.md
@@ -152,7 +152,8 @@ One-shot actions (toggles, modals, weapon switch, reload) need rising edges, not
    :select-weapon1 (and (:k1 now) (not (:k1 prev)))     ; pistol
    :select-weapon2 (and (:k2 now) (not (:k2 prev)))     ; shotgun
    :select-weapon3 (and (:k3 now) (not (:k3 prev)))     ; chaingun
-   :select-weapon4 (and (:k4 now) (not (:k4 prev)))})   ; chainsaw
+   :select-weapon4 (and (:k4 now) (not (:k4 prev)))      ; chainsaw
+   :select-weapon5 (and (:k5 now) (not (:k5 prev)))})   ; BFG
 ```
 
 `game-loop` carries `prev-keys` across iterations; `rising-edges` runs each frame. `tick-world` consumes the edges map. Pure data.

--- a/src/commands/play.phel
+++ b/src/commands/play.phel
@@ -490,6 +490,7 @@
                    (:select-weapon2 edges) (switch-weapon w1 (get weapon-order 1))
                    (:select-weapon3 edges) (switch-weapon w1 (get weapon-order 2))
                    (:select-weapon4 edges) (switch-weapon w1 (get weapon-order 3))
+                   (:select-weapon5 edges) (switch-weapon w1 (get weapon-order 4))
                    :else                   w1)
             ;; tick-stamina runs BEFORE apply-physics so that, on the
             ;; frame the player's pool empties, the `:sprint-blocked?`

--- a/src/core/combat.phel
+++ b/src/core/combat.phel
@@ -1,6 +1,6 @@
 (ns phel-doom.core.combat
   (:require phel-doom.core.engine   :refer [cast-ray])
-  (:require phel-doom.core.enemy    :refer [push-back-enemy shoot])
+  (:require phel-doom.core.enemy    :refer [push-back-enemy shoot beam-impact splash])
   (:require phel-doom.core.enemy-ai :refer [attacks? noise-wake])
   (:require phel-doom.core.physics  :refer [try-move])
   (:require phel-doom.core.state    :refer [max-lives])
@@ -666,22 +666,71 @@
                :ammo-reserve    (php/- reserve drawn)
                :reload-cooldown (:reload-duration sp))))))
 
-(defn fire-shot
-  "Resolve one trigger pull end-to-end. After the hitscan, run a
-   flood-fill sound-wake from the player's cell so dormant enemies
-   in the same room hear the shot and switch to :aware. Doors block
-   the BFS so the wake stays local — same per-sector noise rule
-   DOOM uses."
+(defn- bfg-fire
+  "Resolve a BFG shot (any weapon with a `:splash-radius`). The beam
+   lands at `beam-impact` (nearest enemy along the ray, else the wall);
+   `splash` then damages every enemy within `:splash-radius` of that
+   point — a multi-kill room-clearer. Bumps `:kills` by the body count,
+   chains the streak, unlocks the boss door if a cyber died in the
+   blast, arms hit-stop, and (like every shot) wakes the room by noise.
+   No per-enemy loot drops: the blast is its own reward (issue #58)."
   [world]
-  (let [[enemies' hit? hit-pos idx] (resolve-shot world)
-        p                           (:player world)
-        woken                       (noise-wake enemies' (:grid world) (:x p) (:y p))
-        killed?                     (and hit?
-                                         (false? (:alive (get woken idx))))]
+  (let [p            (:player world)
+        spec         (w-spec world)
+        radius       (:splash-radius spec)
+        base         (or (:splash-damage spec) 1)
+        dmg          (if (berserk? world) (php/* base berserk-damage-mul) base)
+        dtype        (:damage-type spec)
+        max-r        (or (:max-range spec) shot-max-range)
+        wall-d       (cast-wall-distance world)
+        [ix iy]      (beam-impact (:enemies world) (:x p) (:y p) (:angle p)
+                                  wall-d shot-hit-radius max-r)
+        [es' killed] (splash (:enemies world) ix iy radius dmg dtype)
+        woken        (noise-wake es' (:grid world) (:x p) (:y p))
+        hit-pos      {:x ix :y iy}
+        killed?      (php/> killed 0)
+        chain?       (pos? (or (:streak-secs world) 0.0))
+        boss-killed? (and (= (:door-lock world) :boss)
+                          (some (fn [e] (and (= (:type e) :cyber)
+                                             (false? (:alive e))))
+                                woken))
+        scored       (assoc world
+                            :enemies     woken
+                            :kills       (php/+ (or (:kills world) 0) killed)
+                            :streak      (if killed?
+                                           (php/+ (if chain? (or (:streak world) 0) 0) killed)
+                                           (or (:streak world) 0))
+                            :streak-secs (if killed? streak-window-seconds
+                                             (or (:streak-secs world) 0.0)))
+        unlocked     (if boss-killed?
+                       (assoc scored :held-keys (conj (or (:held-keys scored) #{}) :boss))
+                       scored)
+        juiced       (if killed?
+                       (assoc unlocked :hit-stop-secs
+                              (if boss-killed? hit-stop-boss-seconds hit-stop-tough-seconds))
+                       unlocked)]
     (play-shot-sfx world killed? hit-pos)
-    (apply-heat (if hit?
-                  (on-shot-hit world woken hit-pos idx)
-                  (on-shot-miss (assoc world :enemies woken))))))
+    (apply-heat (push-blood-fx (assoc juiced :fire-anim fire-anim-seconds) hit-pos))))
+
+(defn fire-shot
+  "Resolve one trigger pull end-to-end. Splash weapons (BFG) route to
+   `bfg-fire`; everything else is a single-target hitscan. After the
+   shot, run a flood-fill sound-wake from the player's cell so dormant
+   enemies in the same room hear it and switch to :aware. Doors block
+   the BFS so the wake stays local — same per-sector noise rule DOOM
+   uses."
+  [world]
+  (if (:splash-radius (w-spec world))
+    (bfg-fire world)
+    (let [[enemies' hit? hit-pos idx] (resolve-shot world)
+          p                           (:player world)
+          woken                       (noise-wake enemies' (:grid world) (:x p) (:y p))
+          killed?                     (and hit?
+                                           (false? (:alive (get woken idx))))]
+      (play-shot-sfx world killed? hit-pos)
+      (apply-heat (if hit?
+                    (on-shot-hit world woken hit-pos idx)
+                    (on-shot-miss (assoc world :enemies woken)))))))
 
 (defn- empty-trigger-pull
   "Trigger pulled while mag = 0 AND no cooldown / jam in the way. Arm

--- a/src/core/enemy.phel
+++ b/src/core/enemy.phel
@@ -190,6 +190,67 @@
                                   (apply-pain (get flashed best) roll))]
                [final true hit-pos best]))))))))
 
+(defn beam-impact
+  "Where a hitscan beam from (px, py) along `angle` lands: the nearest
+   alive enemy struck along the ray, else the wall at `wall-dist`
+   (both capped at `max-range`). Returns `[ix iy]` world point. The BFG
+   centres its `splash` on this impact. Pure projection scan — no
+   mutation (unlike `shoot`)."
+  [enemies ^float px ^float py ^float angle ^float wall-dist ^float hit-radius ^float max-range]
+  (let [cos-a (php/cos angle)
+        sin-a (php/sin angle)
+        cap   (php/min wall-dist max-range)
+        pd    (loop [i 0 best cap]
+                (if (php/>= i (count enemies))
+                  best
+                  (let [e (get enemies i)]
+                    (if (not (:alive e))
+                      (recur (php/+ i 1) best)
+                      (let [dx   (php/- (:x e) px)
+                            dy   (php/- (:y e) py)
+                            proj (php/+ (php/* dx cos-a) (php/* dy sin-a))]
+                        (if (and (php/> proj 0.0) (php/< proj best))
+                          (let [perp-x (php/- dx (php/* proj cos-a))
+                                perp-y (php/- dy (php/* proj sin-a))
+                                perp2  (php/+ (php/* perp-x perp-x) (php/* perp-y perp-y))]
+                            (if (php/<= perp2 (php/* hit-radius hit-radius))
+                              (recur (php/+ i 1) proj)
+                              (recur (php/+ i 1) best)))
+                          (recur (php/+ i 1) best)))))))]
+    [(php/+ px (php/* pd cos-a)) (php/+ py (php/* pd sin-a))]))
+
+(defn splash
+  "Area blast: damage every alive enemy within `radius` world units of
+   `(cx, cy)` by `damage` (0 if it resists `dmg-type`). Returns
+   `[new-enemies killed-count]`. Enemies reduced to 0 lives flip
+   `:alive false` + arm a respawn timer; survivors wake (`:aware`) and
+   take a hit-flash. No pain roll — a room-clearing blast shouldn't
+   stagger-lock the survivors. Pure given the inputs (BFG, issue #58)."
+  [enemies ^float cx ^float cy ^float radius ^int damage dmg-type]
+  (let [r2 (php/* radius radius)]
+    (loop [i 0 acc [] killed 0]
+      (if (php/>= i (count enemies))
+        [acc killed]
+        (let [e   (get enemies i)
+              dx  (php/- (:x e) cx)
+              dy  (php/- (:y e) cy)
+              in? (and (:alive e)
+                       (php/<= (php/+ (php/* dx dx) (php/* dy dy)) r2))]
+          (if (not in?)
+            (recur (php/+ i 1) (conj acc e) killed)
+            (let [eff   (if (resists? (:type e) dmg-type) 0 damage)
+                  lives (php/max 0 (php/- (or (:lives e) 1) eff))
+                  woke  (assoc e :state :aware :lives lives)]
+              (if (php/<= lives 0)
+                (recur (php/+ i 1)
+                       (conj acc (assoc woke
+                                        :alive false
+                                        :respawn-after (respawn-delay-for e)))
+                       (php/+ killed 1))
+                (recur (php/+ i 1)
+                       (conj acc (assoc woke :hit-flash-secs hit-flash-seconds))
+                       killed)))))))))
+
 (defn push-back-enemy
   "Shove the enemy at `idx` along `(cos-a, sin-a)` by `dist` world
    units; on wall collision try a half then a quarter step before

--- a/src/core/level.phel
+++ b/src/core/level.phel
@@ -341,16 +341,17 @@
               (recur (php/+ y 1)))))))))
 
 (defn- maybe-spawn-weapon-pickups
-  "Per-level weapon drops. L2 always seeds a shotgun, L3 always a
-   chaingun. Both skipped if the player already owns the weapon so a
-   re-played level doesn't spam duplicate pickups. Returns a vector
-   of `{:x :y :weapon kw}` items."
+  "Per-level weapon drops. L2 always seeds a shotgun, L3 a chaingun,
+   L7 the rare BFG (issue #58). Each skipped if the player already owns
+   the weapon so a re-played level doesn't spam duplicate pickups.
+   Returns a vector of `{:x :y :weapon kw}` items."
   [grid level-num owned]
   (let [owned'     (or owned #{:pistol})
         candidates
         (cond
           (php/=== level-num 2) (if (contains? owned' :shotgun)  [] [:shotgun])
           (php/=== level-num 3) (if (contains? owned' :chaingun) [] [:chaingun])
+          (php/=== level-num 7) (if (contains? owned' :bfg)      [] [:bfg])
           :else                 [])]
     (apply vector
            (map (fn [kw]

--- a/src/core/weapons.phel
+++ b/src/core/weapons.phel
@@ -129,13 +129,43 @@
                                 :slide-dim "\e[1;38;5;242m"
                                 :frame     "\e[1;38;5;238m"
                                 :grip-hi   "\e[1;38;5;40m"
-                                :grip-lo   "\e[1;38;5;22m"}}})
+                                :grip-lo   "\e[1;38;5;22m"}}
+   :bfg      {:name            "BFG"
+              :mag-size        1
+              :reserve-start   5
+              :reserve-cap     20
+              :ammo-per-box    5
+              :fire-cooldown   1.2
+              :reload-duration 2.5
+              ;; Heavy direct hit PLUS a radius blast. `:splash-radius`
+              ;; / `:splash-damage` flag the weapon as an AoE shot — the
+              ;; combat path branches on `:splash-radius` to run the
+              ;; blast instead of a single-target hitscan (issue #58).
+              :damage          10
+              :splash-radius   3.0
+              :splash-damage   6
+              ;; :plasma, NOT :ballistic/:fire — caco/baron/archvile/
+              ;; mancubus resist :fire, so a plasma BFG bypasses those
+              ;; resistances and is the answer to grouped late-game mobs.
+              :damage-type     :plasma
+              ;; Single-action: one deliberate, expensive shot. The slow
+              ;; 1.2s cooldown + the charge sfx read as a wind-up.
+              :auto-fire?      false
+              :fire-sfx        :shoot-bfg
+              ;; Plasma green: bright emerald core, darker body.
+              :palette         {:muzzle    "\e[1;38;5;46m"
+                                :slide     "\e[1;38;5;34m"
+                                :slide-dim "\e[1;38;5;28m"
+                                :frame     "\e[1;38;5;22m"
+                                :grip-hi   "\e[1;38;5;82m"
+                                :grip-lo   "\e[1;38;5;40m"}}})
 
 (def weapon-order
-  "Slot order keyed by 1/2/3/4. Chainsaw lives at slot 4 so picking it
-   up doesn't yank the player off pistol/shotgun/chaingun mid-firefight
-   the way the give-weapon auto-switch does for ranged."
-  [:pistol :shotgun :chaingun :chainsaw])
+  "Slot order keyed by 1/2/3/4/5. Chainsaw at slot 4 so picking it up
+   doesn't yank the player off pistol/shotgun/chaingun mid-firefight
+   the way the give-weapon auto-switch does for ranged. BFG at slot 5
+   (issue #58): a rare, expensive AoE answer to grouped enemies."
+  [:pistol :shotgun :chaingun :chainsaw :bfg])
 
 (defn current-weapon
   "Active weapon keyword for `world`. Defaults to :pistol so fresh test

--- a/src/glue/controls.phel
+++ b/src/glue/controls.phel
@@ -357,7 +357,8 @@
    :k1 (key-pressed? keys "1" 49)
    :k2 (key-pressed? keys "2" 50)
    :k3 (key-pressed? keys "3" 51)
-   :k4 (key-pressed? keys "4" 52)})
+   :k4 (key-pressed? keys "4" 52)
+   :k5 (key-pressed? keys "5" 53)})
 
 (defn rising-edges
   "Build the edges map tick consumes — truthy only for keys that just
@@ -388,4 +389,5 @@
    :select-weapon1 (and (:k1 now) (not (:k1 prev)))
    :select-weapon2 (and (:k2 now) (not (:k2 prev)))
    :select-weapon3 (and (:k3 now) (not (:k3 prev)))
-   :select-weapon4 (and (:k4 now) (not (:k4 prev)))})
+   :select-weapon4 (and (:k4 now) (not (:k4 prev)))
+   :select-weapon5 (and (:k5 now) (not (:k5 prev)))})

--- a/src/io/render.phel
+++ b/src/io/render.phel
@@ -292,6 +292,13 @@
 (def chaingun-pickup-glyph  "\e[48;5;238;38;5;46;1m≣")
 (def chaingun-pickup-glyph-bright "\e[48;5;244;38;5;46;1m≣")
 
+;; BFG pickup: emerald plasma core on a dark-green crate so it reads as
+;; a rare power weapon from across the room (issue #58).
+(def bfg-pickup-shade  "\e[48;5;22m ")
+(def bfg-pickup-bright "\e[48;5;28m ")
+(def bfg-pickup-glyph  "\e[48;5;22;38;5;46;1m✸")
+(def bfg-pickup-glyph-bright "\e[48;5;28;38;5;82;1m✸")
+
 (def keycard-blue-shade  "\e[48;5;21m ")
 (def keycard-blue-bright "\e[48;5;33m ")
 (def keycard-blue-glyph  "\e[48;5;21;38;5;231;1m⚿")
@@ -2510,6 +2517,8 @@
         shotgun-pickup-glyph-now           (if weapon-pickup-bright? shotgun-pickup-glyph-bright shotgun-pickup-glyph)
         chaingun-pickup-shade-now          (if weapon-pickup-bright? chaingun-pickup-bright chaingun-pickup-shade)
         chaingun-pickup-glyph-now          (if weapon-pickup-bright? chaingun-pickup-glyph-bright chaingun-pickup-glyph)
+        bfg-pickup-shade-now               (if weapon-pickup-bright? bfg-pickup-bright bfg-pickup-shade)
+        bfg-pickup-glyph-now               (if weapon-pickup-bright? bfg-pickup-glyph-bright bfg-pickup-glyph)
         ;; Atmospheric haze pulls walls toward black as lives drop, so
         ;; the world reads as 'consumed by darkness' the closer the
         ;; player is to dying. Sky / floor untouched; doors keep their
@@ -2761,9 +2770,15 @@
                                                         (or (:weapon-pickups world) [])))
                                          (:player world) dists edists vw vh
                                          chaingun-pickup-shade-now chaingun-pickup-glyph-now)
+          bp-wb     (paint-pickups-into  bp-wc
+                                         (apply vector
+                                                (filter (fn [w] (php/=== (:weapon w) :bfg))
+                                                        (or (:weapon-pickups world) [])))
+                                         (:player world) dists edists vw vh
+                                         bfg-pickup-shade-now bfg-pickup-glyph-now)
           ;; Fireballs paint last into the overlay so an incoming bolt
           ;; sits on top of every pickup glow it crosses.
-          bp-proj   (paint-projectiles-into bp-wc (or (:projectiles world) [])
+          bp-proj   (paint-projectiles-into bp-wb (or (:projectiles world) [])
                                             (:player world) dists edists vw vh)
           parts     (buf-mk)]
       (dotimes [row vh]

--- a/src/io/sound.phel
+++ b/src/io/sound.phel
@@ -35,6 +35,9 @@
    :shoot-shotgun  "/System/Library/Sounds/Blow.aiff"
    :shoot-chaingun "/System/Library/Sounds/Morse.aiff"
    :shoot-chainsaw "/System/Library/Sounds/Purr.aiff"
+   ;; BFG: bright glassy plasma discharge, distinct from the ballistic
+   ;; weapons.
+   :shoot-bfg      "/System/Library/Sounds/Glass.aiff"
    :kill      "/System/Library/Sounds/Pop.aiff"
    :hit       "/System/Library/Sounds/Sosumi.aiff"
    :wound     "/System/Library/Sounds/Submarine.aiff"

--- a/tests/commands/play-test.phel
+++ b/tests/commands/play-test.phel
@@ -111,6 +111,28 @@
     ;; reward sits at the revealed cell centre (2.5, 1.5).
     (is (= 2.5 (:x (first (:soulspheres w')))))))
 
+(deftest test-tick-world-select-weapon5-switches-to-bfg
+  ;; Player owns the BFG and presses 5 -> active weapon becomes :bfg.
+  (let [w0 (assoc (new-world open-grid (new-player 5.0 5.0 0.0))
+                  :owned-weapons #{:pistol :bfg})
+        w' (tick-world w0 "" 0.016 (assoc no-edges :select-weapon5 true))]
+    (is (= :bfg (:weapon w')))))
+
+(deftest test-tick-world-bfg-blast-multi-kills
+  ;; Player at (2,5) facing east with the BFG; three 1-HP imps clustered
+  ;; near (5,5). One blast wipes the cluster and bumps :kills by 3.
+  (let [w0 (assoc (with-enemies (new-world open-grid (new-player 2.0 5.0 0.0))
+                                [(new-enemy 5.0 5.0 1 :imp)
+                                 (new-enemy 5.0 6.0 1 :imp)
+                                 (new-enemy 6.0 5.0 1 :imp)])
+                  :weapon :bfg
+                  :owned-weapons #{:pistol :bfg}
+                  :mag 1 :ammo-reserve 5)
+        w' (tick-world w0 "" 0.016 (assoc no-edges :fire true))]
+    (is (= 3 (:kills w')) "blast counts all three kills")
+    (is (every? (fn [e] (false? (:alive e))) (:enemies w')))
+    (is (= 0 (:mag w')) "one cell consumed")))
+
 (deftest test-tick-world-toggle-map-edge-flips-show-map
   (let [w' (tick-world (new-world open-grid (new-player 5.0 5.0 0.0))
                        "" 0.016 (assoc no-edges :toggle-map true))]

--- a/tests/core/enemy-test.phel
+++ b/tests/core/enemy-test.phel
@@ -1,6 +1,6 @@
 (ns phel-doom-tests.core.enemy-test
   (:require phel.test :refer [deftest is])
-  (:require phel-doom.core.enemy :refer [default-wander-fraction new-enemy promote-wanderers push-back-enemy spawn-enemies spawn-enemies-mixed shoot advance tick-scare rear-attacker?]))
+  (:require phel-doom.core.enemy :refer [default-wander-fraction new-enemy promote-wanderers push-back-enemy spawn-enemies spawn-enemies-mixed shoot splash beam-impact advance tick-scare rear-attacker?]))
 
 (def open-grid
   "Bordered 10x10 open arena, no interior walls."
@@ -599,3 +599,55 @@
         es' (push-back-enemy es open-grid 0 1.0 0.0 2.0)]
     (is (or (= 8.5 (:x (first es')))      ; quarter-step success
             (= 8.0 (:x (first es')))))))  ; or no-clearance fallback
+
+;; ---------------------------------------------------------------------
+;; splash + beam-impact: BFG area blast (issue #58).
+;; ---------------------------------------------------------------------
+
+(deftest test-splash-damages-all-in-radius
+  ;; Three 1-HP imps clustered around (5,5); blast radius 3 wipes all.
+  (let [es           [(new-enemy 5.0 5.0 1 :imp)
+                      (new-enemy 6.0 5.0 1 :imp)
+                      (new-enemy 5.0 7.0 1 :imp)]
+        [out killed] (splash es 5.0 5.0 3.0 6 :plasma)]
+    (is (= 3 killed) "all three within radius die")
+    (is (every? (fn [e] (false? (:alive e))) out))))
+
+(deftest test-splash-spares-enemies-outside-radius
+  (let [es [(new-enemy 5.0 5.0 1 :imp)
+            (new-enemy 12.0 12.0 1 :imp)]      ;; far away
+        [out killed] (splash es 5.0 5.0 3.0 6 :plasma)]
+    (is (= 1 killed))
+    (is (= false (:alive (get out 0))))
+    (is (= true  (:alive (get out 1))) "far imp untouched")))
+
+(deftest test-splash-wounds-without-killing
+  ;; A 5-HP enemy hit by 2 damage survives, wakes, keeps lower lives.
+  (let [es           [(new-enemy 5.0 5.0 5 :baron)]
+        [out killed] (splash es 5.0 5.0 3.0 2 :plasma)]
+    (is (= 0 killed))
+    (is (= 3 (:lives (get out 0))))
+    (is (= :aware (:state (get out 0))))))
+
+(deftest test-splash-respects-resistance
+  ;; Caco resists :fire — a :fire blast deals 0; a :plasma blast kills.
+  (let [es [(new-enemy 5.0 5.0 3 :caco)]]
+    (is (= 0 (second (splash es 5.0 5.0 3.0 6 :fire))) "fire resisted -> no kill")
+    (is (= 1 (second (splash es 5.0 5.0 3.0 6 :plasma))) "plasma lands")))
+
+(deftest test-splash-ignores-dead-enemies
+  (let [es         [(assoc (new-enemy 5.0 5.0 1 :imp) :alive false)]
+        [_ killed] (splash es 5.0 5.0 3.0 6 :plasma)]
+    (is (= 0 killed))))
+
+(deftest test-beam-impact-stops-at-enemy
+  ;; Player at (1,5) facing east, enemy at (4,5): impact near the enemy.
+  (let [[ix iy] (beam-impact [(new-enemy 4.0 5.0 1 :imp)]
+                             1.0 5.0 0.0 20.0 0.5 12.0)]
+    (is (< (php/abs (php/- ix 4.0)) 0.001) "impact x at the enemy")
+    (is (< (php/abs (php/- iy 5.0)) 0.001))))
+
+(deftest test-beam-impact-falls-back-to-wall
+  ;; No enemy along the ray -> impact at the wall distance (capped).
+  (let [[ix _] (beam-impact [] 1.0 5.0 0.0 6.0 0.5 12.0)]
+    (is (< (php/abs (php/- ix 7.0)) 0.001) "impact at player + wall-dist")))

--- a/tests/core/weapons-test.phel
+++ b/tests/core/weapons-test.phel
@@ -129,11 +129,12 @@
     (is (= true (:auto-fire? s)))
     (is (= 1 (:damage s)))))
 
-(deftest test-weapon-order-includes-chainsaw-at-slot-4
-  ;; Player presses 4 to swap to the chainsaw. Slot ordering must
-  ;; stay stable so muscle memory survives.
-  (is (= [:pistol :shotgun :chaingun :chainsaw] weapon-order))
-  (is (= :chainsaw (get weapon-order 3))))
+(deftest test-weapon-order-slots
+  ;; Player presses 1-5 to swap weapons. Slot ordering must stay stable
+  ;; so muscle memory survives. BFG is slot 5 (issue #58).
+  (is (= [:pistol :shotgun :chaingun :chainsaw :bfg] weapon-order))
+  (is (= :chainsaw (get weapon-order 3)))
+  (is (= :bfg      (get weapon-order 4))))
 
 (deftest test-effective-reserve-cap-scales-with-backpack-level
   ;; Pistol's reserve-cap is 50 from the catalog. Backpack stack scales
@@ -175,3 +176,16 @@
   (is (= :shoot-shotgun  (:fire-sfx (get weapons :shotgun))))
   (is (= :shoot-chaingun (:fire-sfx (get weapons :chaingun))))
   (is (= :shoot-chainsaw (:fire-sfx (get weapons :chainsaw)))))
+
+;; ---------------------------------------------------------------------
+;; BFG (issue #58): slot-5 splash weapon.
+;; ---------------------------------------------------------------------
+
+(deftest test-bfg-spec-is-an-aoe-weapon
+  (let [b (get weapons :bfg)]
+    (is (= "BFG" (:name b)))
+    (is (some? (:splash-radius b)) "carries a splash radius (combat branches on it)")
+    (is (> (:splash-damage b) 0))
+    (is (= :plasma (:damage-type b)) "plasma bypasses fire-resist mobs")
+    (is (= :shoot-bfg (:fire-sfx b)))
+    (is (= false (:auto-fire? b)) "single-action heavy shot")))

--- a/tests/io/sound-test.phel
+++ b/tests/io/sound-test.phel
@@ -32,3 +32,6 @@
   (is (= nil (play-sfx! :shoot-shotgun)))
   (is (= nil (play-sfx! :shoot-chaingun)))
   (is (= nil (play-sfx! :shoot-chainsaw))))
+
+(deftest test-bfg-fire-event-is-silent-under-test-env
+  (is (= nil (play-sfx! :shoot-bfg))))


### PR DESCRIPTION
## 📚 Description

Closes #58. Adds the **BFG**: a slot-5 plasma weapon that clears grouped enemies and answers the fire-resistant late-game mobs. Found on L7.

## 🔖 Changes

- **`weapons`**: `:bfg` spec (slot 5) - `:splash-radius` + `:splash-damage`, `:damage-type :plasma` (bypasses caco / baron / archvile / mancubus fire-resist), single-action, expensive cells (mag 1, reserve cap 20).
- **`enemy`**: `beam-impact` (pure - nearest enemy along the ray, else the wall) + `splash` (AoE damage in radius, returns `[enemies killed-count]`; survivors wake, no pain-lock).
- **`combat`**: `fire-shot` branches on `:splash-radius` → `bfg-fire`: multi-kill `:kills` bump, streak chain, boss-door unlock if a cyber dies in the blast, hit-stop. Plays the `:shoot-bfg` report.
- **`controls` / `play`**: `5` key → `select-weapon5` → slot 5.
- **`level`**: rare pickup on L7.
- **`render`**: BFG pickup glyph (emerald plasma) + paint-chain branch.
- **`sound`**: `:shoot-bfg` → Glass.aiff.
- **Tests**: `splash` (in/out radius, wound, resist, dead-skip), `beam-impact` (enemy vs wall), BFG spec, `select-weapon5`, multi-kill integration. 1225 → 1251.
- **Docs**: features, combat, audio, input + CHANGELOG.

## ✅ Verification

- `composer ci` clean: format-check, lint, 1251 tests, build (55 files).
- Smoke: L7 spawns exactly 1 BFG pickup; `give-weapon :bfg` switches active weapon; a frame renders with the BFG active; `tick-world` BFG fire wipes a 3-imp cluster and bumps kills by 3.

Closes #58