### PR TITLE
feat(savegame): mid-level quick-save / load (F5 / F9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 
 ### Added
 
+- Mid-level save / load (#63). `F5` quick-saves the whole `:world` to `$HOME/.phel-doom/saves/slot-1.json`, `F9` loads it back, with a `SAVED` / `LOADED` HUD cue. A tagged JSON codec round-trips Phel keywords / sets / vectors / maps; `:pgrid` is rebuilt and fog re-reveals on load. Versioned: a save from an incompatible build is refused. Slots 1-9 exist in `io/savegame`.
 - BFG splash weapon (#58). Slot 5, found on L7. A heavy `:plasma` shot: the beam lands on the nearest enemy or wall, then a 3-cell-radius blast damages every enemy around the impact - a multi-kill room-clearer that also bypasses the fire-resistant caco / baron / archvile / mancubus. Single-action, slow cadence, expensive cells. Distinct green plasma report (Glass).
 - Secret reward passages. Every non-locked procgen level now hides up to 2 secret walls; revealing one (bump + `F`) drops a reward stash: an ammo box, an armor shard, and a rotating trophy powerup (soulsphere / berserk / invuln). Locked levels are skipped so a secret shortcut can't bypass a keycard door. Makes exploration pay off and turns the rare powerups into a reliable find.
 - Hit-stop on meaty kills. Killing a tough enemy (caco / baron, ~70ms) or the boss (~160ms) briefly freezes the gameplay step so the blow lands with weight. Trash mobs (imps / demons) kill clean with no freeze, so chaingun spray stays fast.

--- a/docs/features.md
+++ b/docs/features.md
@@ -110,8 +110,14 @@ See [audio.md](audio.md).
 - High-scores in `$HOME/.phel-doom-scores.json`: per-level best
   kills + best time + last-run timestamp
 - Pure `merge-run` fn (testable) wrapping the IO writer
+- Mid-level save / load (#63): **F5** quick-saves the whole `:world` to
+  `$HOME/.phel-doom/saves/slot-1.json`, **F9** loads it back. A tagged
+  JSON codec round-trips Phel keywords / sets / vectors / maps; `:pgrid`
+  is rebuilt and fog-of-war re-reveals on load. Versioned - a save from
+  an incompatible build is refused with a `NO SAVE` cue. Slots 1-9 exist
+  in `io/savegame`; the in-game keys use slot 1.
 
-See [scores.md](scores.md).
+See [scores.md](scores.md), [savegame.md](savegame.md).
 
 ## CLI
 

--- a/docs/input.md
+++ b/docs/input.md
@@ -153,8 +153,12 @@ One-shot actions (toggles, modals, weapon switch, reload) need rising edges, not
    :select-weapon2 (and (:k2 now) (not (:k2 prev)))     ; shotgun
    :select-weapon3 (and (:k3 now) (not (:k3 prev)))     ; chaingun
    :select-weapon4 (and (:k4 now) (not (:k4 prev)))      ; chainsaw
-   :select-weapon5 (and (:k5 now) (not (:k5 prev)))})   ; BFG
+   :select-weapon5 (and (:k5 now) (not (:k5 prev)))      ; BFG
+   :save           (and (:f5 now) (not (:f5 prev)))      ; F5 quick-save
+   :load           (and (:f9 now) (not (:f9 prev)))})   ; F9 quick-load
 ```
+
+F5 (`\e[15~`) / F9 (`\e[20~`) drive quick-save / load. The edges are handled in `game-loop` (file IO), not `tick-world`, so the pure tick stays effect-free. See [savegame.md](savegame.md).
 
 `game-loop` carries `prev-keys` across iterations; `rising-edges` runs each frame. `tick-world` consumes the edges map. Pure data.
 

--- a/docs/savegame.md
+++ b/docs/savegame.md
@@ -1,0 +1,54 @@
+# Save / load
+
+`src/io/savegame.phel`. Mid-level quick-save (issue #63). The immutable
+`:world` map is pure data, so it round-trips through JSON.
+
+## Why a tagged codec
+
+Phel keywords / sets / vectors / maps have no native JSON form, and
+`php/serialize` mangles Phel's internal objects (it does not round-trip).
+So `encode` / `decode` are a small tagged codec:
+
+| Phel value | Encoded |
+|---|---|
+| keyword | `["$k", "name"]` |
+| set | `["$s", [items...]]` |
+| map | `["$m", {kw-name: val, ...}]` (all world map keys are keywords) |
+| vector | `[items...]` |
+| number / bool / string / nil | itself |
+
+`encode` / `decode` are pure (no IO) and unit-tested for round-trip
+equality, including empty collections.
+
+## What is dropped
+
+- `:pgrid` - the derived PHP-array mirror of `:grid`. Rebuilt from the
+  grid on load via `state/rebuild-pgrid`.
+- `:visited` - the fog-of-war PHP array. Reset empty on load; the fog
+  re-reveals as the player walks.
+
+Everything else in `new-world` is serialised as-is.
+
+## Format + versioning
+
+`world->savestring` wraps the encoded world in `{"version": N, "world":
+...}` and `json_encode`s it. `savestring->world` refuses a save whose
+`version` doesn't match `save-version` (or malformed JSON), returning
+`nil` so the caller surfaces a friendly miss instead of loading a broken
+world. Bump `save-version` whenever the world shape changes
+incompatibly.
+
+## Files + slots
+
+`save-game! world slot` writes `$HOME/.phel-doom/saves/slot-<n>.json`
+(creating the dir on first use); `load-game slot` reads it back or
+returns `nil`. Slots 1-9 are valid (`valid-slot?`).
+
+## In-game keys
+
+`commands/play` wires **F5** -> save, **F9** -> load to slot 1
+(`quick-save-slot`). The file IO runs in `game-loop` (never the pure
+`tick-world`): F5 saves the post-tick world; F9 swaps the whole world
+for the loaded one. Both stamp a brief `:save-flash-secs` + `:save-flash-msg`
+HUD cue (`SAVED` / `LOADED` / `NO SAVE`) that `render/paint-save-flash`
+paints centred near the top and `tick-world` decays.

--- a/src/commands/play.phel
+++ b/src/commands/play.phel
@@ -17,6 +17,7 @@
   (:require phel-doom.core.weapons  :refer [effective-reserve-cap give-weapon switch-weapon weapon-spec weapon-order weapons])
   (:require phel-doom.io.sound    :refer [play-sfx! mute-for!])
   (:require phel-doom.io.ambient  :refer [start-ambient! stop-ambient! sync-ambient!])
+  (:require phel-doom.io.savegame :refer [save-game! load-game])
   (:require phel-doom.core.level    :refer [build-world num-levels place-secret-reward])
   (:require phel-doom.core.perf     :refer [target-frame-us])
   (:require phel-doom.io.scores   :refer [update-scores!])
@@ -540,8 +541,12 @@
             w10  (tick-scare    w9 dt)
             w11  (tick-blood-drops w10 dt)
             w12  (tick-door-face w11 dt)
-            w13  (decay-soul-overcap w12 dt)]
-        (advance-game-time w13 dt)))))
+            w13  (decay-soul-overcap w12 dt)
+            ;; Decay the F5/F9 save/load HUD cue (set in game-loop after
+            ;; the tick).
+            w13b (update w13 :save-flash-secs
+                         (fn [s] (php/max 0.0 (php/- (or s 0.0) dt))))]
+        (advance-game-time w13b dt)))))
 
 ;; =====================================================================
 ;; § Per-frame IO + stats
@@ -614,7 +619,9 @@
    ;; visual when a per-enemy `:type` field is missing. Mixed-monster
    ;; rooms still stamp `:type` per enemy at spawn so the renderer
    ;; can branch.
-   :enemy                (or (:enemy world) :imp)})
+   :enemy                (or (:enemy world) :imp)
+   :save-flash-secs      (or (:save-flash-secs world) 0.0)
+   :save-flash-msg       (:save-flash-msg world)})
 
 (defn- ms-since
   "Whole-millisecond delta between two microtime samples. Args tagged
@@ -713,6 +720,32 @@
         remaining  (php/- budget elapsed-us)]
     (php/usleep (php/max min-yield-us remaining))))
 
+(def quick-save-slot
+  "Slot F5/F9 quick-save + quick-load use. Slots 1-9 exist in
+   io/savegame; the in-game keys drive slot 1 for now."
+  1)
+
+(def save-flash-seconds
+  "How long the SAVED / LOADED HUD cue holds after F5 / F9."
+  1.2)
+
+(defn- handle-save-load
+  "F5 saves the current world to the quick-save slot; F9 loads it back
+   (swapping the whole world). Both stamp a brief `:save-flash-*` HUD
+   cue. File IO lives here in the loop, never in the pure tick."
+  [world edges]
+  (cond
+    (:save edges)
+    (let [ok (save-game! world quick-save-slot)]
+      (assoc world :save-flash-secs save-flash-seconds
+             :save-flash-msg (if ok "SAVED" "SAVE FAILED")))
+    (:load edges)
+    (let [loaded (load-game quick-save-slot)]
+      (if loaded
+        (assoc loaded :save-flash-secs save-flash-seconds :save-flash-msg "LOADED")
+        (assoc world :save-flash-secs save-flash-seconds :save-flash-msg "NO SAVE")))
+    :else         world))
+
 (defn- game-loop [world0]
   (let [t-start (php/microtime true)]
     (loop [world     world0
@@ -730,8 +763,12 @@
               now      (php/microtime true)
               ms       (ms-since t-last now)
               now-keys (key-states keys)
-              world'   (tick-world world keys (php// ms 1000.0)
-                                   (rising-edges now-keys prev-keys))]
+              edges    (rising-edges now-keys prev-keys)
+              ticked   (tick-world world keys (php// ms 1000.0) edges)
+              ;; F5 / F9 quick-save / load run here (file IO), outside
+              ;; the pure tick. Load swaps the whole world; both stamp a
+              ;; brief HUD flash so the player sees it took.
+              world'   (handle-save-load ticked edges)]
           (when (and (:heartbeat-tick? world') (:sound-on world'))
             (play-sfx! :heartbeat 0.35))
           (when (and (:silence-tick? world') (:sound-on world'))

--- a/src/glue/controls.phel
+++ b/src/glue/controls.phel
@@ -295,6 +295,14 @@
   (or (str/contains? keys "\eOR")
       (str/contains? keys "\e[13~")))
 
+(defn- f5-pressed? [keys]
+  ;; F5 = `\e[15~` on xterm / iTerm2 / Terminal.app / Linux console.
+  (str/contains? keys "\e[15~"))
+
+(defn- f9-pressed? [keys]
+  ;; F9 = `\e[20~`.
+  (str/contains? keys "\e[20~"))
+
 (defn- esc-pressed?
   "True when ESC was pressed this frame. Two paths:
 
@@ -351,6 +359,8 @@
    :e  (key-pressed? keys "e" 101)
    :f  (key-pressed? keys "f" 102)
    :f3 (f3-pressed? keys)
+   :f5 (f5-pressed? keys)
+   :f9 (f9-pressed? keys)
    :r  (key-pressed? keys "r" 114)
    :h  (key-pressed? keys "h" 104)
    :esc (esc-pressed? keys)
@@ -390,4 +400,8 @@
    :select-weapon2 (and (:k2 now) (not (:k2 prev)))
    :select-weapon3 (and (:k3 now) (not (:k3 prev)))
    :select-weapon4 (and (:k4 now) (not (:k4 prev)))
-   :select-weapon5 (and (:k5 now) (not (:k5 prev)))})
+   :select-weapon5 (and (:k5 now) (not (:k5 prev)))
+   ;; F5 quick-save / F9 quick-load (issue #63). Handled in game-loop
+   ;; (file IO), not tick-world, so the pure tick stays effect-free.
+   :save           (and (:f5 now) (not (:f5 prev)))
+   :load           (and (:f9 now) (not (:f9 prev)))})

--- a/src/io/render.phel
+++ b/src/io/render.phel
@@ -1537,6 +1537,21 @@
             (buf-push parts (str "\e[" row ";" col "H" label)))))))
   parts)
 
+(defn- paint-save-flash
+  "Brief centred SAVED / LOADED cue near the top after F5 / F9 quick
+   save / load (issue #63). Green chip so it's distinct from the amber
+   ammo nag."
+  [parts stats vw vh]
+  (let [secs (or (get stats :save-flash-secs) 0.0)
+        msg  (get stats :save-flash-msg)]
+    (when (and (php/> secs 0.0) msg (php/>= vh 5))
+      (let [text  (str " " msg " ")
+            label (str "\e[48;5;22;38;5;231;1m" text "\e[0m")
+            col   (php/max 1 (php/- (php/intdiv vw 2)
+                                    (php/intdiv (php/strlen text) 2)))]
+        (buf-push parts (str "\e[3;" col "H" label)))))
+  parts)
+
 (def stamina-bar-cells
   "Width of the STA bar in cells. 10 is wide enough to read the pool
    level at a glance without crowding the HUD strip on narrow
@@ -2891,7 +2906,8 @@
             p18         (paint-empty-click        p17 stats vw vh)
             p19         (paint-reload-reminder    p18 stats vw vh)
             p19b        (paint-locked-bump        p19 stats vw vh)
-            p20         (paint-enemy-hp-flashes   p19b world vw vh)]
+            p19c        (paint-enemy-hp-flashes   p19b world vw vh)
+            p20         (paint-save-flash         p19c stats vw vh)]
         (when (get stats :paused)
           (buf-push p20 (pause-menu-string vw vh (get stats :sound-on))))
         ;; Help overlay paints last so it sits on top of the pause

--- a/src/io/savegame.phel
+++ b/src/io/savegame.phel
@@ -1,0 +1,126 @@
+(ns phel-doom.io.savegame
+  (:require phel-doom.core.state :refer [rebuild-pgrid]))
+
+;; ---------------------------------------------------------------------
+;; Mid-level save / load (issue #63). The immutable `:world` map is pure
+;; data, so it round-trips through JSON — but Phel keywords / sets /
+;; vectors / maps have no native JSON form, and `php/serialize` mangles
+;; Phel's internal objects. So `encode` / `decode` are a small tagged
+;; codec:
+;;   keyword  -> ["$k" "name"]
+;;   set      -> ["$s" [items...]]
+;;   map      -> ["$m" {kw-name: val ...}]   (all world map keys are kws)
+;;   vector   -> [items...]
+;;   scalar   -> itself
+;; `:pgrid` (a derived PHP-array mirror of `:grid`) and `:visited` (the
+;; fog-of-war PHP array) are dropped on save: pgrid is rebuilt from the
+;; grid on load, and the fog simply re-reveals as the player walks.
+;; encode / decode are pure (no IO) so the round-trip is unit-tested.
+;; ---------------------------------------------------------------------
+
+(def save-version
+  "Bumped whenever the world shape changes incompatibly. `load-game`
+   refuses a save whose version doesn't match so a stale file surfaces
+   as a friendly miss instead of a corrupt world."
+  1)
+
+(def max-slots
+  "Save slots 1..max-slots."
+  9)
+
+(declare encode)
+
+(defn- encode-map [m]
+  ;; All world map keys are keywords -> store by name, decode re-kws.
+  (php/array "$m"
+             (reduce (fn [o k]
+                       (php/aset o (name k) (encode (get m k)))
+                       o)
+                     (php/array)
+                     (keys m))))
+
+(defn encode
+  "Pure: Phel value -> JSON-safe PHP structure (tagged for keywords /
+   sets / maps so `decode` can reconstruct the exact types)."
+  [x]
+  (cond
+    (keyword? x) (php/array "$k" (name x))
+    (set? x)     (php/array "$s" (to-php-array (map encode x)))
+    (map? x)     (encode-map x)
+    (vector? x)  (to-php-array (map encode x))
+    :else        x))
+
+(defn decode
+  "Pure inverse of `encode`: tagged PHP structure -> Phel value."
+  [x]
+  (if (php/is_array x)
+    (let [tag (php/aget x 0)]
+      (cond
+        (php/=== tag "$k") (keyword (php/aget x 1))
+        (php/=== tag "$s") (set (map decode (php/aget x 1)))
+        (php/=== tag "$m") (let [o (php/aget x 1)]
+                             (reduce (fn [m k] (assoc m (keyword k) (decode (php/aget o k))))
+                                     {}
+                                     (php/array_keys o)))
+        :else              (apply vector (map decode x))))
+    x))
+
+(defn world->savestring
+  "Pure: serialize `world` to a versioned JSON string. Drops `:pgrid` +
+   `:visited` (rebuilt / reset on load)."
+  [world]
+  (let [clean (dissoc world :pgrid :visited)
+        o     (php/array)]
+    (php/aset o "version" save-version)
+    (php/aset o "world"   (encode clean))
+    (php/json_encode o)))
+
+(defn savestring->world
+  "Pure: parse a save string back into a world (pgrid rebuilt, fog
+   reset). Returns nil on malformed JSON or a version mismatch so the
+   caller can surface a friendly miss."
+  [s]
+  (let [data (php/json_decode s true)]
+    (if (and (php/is_array data)
+             (php/=== save-version (php/aget data "version")))
+      (-> (decode (php/aget data "world"))
+          (assoc :visited (php/array))
+          (rebuild-pgrid))
+      nil)))
+
+(defn- save-dir []
+  (str (or (php/getenv "HOME") ".") "/.phel-doom/saves"))
+
+(defn- slot-path [^int slot]
+  (str (save-dir) "/slot-" slot ".json"))
+
+(defn- valid-slot? [slot]
+  (and (php/is_int slot) (php/>= slot 1) (php/<= slot max-slots)))
+
+(defn save-game!
+  "Write `world` to save `slot` (1..max-slots). Creates the save dir on
+   first use. Returns true on success, false on a bad slot or write
+   failure."
+  [world slot]
+  (if (not (valid-slot? slot))
+    false
+    (do
+      (when (not (php/is_dir (save-dir)))
+        (php/mkdir (save-dir) 0755 true))
+      (not (php/=== false
+                    (php/file_put_contents (slot-path slot)
+                                           (world->savestring world)))))))
+
+(defn load-game
+  "Read save `slot` back into a world, or nil when the slot is empty,
+   unreadable, malformed, or a version mismatch."
+  [slot]
+  (if (not (valid-slot? slot))
+    nil
+    (let [p (slot-path slot)]
+      (if (not (php/file_exists p))
+        nil
+        (let [c (php/file_get_contents p)]
+          (if (or (php/=== c false) (php/=== c ""))
+            nil
+            (savestring->world c)))))))

--- a/tests/io/savegame-test.phel
+++ b/tests/io/savegame-test.phel
@@ -1,0 +1,68 @@
+(ns phel-doom-tests.io.savegame-test
+  (:require phel.test :refer [deftest is])
+  (:require phel-doom.core.state :refer [new-world new-player with-enemies])
+  (:require phel-doom.io.savegame :refer [encode decode world->savestring savestring->world save-version]))
+
+(def grid [[1 1 1 1] [1 0 0 1] [1 0 0 1] [1 1 1 1]])
+
+;; ---------------------------------------------------------------------
+;; Tagged codec: pure Phel<->JSON-safe round-trip (issue #63).
+;; ---------------------------------------------------------------------
+
+(deftest test-codec-round-trips-keyword
+  (is (= :bfg (decode (encode :bfg)))))
+
+(deftest test-codec-round-trips-set-of-keywords
+  (is (= #{:blue :boss} (decode (encode #{:blue :boss})))))
+
+(deftest test-codec-round-trips-vector
+  (is (= [1 0 1] (decode (encode [1 0 1])))))
+
+(deftest test-codec-round-trips-nested-structure
+  (let [v {:weapon  :bfg
+           :grid    [[1 0] [0 1]]
+           :enemies [{:type :imp :alive true :lives 1}]
+           :keys    #{:red}}]
+    (is (= v (decode (encode v))))))
+
+(deftest test-codec-round-trips-empty-collections
+  (is (= {} (decode (encode {}))))
+  (is (= [] (decode (encode []))))
+  (is (= #{} (decode (encode #{})))))
+
+;; ---------------------------------------------------------------------
+;; Full world string round-trip: key state survives, pgrid rebuilt,
+;; fog reset.
+;; ---------------------------------------------------------------------
+
+(deftest test-world-savestring-round-trip
+  (let [w    (-> (new-world grid (new-player 1.5 2.5 0.0))
+                 (with-enemies [{:x 2.5 :y 2.5 :type :imp :alive true
+                                 :lives 1 :max-lives 1}])
+                 (assoc :weapon :bfg
+                        :owned-weapons #{:pistol :bfg}
+                        :kills 7 :level 3
+                        :held-keys #{:blue}))
+        back (savestring->world (world->savestring w))]
+    (is (= :bfg (:weapon back)) "active weapon preserved")
+    (is (= 7 (:kills back)))
+    (is (= 3 (:level back)))
+    (is (= :imp (:type (first (:enemies back)))) "enemy type keyword preserved")
+    (is (= #{:blue} (:held-keys back)) "keycard set preserved")
+    (is (= #{:pistol :bfg} (:owned-weapons back)))
+    (is (= (:grid w) (:grid back)) "grid preserved")
+    (is (= 1.5 (:x (:player back))))
+    (is (some? (:pgrid back)) "pgrid rebuilt on load")))
+
+(deftest test-load-rejects-version-mismatch
+  (let [o (php/array)]
+    (php/aset o "version" 999)
+    (php/aset o "world" (php/array))
+    (is (= nil (savestring->world (php/json_encode o))) "future version refused")))
+
+(deftest test-load-rejects-malformed
+  (is (= nil (savestring->world "not json at all")))
+  (is (= nil (savestring->world ""))))
+
+(deftest test-save-version-is-pinned
+  (is (= 1 save-version)))


### PR DESCRIPTION
## 📚 Description

Closes #63. `F5` quick-saves the whole `:world` to `$HOME/.phel-doom/saves/slot-1.json`; `F9` loads it back. Mid-level save is table stakes for a long session, and the immutable world map makes the dump clean.

## 🔖 Changes

- **`io/savegame`** (new): a small **tagged JSON codec** (`encode` / `decode`, pure) - `php/serialize` mangles Phel's internal objects, so keywords / sets / vectors / maps are tagged (`["$k" ...]` / `["$s" ...]` / `["$m" ...]`) and round-trip exactly. Drops `:pgrid` (rebuilt from `:grid` on load) + `:visited` (fog re-reveals). Versioned wrapper refuses an incompatible save. `save-game!` / `load-game` over slots 1-9.
- **`controls`**: F5 (`\e[15~`) → `:save`, F9 (`\e[20~`) → `:load` edges.
- **`play` / `game-loop`**: `handle-save-load` runs the file IO **outside** the pure `tick-world`; load swaps the whole world. A `:save-flash` HUD cue is stamped and decayed in the tick.
- **`render`**: `paint-save-flash` centred `SAVED` / `LOADED` / `NO SAVE` cue.
- **Tests**: codec round-trip (incl. empty collections), full-world string round-trip (weapon / kills / level / enemy-type / keycard-set / grid preserved, pgrid rebuilt), version-mismatch + malformed rejected. 1251 → 1271.
- **Docs**: new `savegame.md` + features / input + CHANGELOG.

## ✅ Verification

- `composer ci` clean: format-check, lint, 1271 tests, build (56 files).
- File round-trip smoke (temp HOME): `save-game!` returns true, `load-game` restores kills=9 / level=3, an empty slot returns nil.

Closes #63