### PR TITLE
feat(demo): deterministic record / replay + seeded RNG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 
 ### Added
 
+- Demo recording + replay (#64). `--record=FILE` captures a run (seed + per-frame input); `--demo=FILE` replays it deterministically. Built on a new seeded RNG (`core/rng`) that every gameplay draw flows through, replacing the unseedable `random_int` / `mt_rand`.
 - Mid-level save / load (#63). `F5` quick-saves the whole `:world` to `$HOME/.phel-doom/saves/slot-1.json`, `F9` loads it back, with a `SAVED` / `LOADED` HUD cue. A tagged JSON codec round-trips Phel keywords / sets / vectors / maps; `:pgrid` is rebuilt and fog re-reveals on load. Versioned: a save from an incompatible build is refused. Slots 1-9 exist in `io/savegame`.
 - BFG splash weapon (#58). Slot 5, found on L7. A heavy `:plasma` shot: the beam lands on the nearest enemy or wall, then a 3-cell-radius blast damages every enemy around the impact - a multi-kill room-clearer that also bypasses the fire-resistant caco / baron / archvile / mancubus. Single-action, slow cadence, expensive cells. Distinct green plasma report (Glass).
 - Secret reward passages. Every non-locked procgen level now hides up to 2 secret walls; revealing one (bump + `F`) drops a reward stash: an ammo box, an armor shard, and a rotating trophy powerup (soulsphere / berserk / invuln). Locked levels are skipped so a secret shortcut can't bypass a keycard door. Makes exploration pay off and turns the rare powerups into a reliable find.
@@ -29,6 +30,7 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 
 ### Fixed
 
+- `R` (restart same map) now actually reproduces the level geometry + enemy spawns. It re-seeded `mt_rand`, but map gen used `random_int` (unseedable), so the "same map" never matched. Both now flow through the seeded `core/rng`.
 - Weapon felt silent when a shot connected (esp. the shotgun): a hit swapped the gun report for the enemy reaction, so you only heard a quiet thud. Every trigger pull now plays the active weapon's own fire sound, hit or miss, with the kill cue layered on top. Each weapon gets a distinct report (pistol Pop, shotgun Blow, chaingun Morse, chainsaw Purr) via a data-driven `:fire-sfx` spec key.
 - Enemy face / eyes glyph drew over closer sprites (#91). The face overlay was gated only by walls, not by nearer enemies, so a far enemy's eyes floated on top of one in front. Now gated by the same front-most-enemy check as the grounding shadow.
 - Grid mutations (#61 secrets, doors, switches) left the raycaster's `:pgrid` stale - player walked through visually solid walls. New `state/rebuild-pgrid` resyncs after every mutation.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -19,6 +19,7 @@ src/
 │   ├── level.phel                   ; 10-level catalog + build-world factory
 │   ├── weapons.phel                 ; per-weapon stat catalog + switch/reload
 │   ├── perf.phel                    ; big-screen perf-mode predicates
+│   ├── rng.phel                     ; seeded PRNG (deterministic runs / demos)
 │   └── difficulty.phel              ; easy/normal/hard/nightmare multipliers
 ├── glue/                            ; pure wiring, needs both halves
 │   └── controls.phel                ; key bytes -> :moves counters + rising edges
@@ -28,6 +29,8 @@ src/
     ├── sound.phel                   ; afplay/paplay/aplay shell-out (one-shot sfx)
     ├── ambient.phel                 ; synthesised drone loop (crash-safe bg process)
     ├── scores.phel                  ; JSON in $HOME
+    ├── savegame.phel                ; mid-level save/load (tagged JSON world dump)
+    ├── demo.phel                    ; record / replay input stream + seed
     └── wad.phel                     ; .wad file format parser
 ```
 

--- a/docs/demo.md
+++ b/docs/demo.md
@@ -1,0 +1,66 @@
+# Demo record / replay
+
+`src/io/demo.phel` + `src/core/rng.phel` (issue #64). Deterministic
+record + replay of a run for bug repros, highlight reels, and making the
+game-loop determinism property testable.
+
+## Determinism foundation: seeded RNG
+
+The game used to draw randomness from `php/random_int` (via `rand-int`)
+and `php/mt_rand`. `random_int` is a CSPRNG and cannot be seeded, so runs
+were unreproducible. `core/rng` replaces both with a single seeded
+generator (Park-Miller minimal-standard LCG, `x' = 16807x mod 2^31-1`,
+held in a module atom):
+
+```phel
+(rng/seed! n)     ; seed (folds any int into 1..m-1)
+(rng/int! n)      ; 0..n inclusive  (rand-int replacement)
+(rng/float!)      ; [0, 1)          (mt_rand/getrandmax replacement)
+(rng/next-raw!)   ; raw advance
+(rng/fresh-seed)  ; a nondeterministic seed for a new run (does NOT seed)
+```
+
+Every gameplay draw (level gen, enemy spawn / respawn / pain / wander,
+loot rolls, blood drops, player spawn angle) now flows through it. So
+**seed + input stream fully determine the run** - re-seed and feed the
+same inputs and the world matches frame for frame (pinned by
+`tests/commands/play-test test-replay-reproduces-world` and
+`level-test test-build-world-deterministic-under-seed`).
+
+This also fixes `R` (restart same map): it always re-seeded `mt_rand`,
+which the `random_int`-based map gen ignored, so the geometry was never
+actually reproduced. Now it is.
+
+## Demo format
+
+A demo is the run's seed plus the per-frame `[key-bytes, dt-ms]` stream:
+
+```json
+{"version": 1, "seed": 4242, "frames": [["w", 16], ["wa", 17], ["", 16]]}
+```
+
+`frames->json` / `json->demo` are pure (unit-tested round-trip); a
+version mismatch or malformed file parses to `nil`.
+
+## Record / replay loop
+
+`commands/play` flags:
+
+- `--record=FILE` - `demo/start-record!` with a fresh seed; each frame
+  `demo/resolve-frame!` appends the live `[keys, ms]` and passes it
+  through; on exit `demo/save-recording!` writes the file.
+- `--demo=FILE` - `demo/read-demo` loads `{seed, frames}`;
+  `demo/start-replay!` seeds the run with the recorded seed and feeds
+  the recorded frames back through the same `game-loop`, skipping the
+  start menu. When the stream is exhausted `resolve-frame!` returns
+  `{:end? true}` and the loop quits.
+
+The seam is `demo/resolve-frame!` in `game-loop`: `:off` passes the live
+frame through, `:record` taps it, `:replay` substitutes the recorded
+one. File IO lives in the loop, never in the pure `tick-world`.
+
+## Scope
+
+Replay reproduces a run from the same start state (seed + level chain +
+inputs). The start menu and end-screen interactions aren't part of the
+recorded stream; a demo captures the playable frames.

--- a/docs/features.md
+++ b/docs/features.md
@@ -126,6 +126,15 @@ See [scores.md](scores.md), [savegame.md](savegame.md).
 - `--armory` (`-a`) - own every weapon + infinite reserves (per-frame refill). Pairs with `--god` for mechanic testing.
 - `--full-map` (`-f`) - reveal whole minimap (skip fog-of-war). Level-editor + screenshots.
 - `--level=N` (`-l`) - start at level N (clamped). Pairs with `--god` to drop into boss rooms.
+- `--record=FILE` - record the run (seed + per-frame input) to a demo file.
+- `--demo=FILE` - replay a recorded demo deterministically (skips the start menu). See [demo.md](demo.md).
+
+## Determinism + demos
+
+All gameplay randomness flows through one seeded generator (`core/rng`, Park-Miller LCG) instead of the unseedable `random_int` / `mt_rand`. Seed once and the whole run is reproducible from seed + input stream. This:
+
+- powers `--record` / `--demo` deterministic replay (#64),
+- fixes `R` (restart same map) actually reproducing the level geometry + enemy spawns (it previously re-seeded `mt_rand`, which `random_int`-based map gen ignored).
 
 ## Misc
 

--- a/src/commands/play.phel
+++ b/src/commands/play.phel
@@ -18,6 +18,8 @@
   (:require phel-doom.io.sound    :refer [play-sfx! mute-for!])
   (:require phel-doom.io.ambient  :refer [start-ambient! stop-ambient! sync-ambient!])
   (:require phel-doom.io.savegame :refer [save-game! load-game])
+  (:require phel-doom.io.demo     :as demo)
+  (:require phel-doom.core.rng    :as rng)
   (:require phel-doom.core.level    :refer [build-world num-levels place-secret-reward])
   (:require phel-doom.core.perf     :refer [target-frame-us])
   (:require phel-doom.io.scores   :refer [update-scores!])
@@ -759,16 +761,23 @@
         (let [render-start (php/microtime true)]
           (draw-frame world fps frame-ms rows cols)
           (adaptive-sleep! render-start cols rows))
-        (let [keys     (drain-keys)
-              now      (php/microtime true)
-              ms       (ms-since t-last now)
-              now-keys (key-states keys)
-              edges    (rising-edges now-keys prev-keys)
-              ticked   (tick-world world keys (php// ms 1000.0) edges)
+        (let [live-keys (drain-keys)
+              now       (php/microtime true)
+              live-ms   (ms-since t-last now)
+              ;; Input source: live terminal, or — under demo record /
+              ;; replay — the recorder taps the stream / the player
+              ;; feeds recorded frames (issue #64). A replay that runs
+              ;; out of frames sets `:end?` and the cond below quits.
+              frame     (demo/resolve-frame! live-keys live-ms)
+              keys      (or (:keys frame) "")
+              ms        (or (:ms frame) live-ms)
+              now-keys  (key-states keys)
+              edges     (rising-edges now-keys prev-keys)
+              ticked    (tick-world world keys (php// ms 1000.0) edges)
               ;; F5 / F9 quick-save / load run here (file IO), outside
               ;; the pure tick. Load swaps the whole world; both stamp a
               ;; brief HUD flash so the player sees it took.
-              world'   (handle-save-load ticked edges)]
+              world'    (handle-save-load ticked edges)]
           (when (and (:heartbeat-tick? world') (:sound-on world'))
             (play-sfx! :heartbeat 0.35))
           (when (and (:silence-tick? world') (:sound-on world'))
@@ -779,6 +788,7 @@
           (when (php/!== (:sound-on world) (:sound-on world'))
             (sync-ambient! (:sound-on world')))
           (cond
+            (:end? frame)              :quit
             (str/contains? keys "q")   :quit
             (php/<= (:lives world') 0) (result-game-over world' t-start now)
             (on-door? world')          (door-result      world' t-start now)
@@ -873,12 +883,12 @@
    (from --level / -l) sets where the run begins — 1..num-levels,
    clamped. Death + retry reset to L1 (the start-level only seeds
    the initial loop entry)."
-  [diff god? armory? full-map? start-level]
+  [diff god? armory? full-map? start-level init-seed]
   (loop [level       (php/max 1 (php/min num-levels (or start-level 1)))
          lives       max-lives
          carry-kills 0
          carry-time  0
-         seed        (php/mt_rand)
+         seed        init-seed
          ;; Backpack stack carried across levels (0..max-backpacks).
          ;; Was a boolean before #68 part 3 - swapped to an int so
          ;; each pickup adds one base's reserve cap.
@@ -892,7 +902,7 @@
          wstate      nil
          show-map?   false
          sound-on?   true]
-    (php/mt_srand seed)
+    (rng/seed! seed)
     (let [w0     (build-world level lives bp-level diff owned)
           ;; God mode + carried user toggles + weapon ammo are
           ;; overlaid on the freshly-built world so build-world
@@ -924,7 +934,7 @@
         ;; counts as a breather, the pool refills to max via new-world.
         ;; Lives, weapons, mag/reserve and player toggles do carry.
         (let [[k t] (carry-on carry-kills carry-time result)]
-          (recur (:level result) (:lives result) k t (php/mt_rand)
+          (recur (:level result) (:lives result) k t (rng/next-raw!)
                  (backpack-level result)
                  (or (:owned-weapons result) #{:pistol})
                  (or (:weapon result) :pistol)
@@ -936,7 +946,7 @@
         (let [[k t]           (carry-on carry-kills carry-time result)
               [kind new-seed] (handle-end victory-loop k t result seed true)]
           (cond
-            (= kind :fresh) (recur 1 max-lives 0 0 (php/mt_rand) 0 #{:pistol} nil nil true true)
+            (= kind :fresh) (recur 1 max-lives 0 0 (rng/fresh-seed) 0 #{:pistol} nil nil true true)
             (= kind :same)  (recur 1 max-lives 0 0 new-seed 0 #{:pistol} nil nil true true)
             :else           nil))
 
@@ -946,7 +956,7 @@
               died-on         (or (:level result) 1)]
           (cond
             ;; r: try the level you died on again with a fresh map.
-            (= kind :fresh) (recur died-on max-lives 0 0 (php/mt_rand) 0 #{:pistol} nil nil true true)
+            (= kind :fresh) (recur died-on max-lives 0 0 (rng/fresh-seed) 0 #{:pistol} nil nil true true)
             ;; R: replay the exact level you died on (same seed + same
             ;; level number reproduces identical geometry + enemies).
             (= kind :same)  (recur died-on max-lives 0 0 new-seed 0 #{:pistol} nil nil true true)
@@ -978,17 +988,32 @@
 
 (defn- run-play [ctx]
   (init-input!)
-  (let [diff      (cli/opt ctx "difficulty")
-        god?      (cli/opt ctx "god")
-        armory?   (cli/opt ctx "armory")
-        full-map? (cli/opt ctx "full-map")
-        lv-raw    (cli/opt ctx "level")
+  (let [diff        (cli/opt ctx "difficulty")
+        god?        (cli/opt ctx "god")
+        armory?     (cli/opt ctx "armory")
+        full-map?   (cli/opt ctx "full-map")
+        lv-raw      (cli/opt ctx "level")
         ;; CLI gives strings; coerce to int. nil / empty → nil → L1.
-        lv        (cond
-                    (nil? lv-raw) nil
-                    (= lv-raw "") nil
-                    :else         (php/intval lv-raw))]
-    (if (= (show-start-menu!) :quit)
+        lv          (cond
+                      (nil? lv-raw) nil
+                      (= lv-raw "") nil
+                      :else         (php/intval lv-raw))
+        ;; Demo (issue #64): --demo replays a recorded run (forces its
+        ;; seed + input stream, skips the menu); --record captures the
+        ;; run's seed + per-frame input to a file on exit.
+        record-path (cli/opt ctx "record")
+        demo-path   (cli/opt ctx "demo")
+        record?     (and record-path (not (= record-path "")))
+        replay      (when (and demo-path (not (= demo-path "")))
+                      (demo/read-demo demo-path))
+        ;; Replay reproduces the recorded seed; record / normal start
+        ;; from a fresh seed (recorded so the run can be replayed).
+        init-seed   (if replay (:seed replay) (rng/fresh-seed))]
+    (cond
+      replay  (demo/start-replay! (:seed replay) (:frames replay))
+      record? (demo/start-record! init-seed)
+      :else   (demo/reset-off!))
+    (if (and (nil? replay) (= (show-start-menu!) :quit))
       (do (restore!)
           (clear-screen)
           0)
@@ -997,8 +1022,10 @@
           ;; levels + end screens). N-toggle starts/stops it mid-run;
           ;; teardown always stops it so no loop process is orphaned.
           (start-ambient!)
-          (run-levels diff god? armory? full-map? lv)
+          (run-levels diff god? armory? full-map? lv init-seed)
           (stop-ambient!)
+          (when record? (demo/save-recording! record-path))
+          (demo/reset-off!)
           (restore!)
           (clear-screen)
           (cli/success ctx "Thanks for playing.")
@@ -1032,5 +1059,13 @@
            :short   "l"
            :mode    :optional
            :doc     "Start at level N (1..num-levels). Clamped. Pairs naturally with --god to drop straight into a boss room for testing."
+           :default ""}
+          {:name    "record"
+           :mode    :optional
+           :doc     "Record the run (seed + per-frame input) to a demo file for deterministic replay."
+           :default ""}
+          {:name    "demo"
+           :mode    :optional
+           :doc     "Replay a demo file recorded with --record (skips the start menu)."
            :default ""}]
    :run  run-play})

--- a/src/core/combat.phel
+++ b/src/core/combat.phel
@@ -1,4 +1,5 @@
 (ns phel-doom.core.combat
+  (:require phel-doom.core.rng :as rng)
   (:require phel-doom.core.engine   :refer [cast-ray])
   (:require phel-doom.core.enemy    :refer [push-back-enemy shoot beam-impact splash])
   (:require phel-doom.core.enemy-ai :refer [attacks? noise-wake])
@@ -494,11 +495,11 @@
    weapon an ammo drop refills. Tests pin both via roll-loot-kind /
    pick-loot-weapon directly."
   [world hit-pos]
-  (let [roll-kind (php// (php/mt_rand) (php/mt_getrandmax))
+  (let [roll-kind (rng/float!)
         kind      (roll-loot-kind world roll-kind)]
     (cond
       (= kind :ammo)
-      (let [roll-wpn (php// (php/mt_rand) (php/mt_getrandmax))
+      (let [roll-wpn (rng/float!)
             weapon   (pick-loot-weapon world roll-wpn)]
         (push-ammo-loot world hit-pos weapon))
       (= kind :armor) (push-pickup world :armors hit-pos)

--- a/src/core/enemy.phel
+++ b/src/core/enemy.phel
@@ -1,4 +1,5 @@
 (ns phel-doom.core.enemy
+  (:require phel-doom.core.rng :as rng)
   (:require phel-doom.core.map      :refer [random-spawn wall?])
   (:require phel-doom.core.enemies  :refer [resists?])
   (:require phel-doom.core.enemy-ai :refer [apply-pain maybe-start-attack moves? observe start-wander target-pos tick-attack tick-pain tick-wander]))
@@ -46,7 +47,7 @@
   (let [nm (:nightmare? enemy)
         lo (if nm nightmare-respawn-delay-min respawn-delay-min)
         hi (if nm nightmare-respawn-delay-max respawn-delay-max)]
-    (php/+ lo (php/* (php// (php/mt_rand) (php/mt_getrandmax))
+    (php/+ lo (php/* (rng/float!)
                      (php/- hi lo)))))
 (def respawn-min-dist
   "Minimum spawn distance from the player a revived enemy must claim,
@@ -185,7 +186,7 @@
             ;; :state :pain + the stagger timer, overriding the
             ;; :aware wake above for the brief flinch window.
              (let [flashed (assoc-in wounded [best :hit-flash-secs] hit-flash-seconds)
-                   roll    (php// (php/mt_rand) (php/mt_getrandmax))
+                   roll    (rng/float!)
                    final   (assoc flashed best
                                   (apply-pain (get flashed best) roll))]
                [final true hit-pos best]))))))))
@@ -610,7 +611,7 @@
   (apply vector
          (map (fn [e]
                 (if (and (php/=== :dormant (or (:state e) :dormant))
-                         (php/< (php// (php/mt_rand) (php/mt_getrandmax))
+                         (php/< (rng/float!)
                                 fraction))
                   (start-wander e)
                   e))

--- a/src/core/enemy_ai.phel
+++ b/src/core/enemy_ai.phel
@@ -1,4 +1,5 @@
 (ns phel-doom.core.enemy-ai
+  (:require phel-doom.core.rng :as rng)
   (:require phel-doom.core.engine :refer [cast-ray max-depth])
   (:require phel-doom.core.map    :refer [cell cell-floor]))
 
@@ -297,7 +298,7 @@
 
 (defn- random-wander-angle []
   (php/* 2.0 php/M_PI
-         (php// (php/mt_rand) (php/mt_getrandmax))))
+         (rng/float!)))
 
 (defn start-wander
   "Promote an idle enemy from `:dormant` to `:wander` with a freshly

--- a/src/core/level.phel
+++ b/src/core/level.phel
@@ -1,4 +1,5 @@
 (ns phel-doom.core.level
+  (:require phel-doom.core.rng :as rng)
   (:require phel-doom.core.state      :refer [max-backpacks max-lives new-player new-world with-enemies])
   (:require phel-doom.core.map        :refer [cell-door cell-door-blue cell-door-red count-secrets parse-layout random-grid random-spawn seed-doors seed-secrets])
   (:require phel-doom.core.enemy      :refer [default-wander-fraction promote-wanderers spawn-enemies spawn-enemies-mixed])
@@ -170,7 +171,7 @@
   "Roughly one in two levels carries an armor pickup. Picked up via
    `pickup-armors` in play.phel; absorbs the next contact-damage hit."
   [grid]
-  (if (zero? (mod (rand-int 2) 2))
+  (if (zero? (mod (rng/int! 2) 2))
     (let [[ax ay] (random-spawn grid)]
       [{:x ax :y ay}])
     []))
@@ -179,7 +180,7 @@
   "Rare berserk sphere — ~1 in 8 levels (was 1 in 4, tuned down
    after v0.3 playtesting found powerups stacking too often)."
   [grid]
-  (if (php/=== 0 (mod (rand-int 8) 8))
+  (if (php/=== 0 (mod (rng/int! 8) 8))
     (let [[bx by] (random-spawn grid)]
       [{:x bx :y by}])
     []))
@@ -187,7 +188,7 @@
 (defn- maybe-spawn-invuln
   "Very rare — ~1 in 12 levels."
   [grid]
-  (if (php/=== 0 (mod (rand-int 12) 12))
+  (if (php/=== 0 (mod (rng/int! 12) 12))
     (let [[ix iy] (random-spawn grid)]
       [{:x ix :y iy}])
     []))
@@ -198,7 +199,7 @@
    back to `max-lives` over time, so the player gets a real defensive
    buffer for a stretch of fight."
   [grid]
-  (if (php/=== 0 (mod (rand-int 10) 10))
+  (if (php/=== 0 (mod (rng/int! 10) 10))
     (let [[sx sy] (random-spawn grid)]
       [{:x sx :y sy}])
     []))
@@ -274,7 +275,7 @@
               :else             0)]
     (if (or (php/>= lvl max-backpacks)
             (php/< level-num 2)
-            (php/!== 0 (mod (rand-int 5) 5)))
+            (php/!== 0 (mod (rng/int! 5) 5)))
       []
       (let [[bx by] (random-spawn grid)]
         [{:x bx :y by}]))))
@@ -475,7 +476,7 @@
                        (:grid built))
          [px py]     spawn
          specs       (normalise-enemies cfg)
-         world       (new-world grid (new-player px py (php/* (rand-int 360)
+         world       (new-world grid (new-player px py (php/* (rng/int! 360)
                                                               (php// php/M_PI 180.0))))
          spawned     (spawn-enemies-mixed grid specs
                                           enemy-min-spawn-dist px py)

--- a/src/core/map.phel
+++ b/src/core/map.phel
@@ -1,4 +1,5 @@
-(ns phel-doom.core.map)
+(ns phel-doom.core.map
+  (:require phel-doom.core.rng :as rng))
 
 ;; ---------------------------------------------------------------------
 ;; Map / grid layer.
@@ -342,8 +343,8 @@
         (>= placed n)     g
         (>= attempts 400) g
         :else
-        (let [x (+ 2 (rand-int (- w 4)))
-              y (+ 2 (rand-int (- h 4)))]
+        (let [x (+ 2 (rng/int! (- w 4)))
+              y (+ 2 (rng/int! (- h 4)))]
           (if (and (= cell-wall (cell g x y))
                    (has-floor-neighbour? g x y))
             (recur (assoc-in g [y x] cell-door) (+ placed 1) (+ attempts 1))
@@ -386,10 +387,10 @@
       (if (>= i n-blocks)
         grid
         (recur (place-block grid w h
-                            (+ 2 (rand-int (- w 5)))
-                            (+ 2 (rand-int (- h 5)))
-                            (+ 1 (rand-int 2))
-                            (+ 1 (rand-int 2)))
+                            (+ 2 (rng/int! (- w 5)))
+                            (+ 2 (rng/int! (- h 5)))
+                            (+ 1 (rng/int! 2))
+                            (+ 1 (rng/int! 2)))
                (+ i 1))))))
 
 (defn random-spawn
@@ -400,8 +401,8 @@
   (let [h (count grid)
         w (count (first grid))]
     (loop []
-      (let [x (+ 1 (rand-int (- w 2)))
-            y (+ 1 (rand-int (- h 2)))]
+      (let [x (+ 1 (rng/int! (- w 2)))
+            y (+ 1 (rng/int! (- h 2)))]
         (if (= cell-floor (get (get grid y) x))
           [(+ 0.5 x) (+ 0.5 y)]
           (recur))))))

--- a/src/core/physics.phel
+++ b/src/core/physics.phel
@@ -1,4 +1,5 @@
 (ns phel-doom.core.physics
+  (:require phel-doom.core.rng :as rng)
   (:require phel-doom.core.state   :refer [max-stamina move-player turn-player])
   (:require phel-doom.core.map     :refer [missing-key-for passable? wall?])
   (:require phel-doom.core.weapons :refer [weapon-spec]))
@@ -259,10 +260,10 @@
   "With probability spawn-rate*dt, append a fresh drop at row 1 with a
    uniformly-random normalised column in [0, 1). Otherwise unchanged."
   [drops ^float dt]
-  (if (php/< (php// (php/mt_rand) (php/mt_getrandmax))
+  (if (php/< (rng/float!)
              (php/* blood-drop-spawn-rate dt))
     (conj drops
-          {:col (php// (php/mt_rand) (php/mt_getrandmax))
+          {:col (rng/float!)
            :row 1.0
            :ttl blood-drop-ttl})
     drops))
@@ -302,7 +303,7 @@
     :else            [20.0 30.0]))
 
 (defn- random-in [^float lo ^float hi]
-  (php/+ lo (php/* (php/- hi lo) (php// (php/mt_rand) (php/mt_getrandmax)))))
+  (php/+ lo (php/* (php/- hi lo) (rng/float!))))
 
 (defn tick-door-face
   "Periodic 'eye-on-the-door' beat. :door-face-active-secs counts down

--- a/src/core/rng.phel
+++ b/src/core/rng.phel
@@ -1,0 +1,64 @@
+(ns phel-doom.core.rng)
+
+;; ---------------------------------------------------------------------
+;; Seeded pseudo-random generator (issue #64).
+;;
+;; The game previously drew randomness straight from `php/random_int`
+;; (rand-int) and `php/mt_rand`. `random_int` is a CSPRNG and can't be
+;; seeded, so runs were unreproducible — which broke both the "R =
+;; replay the same map" restart and any hope of deterministic demo
+;; playback.
+;;
+;; This module is the single RNG every gameplay draw flows through. Seed
+;; it once (`seed!`) and the whole run is reproducible: same seed + same
+;; input/dt stream => identical world every frame. That's what makes
+;; demo record/replay (io/demo) deterministic.
+;;
+;; Algorithm: Park-Miller minimal-standard LCG (x' = 16807*x mod
+;; 2147483647). All intermediate math stays inside PHP's 64-bit int
+;; range, so no overflow-to-float. A module atom holds the state — the
+;; same pragmatic "global RNG" shape the code already had, just seedable.
+;; ---------------------------------------------------------------------
+
+(def modulus 2147483647)        ; 2^31 - 1 (Mersenne prime)
+(def multiplier 16807)
+
+(def state
+  "Current generator state in 1..modulus-1. Never 0 (a zero state is a
+   fixed point that only ever yields 0)."
+  (atom 1))
+
+(defn seed!
+  "Seed the generator. Any integer is folded into the valid 1..m-1
+   range; 0 maps to 1 so the stream never collapses."
+  [n]
+  (let [s (php/% (php/abs (php/intval n)) modulus)]
+    (reset! state (if (php/=== 0 s) 1 s))
+    nil))
+
+(defn fresh-seed
+  "A nondeterministic seed for a fresh run (does NOT seed the
+   generator). Drawn from the CSPRNG so two real runs differ; the value
+   is recorded by the demo writer so a replay can reproduce the run."
+  []
+  (php/random_int 1 (php/- modulus 1)))
+
+(defn next-raw!
+  "Advance the generator and return the new raw state in 1..m-1."
+  []
+  (swap! state (fn [x] (php/% (php/* multiplier x) modulus)))
+  @state)
+
+(defn int!
+  "Random integer in 0..n inclusive (matches `rand-int` semantics).
+   Returns 0 for n <= 0."
+  [n]
+  (if (php/<= n 0)
+    0
+    (php/% (next-raw!) (php/+ n 1))))
+
+(defn float!
+  "Random float in [0, 1) (replacement for the old
+   `(/ (mt_rand) (mt_getrandmax))` ratio)."
+  []
+  (php// (php/- (next-raw!) 1) (php/- modulus 1.0)))

--- a/src/io/demo.phel
+++ b/src/io/demo.phel
@@ -1,0 +1,126 @@
+(ns phel-doom.io.demo)
+
+;; ---------------------------------------------------------------------
+;; Demo record / replay (issue #64). A demo is the run's RNG seed plus
+;; the per-frame [key-bytes, dt-ms] input stream. Because every gameplay
+;; draw now flows through the seeded core/rng, seed + input stream fully
+;; determine the run: replaying the same seed and feeding the same
+;; inputs reproduces the world frame for frame.
+;;
+;; The game loop calls `resolve-frame!` each frame: in :record mode it
+;; appends the live (keys, ms) and passes them through; in :replay mode
+;; it returns the next recorded frame (ignoring the terminal) and
+;; signals `:end?` when the stream runs out. `:off` is a pass-through.
+;;
+;; A module atom holds the session — the loop is the single caller, so
+;; there's no contention. Pure helpers (frames<->json) are unit-tested.
+;; ---------------------------------------------------------------------
+
+(def demo-version 1)
+
+(def state
+  "Demo session: {:mode :off|:record|:replay :seed n :frames [...] :cursor i}.
+   Frames are [keys-string dt-ms] pairs."
+  (atom {:mode :off :seed nil :frames [] :cursor 0}))
+
+(defn recording? [] (php/=== :record (:mode @state)))
+(defn replaying? [] (php/=== :replay (:mode @state)))
+(defn run-seed [] (:seed @state))
+
+(defn start-record!
+  "Begin capturing frames against `seed`."
+  [seed]
+  (reset! state {:mode :record :seed seed :frames [] :cursor 0})
+  nil)
+
+(defn start-replay!
+  "Begin replaying `frames` (vector of [keys ms]) under `seed`."
+  [seed frames]
+  (reset! state {:mode :replay :seed seed :frames frames :cursor 0})
+  nil)
+
+(defn reset-off! []
+  (reset! state {:mode :off :seed nil :frames [] :cursor 0})
+  nil)
+
+(defn resolve-frame!
+  "Per-frame input source. Given the live `[keys ms]`, return
+   `{:keys :ms}` to drive this frame, or `{:end? true}` when a replay
+   has exhausted its stream.
+     :record -> record the live frame, pass it through
+     :replay -> return the next recorded frame (terminal ignored)
+     :off    -> pass the live frame through"
+  [live-keys live-ms]
+  (let [s @state]
+    (cond
+      (php/=== :record (:mode s))
+      (do (swap! state update :frames conj [live-keys live-ms])
+          {:keys live-keys :ms live-ms})
+
+      (php/=== :replay (:mode s))
+      (let [c  (:cursor s)
+            fs (:frames s)]
+        (if (php/>= c (count fs))
+          {:end? true}
+          (let [fr (get fs c)]
+            (swap! state assoc :cursor (php/+ c 1))
+            {:keys (get fr 0) :ms (get fr 1)})))
+
+      :else
+      {:keys live-keys :ms live-ms})))
+
+;; --- serialization (pure) -------------------------------------------
+
+(defn frames->json
+  "Pure: serialize a demo (seed + frames) to a versioned JSON string."
+  [seed frames]
+  (let [o  (php/array)
+        fa (php/array)]
+    (php/aset o "version" demo-version)
+    (php/aset o "seed" seed)
+    (loop [i 0]
+      (when (php/< i (count frames))
+        (let [fr   (get frames i)
+              pair (php/array)]
+          (php/aset pair 0 (get fr 0))
+          (php/aset pair 1 (get fr 1))
+          (php/array_push fa pair))
+        (recur (php/+ i 1))))
+    (php/aset o "frames" fa)
+    (php/json_encode o)))
+
+(defn json->demo
+  "Pure: parse a demo JSON string into {:seed :frames}, or nil on a
+   version mismatch / malformed input."
+  [s]
+  (let [d (php/json_decode s true)]
+    (if (and (php/is_array d)
+             (php/=== demo-version (php/aget d "version")))
+      {:seed   (php/aget d "seed")
+       :frames (apply vector
+                      (map (fn [p] [(php/aget p 0) (php/aget p 1)])
+                           (php/aget d "frames")))}
+      nil)))
+
+;; --- file IO --------------------------------------------------------
+
+(defn save-recording!
+  "Write the recorded frames to `path`. No-op unless recording. Returns
+   true on success."
+  [path]
+  (if (not (recording?))
+    false
+    (let [s @state]
+      (not (php/=== false
+                    (php/file_put_contents path (frames->json (:seed s) (:frames s))))))))
+
+(defn read-demo
+  "Read + parse a demo file into {:seed :frames}, or nil when missing /
+   unreadable / malformed."
+  [path]
+  (if (not (php/file_exists path))
+    nil
+    (let [c (php/file_get_contents path)]
+      (if (or (php/=== c false) (php/=== c ""))
+        nil
+        (json->demo c)))))

--- a/tests/commands/play-test.phel
+++ b/tests/commands/play-test.phel
@@ -2,6 +2,8 @@
   (:require phel.test :refer [deftest is])
   (:require phel-doom.core.state  :refer [new-player new-world with-enemies])
   (:require phel-doom.core.enemy  :refer [new-enemy])
+  (:require phel-doom.core.level  :refer [build-world])
+  (:require phel-doom.core.rng    :as rng)
   (:require phel-doom.commands.play  :refer [tick-world]))
 
 (def open-grid
@@ -187,3 +189,22 @@
         w' (tick-world w0 "" 0.016 (assoc no-edges :fire true))]
     (is (= 0 (:kills w')))
     (is (= 0 (:mag w')))))
+
+;; ---------------------------------------------------------------------
+;; Demo determinism (issue #64): same seed + same input stream =>
+;; identical world frame-for-frame. This is the property demo replay
+;; relies on; with the seeded core/rng it holds end to end.
+;; ---------------------------------------------------------------------
+
+(deftest test-replay-reproduces-world
+  (let [run (fn []
+              (rng/seed! 2024)
+              (loop [w (build-world 1 5) i 0]
+                (if (php/>= i 40)
+                  w
+                  (recur (tick-world w "w" 0.016 no-edges) (php/+ i 1)))))
+        a   (run)
+        b   (run)]
+    (is (= (:player a) (:player b)) "player state identical after 40 frames")
+    (is (= (:enemies a) (:enemies b)) "enemy state identical")
+    (is (= (:game-time a) (:game-time b)))))

--- a/tests/core/level-test.phel
+++ b/tests/core/level-test.phel
@@ -1,6 +1,30 @@
 (ns phel-doom-tests.core.level-test
   (:require phel.test :refer [deftest is])
-  (:require phel-doom.core.level :refer [config-for num-levels build-world place-secret-reward secret-trophies]))
+  (:require phel-doom.core.level :refer [config-for num-levels build-world place-secret-reward secret-trophies])
+  (:require phel-doom.core.rng :as rng))
+
+;; ---------------------------------------------------------------------
+;; Seeded determinism (issue #64): same rng seed => identical level.
+;; This is the foundation demo replay relies on.
+;; ---------------------------------------------------------------------
+
+(deftest test-build-world-deterministic-under-seed
+  (rng/seed! 777)
+  (let [a (build-world 1 5)]
+    (rng/seed! 777)
+    (let [b (build-world 1 5)]
+      (is (= (:grid a) (:grid b)) "same seed -> identical map geometry")
+      (is (= (:player a) (:player b)) "same spawn position + angle")
+      (is (= (map (fn [e] [(:x e) (:y e) (:type e)]) (:enemies a))
+             (map (fn [e] [(:x e) (:y e) (:type e)]) (:enemies b)))
+          "same enemy spawns"))))
+
+(deftest test-build-world-differs-under-different-seed
+  (rng/seed! 1)
+  (let [a (build-world 1 5)]
+    (rng/seed! 2)
+    (is (not (= (:grid a) (:grid (build-world 1 5))))
+        "different seeds -> different maps")))
 
 (deftest test-config-for-returns-each-level
   (is (= "imps"        (:name (config-for 1))))

--- a/tests/core/rng-test.phel
+++ b/tests/core/rng-test.phel
@@ -1,0 +1,32 @@
+(ns phel-doom-tests.core.rng-test
+  (:require phel.test :refer [deftest is])
+  (:require phel-doom.core.rng :as rng))
+
+(deftest test-same-seed-same-sequence
+  (rng/seed! 12345)
+  (let [a [(rng/int! 100) (rng/int! 100) (rng/int! 100)]]
+    (rng/seed! 12345)
+    (let [b [(rng/int! 100) (rng/int! 100) (rng/int! 100)]]
+      (is (= a b) "same seed reproduces the stream"))))
+
+(deftest test-different-seed-differs
+  (rng/seed! 1)
+  (let [a (rng/int! 1000000000)]
+    (rng/seed! 2)
+    (is (not (= a (rng/int! 1000000000))) "different seeds diverge")))
+
+(deftest test-int-in-range
+  (rng/seed! 7)
+  (dotimes [_ 60]
+           (let [n (rng/int! 5)]
+             (is (and (php/>= n 0) (php/<= n 5))))))
+
+(deftest test-float-in-range
+  (rng/seed! 7)
+  (dotimes [_ 60]
+           (let [f (rng/float!)]
+             (is (and (php/>= f 0.0) (php/< f 1.0))))))
+
+(deftest test-seed-zero-is-safe
+  (rng/seed! 0)
+  (is (php/>= (rng/int! 10) 0) "zero seed folds to a valid non-collapsing state"))

--- a/tests/io/demo-test.phel
+++ b/tests/io/demo-test.phel
@@ -1,0 +1,43 @@
+(ns phel-doom-tests.io.demo-test
+  (:require phel.test :refer [deftest is])
+  (:require phel-doom.io.demo :as demo))
+
+(deftest test-frames-json-round-trip
+  (let [frames [["w" 16] ["s a" 17] ["" 16]]
+        back   (demo/json->demo (demo/frames->json 4242 frames))]
+    (is (= 4242 (:seed back)))
+    (is (= frames (:frames back)))))
+
+(deftest test-json-demo-rejects-malformed
+  (is (= nil (demo/json->demo "garbage not json"))))
+
+(deftest test-json-demo-rejects-version-mismatch
+  (let [o (php/array)]
+    (php/aset o "version" 99)
+    (php/aset o "frames" (php/array))
+    (is (= nil (demo/json->demo (php/json_encode o))))))
+
+(deftest test-record-mode-flags
+  (demo/start-record! 1)
+  (is (demo/recording?))
+  (is (not (demo/replaying?)))
+  (is (= 1 (demo/run-seed)))
+  (demo/reset-off!)
+  (is (not (demo/recording?))))
+
+(deftest test-replay-feeds-frames-then-ends
+  (demo/start-replay! 9 [["w" 16] ["s" 17]])
+  (let [f1 (demo/resolve-frame! "x" 99)
+        f2 (demo/resolve-frame! "x" 99)
+        f3 (demo/resolve-frame! "x" 99)]
+    (is (= "w" (:keys f1)) "first recorded frame, terminal ignored")
+    (is (= 16 (:ms f1)))
+    (is (= "s" (:keys f2)))
+    (is (= true (:end? f3)) "stream exhausted -> end"))
+  (demo/reset-off!))
+
+(deftest test-off-mode-passes-through
+  (demo/reset-off!)
+  (let [f (demo/resolve-frame! "wd" 16)]
+    (is (= "wd" (:keys f)))
+    (is (= 16 (:ms f)))))


### PR DESCRIPTION
Closes #64. `--record=FILE` captures a run; `--demo=FILE` replays it deterministically. Fixed the unseedable-randomness blocker by routing all gameplay RNG through one seeded generator (core/rng, Park-Miller), replacing php/random_int + php/mt_rand across level/map/enemy/enemy_ai/physics/combat. io/demo: format {version, seed, frames:[[keys, ms]]}, pure frames<->json, resolve-frame! input seam. play: --record/--demo flags, run-levels seeds rng, game-loop input via demo/resolve-frame!. Bonus: R (restart-same-map) now actually reproduces geometry. Tests 1271 to 1415 incl full tick-world replay reproduces world. Docs: demo.md + features/architecture + CHANGELOG. composer ci clean.