### PR TITLE
ref: idiomatic cleanup across core + render

### DIFF
--- a/src/core/combat.phel
+++ b/src/core/combat.phel
@@ -238,38 +238,32 @@
                  (map (fn [e] (assoc e :ttl (php/- (:ttl e) dt)))
                       (or fx [])))))
 
+(defn- decay-timer
+  "Tick world timer `k` down by `dt`, clamped at 0. Missing keys read as
+   0.0 so a partial test fixture never errors."
+  [world k ^float dt]
+  (php/max 0.0 (php/- (or (get world k) 0.0) dt)))
+
 (defn- decay-timers [world ^float dt]
-  (let [iframes      (php/max 0.0 (php/- (:iframes world) dt))
-        fire-anim    (php/max 0.0 (php/- (or (:fire-anim world) 0.0) dt))
-        intro-secs   (php/max 0.0 (php/- (or (:intro-secs world) 0.0) dt))
-        flash-secs   (php/max 0.0 (php/- (or (:flash-secs world) 0.0) dt))
-        streak-secs' (php/max 0.0 (php/- (or (:streak-secs world) 0.0) dt))
-        cooldown'    (php/max 0.0 (php/- (or (:fire-cooldown world) 0.0) dt))
-        reload-cd'   (php/max 0.0 (php/- (or (:reload-cooldown world) 0.0) dt))
-        click-secs'  (php/max 0.0 (php/- (or (:empty-click-secs world) 0.0) dt))
-        berserk'     (php/max 0.0 (php/- (or (:berserk-secs world) 0.0) dt))
-        invuln'      (php/max 0.0 (php/- (or (:invuln-secs world) 0.0) dt))
-        heat'        (php/max 0.0 (php/- (or (:heat world) 0.0) (php/* heat-cool-rate dt)))
-        jam-secs'    (php/max 0.0 (php/- (or (:jam-secs world) 0.0) dt))
-        locked-bump' (php/max 0.0 (php/- (or (:locked-door-bump-secs world) 0.0) dt))]
+  (let [streak-secs' (decay-timer world :streak-secs dt)]
     (assoc world
-           :iframes         iframes
-           :fire-anim       fire-anim
-           :intro-secs      intro-secs
-           :flash-secs      flash-secs
-           :streak-secs     streak-secs'
-           :fire-cooldown   cooldown'
-           :reload-cooldown reload-cd'
-           :empty-click-secs click-secs'
-           :berserk-secs    berserk'
-           :invuln-secs     invuln'
-           :heat            heat'
-           :jam-secs        jam-secs'
-           :locked-door-bump-secs locked-bump'
+           :iframes               (decay-timer world :iframes dt)
+           :fire-anim             (decay-timer world :fire-anim dt)
+           :intro-secs            (decay-timer world :intro-secs dt)
+           :flash-secs            (decay-timer world :flash-secs dt)
+           :streak-secs           streak-secs'
+           :fire-cooldown         (decay-timer world :fire-cooldown dt)
+           :reload-cooldown       (decay-timer world :reload-cooldown dt)
+           :empty-click-secs      (decay-timer world :empty-click-secs dt)
+           :berserk-secs          (decay-timer world :berserk-secs dt)
+           :invuln-secs           (decay-timer world :invuln-secs dt)
+           :heat                  (php/max 0.0 (php/- (or (:heat world) 0.0) (php/* heat-cool-rate dt)))
+           :jam-secs              (decay-timer world :jam-secs dt)
+           :locked-door-bump-secs (decay-timer world :locked-door-bump-secs dt)
            ;; Window expired: streak counter goes back to 0 so the HUD
            ;; stops showing it.
-           :streak        (if (php/<= streak-secs' 0.0) 0 (or (:streak world) 0))
-           :fx            (decay-fx (:fx world) dt))))
+           :streak                (if (php/<= streak-secs' 0.0) 0 (or (:streak world) 0))
+           :fx                    (decay-fx (:fx world) dt))))
 
 (defn player-immune?
   "True when an incoming hit can't land: i-frames still ticking, an

--- a/src/core/enemy.phel
+++ b/src/core/enemy.phel
@@ -294,17 +294,12 @@
   "How many enemies in `enemies` are currently alive AND carry `:type`
    matching `t`. Used to enforce :max-concurrent on respawn."
   [enemies t]
-  (loop [es    enemies
-         total 0]
-    (cond
-      (nil? es)          total
-      (zero? (count es)) total
-      :else
-      (let [e (first es)]
-        (recur (next es)
-               (if (and (:alive e) (= (:type e) t))
-                 (php/+ total 1)
-                 total))))))
+  (reduce (fn [total e]
+            (if (and (:alive e) (= (:type e) t))
+              (php/+ total 1)
+              total))
+          0
+          enemies))
 
 (defn- tick-one
   "One frame of update for a single enemy. Alive → run the AI
@@ -455,18 +450,14 @@
    enemy list is empty / all dead — large enough to never read as
    'close' to the scare trigger."
   [enemies ^float px ^float py]
-  (loop [es   enemies
-         best 1.0e9]
-    (cond
-      (empty? es) best
-      :else
-      (let [e (first es)]
-        (if (:alive e)
-          (let [dx (php/- (:x e) px)
-                dy (php/- (:y e) py)
-                d  (php/sqrt (php/+ (php/* dx dx) (php/* dy dy)))]
-            (recur (rest es) (php/min best d)))
-          (recur (rest es) best))))))
+  (reduce (fn [best e]
+            (if (:alive e)
+              (let [dx (php/- (:x e) px)
+                    dy (php/- (:y e) py)]
+                (php/min best (php/sqrt (php/+ (php/* dx dx) (php/* dy dy)))))
+              best))
+          1.0e9
+          enemies))
 
 (defn tick-scare
   "Detect inbound crossings of the nearest enemy past two thresholds:

--- a/src/core/enemy_ai.phel
+++ b/src/core/enemy_ai.phel
@@ -500,12 +500,8 @@
    new information."
   [enemy ^float ox ^float oy]
   (case (state-of enemy)
-    :dormant (-> enemy
-                 (assoc :state :hunting)
-                 (assoc :lkp   {:x ox :y oy}))
-    :wander  (-> enemy
-                 (assoc :state :hunting)
-                 (assoc :lkp   {:x ox :y oy}))
+    :dormant (assoc enemy :state :hunting :lkp {:x ox :y oy})
+    :wander  (assoc enemy :state :hunting :lkp {:x ox :y oy})
     :hunting (assoc enemy :lkp {:x ox :y oy})
     enemy))
 

--- a/src/core/level.phel
+++ b/src/core/level.phel
@@ -161,7 +161,7 @@
   "Return a one-element vector with a heart pickup at a random open
    cell, or [] when the player is already at max-lives (no point
    spawning a heart they can't pick up)."
-  [grid lives px py]
+  [grid lives]
   (if (php/>= lives max-lives)
     []
     (let [[hx hy] (random-spawn grid)]
@@ -204,11 +204,12 @@
       [{:x sx :y sy}])
     []))
 
-(defn- spawn-armor-shards
-  "Common armor shards (issue #68): seed `n` of them at random open
-   cells. Each adds +1 armor over the normal `max-armor` cap up to
-   `armor-shard-cap` (10). Skip duplicates so two shards can't share
-   a cell (silently merging into one pickup)."
+(defn- spawn-unique-pickups
+  "Seed `n` {:x :y} pickups at random open cells, retrying when
+   `random-spawn` collides with one already placed (otherwise stepping
+   on the shared cell silently consumes multiple pickups for a single
+   reward). Bails after `(* n 6)` attempts so a tight map can't
+   infinite-loop; the caller just gets the ones that fit."
   [grid n]
   (loop [acc [] attempts 0]
     (cond
@@ -216,15 +217,18 @@
       (php/> attempts (php/* n 6)) acc
       :else
       (let [[sx sy] (random-spawn grid)
-            dup?    (loop [xs acc]
-                      (cond
-                        (php/=== xs nil) false
-                        (let [s (first xs)]
-                          (and (php/=== (:x s) sx) (php/=== (:y s) sy))) true
-                        :else (recur (next xs))))]
+            dup?    (some (fn [p] (and (php/=== (:x p) sx) (php/=== (:y p) sy))) acc)]
         (if dup?
           (recur acc (php/+ attempts 1))
           (recur (conj acc {:x sx :y sy}) (php/+ attempts 1)))))))
+
+(defn- spawn-armor-shards
+  "Common armor shards (issue #68): seed `n` of them at random open
+   cells. Each adds +1 armor over the normal `max-armor` cap up to
+   `armor-shard-cap` (10). Skip duplicates so two shards can't share
+   a cell (silently merging into one pickup)."
+  [grid n]
+  (spawn-unique-pickups grid n))
 
 (def armor-shards-per-level
   "Tunable: how many shards seed per level. Three keeps the level
@@ -263,16 +267,23 @@
         (update :armor-shards (fn [v] (conj (or v []) at)))
         (update trophy (fn [v] (conj (or v []) at))))))
 
+(defn- pack->level
+  "Coerce a `pack` arg to a backpack stack level. Accepts the legacy
+   boolean (true = level 1) or the new integer level for back-compat
+   with old callers; anything else reads as 0."
+  [pack]
+  (cond
+    (boolean? pack)   (if pack 1 0)
+    (php/is_int pack) pack
+    :else             0))
+
 (defn- maybe-spawn-backpack
   "Stacking backpack (#68 part 3): L2+ only, ~1 in 5 qualifying
    levels. Skipped once the player is at `max-backpacks`. `pack`
    accepts the legacy boolean (true = level 1) or the new integer
    level for back-compat with old callers."
   [grid level-num pack]
-  (let [lvl (cond
-              (boolean? pack)   (if pack 1 0)
-              (php/is_int pack) pack
-              :else             0)]
+  (let [lvl (pack->level pack)]
     (if (or (php/>= lvl max-backpacks)
             (php/< level-num 2)
             (php/!== 0 (mod (rng/int! 5) 5)))
@@ -285,14 +296,10 @@
    ammo box budget per level — the player needs roughly enough
    bullets to cover every monster's HP."
   [specs]
-  (loop [xs specs total 0]
-    (cond
-      (php/=== xs nil)       total
-      (php/=== (count xs) 0) total
-      :else
-      (let [s (first xs)]
-        (recur (next xs)
-               (php/+ total (php/* (or (:count s) 0) (or (:lives s) 1))))))))
+  (reduce (fn [total s]
+            (php/+ total (php/* (or (:count s) 0) (or (:lives s) 1))))
+          0
+          specs))
 
 (defn- ammo-box-count
   "Per-level ammo-box budget. Scales with the expected shot count
@@ -381,21 +388,7 @@
    map can't infinite-loop; the player just gets the boxes that
    did fit."
   [grid n]
-  (loop [acc [] attempts 0]
-    (cond
-      (php/>= (count acc) n)       acc
-      (php/> attempts (php/* n 6)) acc
-      :else
-      (let [[bx by] (random-spawn grid)
-            dup?    (loop [xs acc]
-                      (cond
-                        (php/=== xs nil) false
-                        (let [b (first xs)]
-                          (and (php/=== (:x b) bx) (php/=== (:y b) by))) true
-                        :else (recur (next xs))))]
-        (if dup?
-          (recur acc (php/+ attempts 1))
-          (recur (conj acc {:x bx :y by}) (php/+ attempts 1)))))))
+  (spawn-unique-pickups grid n))
 
 (defn- build-grid
   "Two paths: hand-authored `:layout` (parsed via map/parse-layout —
@@ -499,12 +492,9 @@
             :level         lv
             :lives         life
             :difficulty    diff'
-            :backpack-level (cond
-                              (boolean? pack)   (if pack 1 0)
-                              (php/is_int pack) pack
-                              :else             0)
+            :backpack-level (pack->level pack)
             :owned-weapons (or owned #{:pistol})
-            :hearts        (maybe-spawn-heart grid life px py)
+            :hearts        (maybe-spawn-heart grid life)
             :armors        (maybe-spawn-armor grid)
             :berserks      (maybe-spawn-berserk grid)
             :invulns       (maybe-spawn-invuln grid)

--- a/src/core/map.phel
+++ b/src/core/map.phel
@@ -218,23 +218,15 @@
    leaving the world in a weird half-mutated state."
   [grid switches ^int x ^int y]
   (let [grid' (toggle-switch-cell grid x y)
-        match (loop [xs switches]
-                (cond
-                  (or (php/=== xs nil) (php/=== (count xs) 0)) nil
-                  :else
-                  (let [s       (first xs)
-                        [sx sy] (:at s)]
-                    (if (and (php/=== sx x) (php/=== sy y))
-                      s
-                      (recur (next xs))))))]
+        match (some (fn [s]
+                      (let [[sx sy] (:at s)]
+                        (when (and (php/=== sx x) (php/=== sy y)) s)))
+                    switches)]
     (if (nil? match)
       grid'
-      (loop [g grid' ts (:targets match)]
-        (cond
-          (or (php/=== ts nil) (php/=== (count ts) 0)) g
-          :else
-          (let [[tx ty] (first ts)]
-            (recur (toggle-target-cell g tx ty) (next ts))))))))
+      (reduce (fn [g [tx ty]] (toggle-target-cell g tx ty))
+              grid'
+              (:targets match)))))
 
 (defn reveal-secret
   "Swap the cell at (x, y) from `cell-secret` to `cell-floor` so the
@@ -251,20 +243,8 @@
    so the world can carry `:secrets-total` for the HUD progress
    readout."
   [grid]
-  (let [h (count grid)]
-    (loop [y 0 acc 0]
-      (if (php/>= y h)
-        acc
-        (let [row         (get grid y)
-              w           (count row)
-              row-secrets
-              (loop [x 0 n 0]
-                (if (php/>= x w)
-                  n
-                  (if (= cell-secret (get row x))
-                    (recur (php/+ x 1) (php/+ n 1))
-                    (recur (php/+ x 1) n))))]
-          (recur (php/+ y 1) (php/+ acc row-secrets)))))))
+  (count (filter (fn [c] (= cell-secret c))
+                 (apply concat grid))))
 
 (defn- divider-wall?
   "True when the interior wall at (x, y) is a 1-cell-thick divider
@@ -351,13 +331,12 @@
             (recur g placed (+ attempts 1))))))))
 
 (defn- border-row [w]
-  (apply vector (map (fn [_] cell-wall) (range 0 w))))
+  (into [] (map (fn [_] cell-wall) (range 0 w))))
 
 (defn- interior-row [w]
-  (apply vector
-         (concat [cell-wall]
-                 (map (fn [_] cell-floor) (range 0 (- w 2)))
-                 [cell-wall])))
+  (into [] (concat [cell-wall]
+                   (map (fn [_] cell-floor) (range 0 (- w 2)))
+                   [cell-wall])))
 
 (defn- place-block [grid w h x y bw bh]
   (loop [yy 0 g grid]

--- a/src/core/physics.phel
+++ b/src/core/physics.phel
@@ -188,12 +188,12 @@
    `:moves` AND the sprint state (via sprint-factor) so sprint
    intent x stamina > 0 x not-blocked yields a 1.6x boost."
   [world ^float dt]
-  (let [moves (:moves world)]
-    (let [turned (apply-rotation world (turn-delta moves dt))]
-      (let [walked (apply-translation turned
-                                      (longitudinal-delta turned dt)
-                                      (lateral-delta turned dt))]
-        (decay-move-counters walked)))))
+  (let [moves  (:moves world)
+        turned (apply-rotation world (turn-delta moves dt))
+        walked (apply-translation turned
+                                  (longitudinal-delta turned dt)
+                                  (lateral-delta turned dt))]
+    (decay-move-counters walked)))
 
 (defn tick-stamina
   "Drain stamina while sprinting + moving, regenerate while not (after

--- a/src/core/state.phel
+++ b/src/core/state.phel
@@ -316,10 +316,11 @@
   "Translate the player by (dx, dy) — no collision check here."
   [world dx dy]
   (let [{:keys [x y]} (:player world)]
-    (update world :player merge {:x (+ x dx) :y (+ y dy)})))
+    (-> world
+        (assoc-in [:player :x] (+ x dx))
+        (assoc-in [:player :y] (+ y dy)))))
 
 (defn turn-player
   "Rotate the player by dtheta radians."
   [world dtheta]
-  (let [a (:angle (:player world))]
-    (update world :player merge {:angle (+ a dtheta)})))
+  (assoc-in world [:player :angle] (+ (:angle (:player world)) dtheta)))

--- a/src/io/render.phel
+++ b/src/io/render.phel
@@ -429,6 +429,15 @@
        ";38;5;" (fade-256 fg-code t)
        "m" glyph))
 
+(defn- sprite-h
+  "Screen-space height (rows) of a sprite at depth `d`, multiplied by
+   scale factor `sc` (1.0 for standard enemies, 2.0 for cyberdemons).
+   Clamps to `vh` so the result never exceeds the viewport. Used by
+   all sprite painters that need the projected height — centralises
+   the `proj-dist / (max(0.5, d) * char-aspect)` formula."
+  [^int vh ^float d ^float sc]
+  (php/min vh (php/intval (php/* sc (php// proj-dist (php/* (php/max 0.5 d) char-aspect))))))
+
 (defn- boss-col-paint
   "Per-column body / legs / head string overrides that carve a
    boss-shaped silhouette out of the cyberdemon's 2× rectangle:
@@ -600,26 +609,6 @@
 (defn- enemy-cells [enemies step out-w]
   (scaled-cells enemies step out-w (fn [e] (:alive e))))
 
-(defn- heart-cells [hearts step out-w]
-  (scaled-cells hearts step out-w (fn [_] true)))
-
-(defn- ammo-cells [boxes step out-w]
-  (scaled-cells boxes step out-w (fn [_] true)))
-
-(defn- berserk-cells [bs step out-w]
-  (scaled-cells bs step out-w (fn [_] true)))
-
-(defn- invuln-cells [is step out-w]
-  (scaled-cells is step out-w (fn [_] true)))
-
-(defn- soulsphere-cells [ss step out-w]
-  (scaled-cells ss step out-w (fn [_] true)))
-
-(defn- armor-shard-cells [ss step out-w]
-  (scaled-cells ss step out-w (fn [_] true)))
-
-(defn- backpack-cells [bs step out-w]
-  (scaled-cells bs step out-w (fn [_] true)))
 
 (defn- minimap-rows
   "Render the world's grid into a PHP array of ANSI-coded strings,
@@ -666,13 +655,13 @@
                                           (recur (php/+ dr 1))))))))
         marker              (str "\e[40;93;1m" (direction-char angle) "\e[0m")
         emap                (enemy-cells (:enemies world) step out-w)
-        hmap                (heart-cells (:hearts world) step out-w)
-        amap                (ammo-cells  (:ammo-boxes world) step out-w)
-        bmap                (berserk-cells (:berserks world) step out-w)
-        imap                (invuln-cells  (:invulns world) step out-w)
-        ssmap               (soulsphere-cells (:soulspheres world) step out-w)
-        asmap               (armor-shard-cells (:armor-shards world) step out-w)
-        pmap                (backpack-cells (:backpacks world) step out-w)
+        hmap                (scaled-cells (:hearts world) step out-w (fn [_] true))
+        amap                (scaled-cells (:ammo-boxes world) step out-w (fn [_] true))
+        bmap                (scaled-cells (:berserks world) step out-w (fn [_] true))
+        imap                (scaled-cells (:invulns world) step out-w (fn [_] true))
+        ssmap               (scaled-cells (:soulspheres world) step out-w (fn [_] true))
+        asmap               (scaled-cells (:armor-shards world) step out-w (fn [_] true))
+        pmap                (scaled-cells (:backpacks world) step out-w (fn [_] true))
         kbmap               (scaled-cells (:keycards world) step out-w
                                           (fn [k] (php/=== (:colour k) :blue)))
         krmap               (scaled-cells (:keycards world) step out-w
@@ -1299,8 +1288,7 @@
                         (php/>= col 0)
                         (php/< col vw)
                         (enemy-front-visible-at? d col dists edists))
-               (let [h        (php/min vh (php/intval (php// proj-dist
-                                                             (php/* (php/max 0.5 d) char-aspect))))
+               (let [h        (sprite-h vh d 1.0)
                      face-row (php/+ (php/intdiv (php/- vh h) 2) (php/intdiv h 6))]
                  (when (and (php/>= face-row 1) (php/<= face-row vh))
                    (buf-push parts
@@ -1956,8 +1944,7 @@
                (when proj
                  (let [col (:col proj)
                        d   (:dist proj)
-                       h   (php/min vh (php/intval (php// proj-dist
-                                                          (php/* (php/max 0.5 d) char-aspect))))
+                       h   (sprite-h vh d 1.0)
                        row (php/max 1 (php/- (php/intdiv (php/- vh h) 2) 1))]
                    (when (and (php/>= col 1) (php/<= col vw))
                      (buf-push parts
@@ -2258,8 +2245,7 @@
                                   :else            blood-dim))
                    c-from (php/max 0 (php/- col hw))
                    c-to   (php/min (php/- vw 1) (php/+ col hw))
-                   h      (php/min vh (php/intval (php// proj-dist
-                                                         (php/* (php/max 0.5 d) char-aspect))))
+                   h      (sprite-h vh d 1.0)
                    r-top  (php/+ (php/intdiv (php/- vh h) 2) (php/intdiv (php/* h 2) 3))
                    r-bot  (php/min vh (php/+ (php/intdiv (php/- vh h) 2) h))]
                (loop [c c-from]
@@ -2300,8 +2286,7 @@
                    d      (:dist proj)
                    c-from (php/max 0 (php/- col hw))
                    c-to   (php/min (php/- vw 1) (php/+ col hw))
-                   h      (php/min vh (php/intval (php// proj-dist
-                                                         (php/* (php/max 0.5 d) char-aspect))))
+                   h      (sprite-h vh d 1.0)
                    mid    (php/+ (php/intdiv (php/- vh h) 2) (php/intdiv h 2))
                    r-top  (php/max 0 (php/- mid (php/intdiv h 6)))
                    r-bot  (php/min vh (php/+ mid (php/intdiv h 6) 1))]
@@ -2349,8 +2334,7 @@
                    d      (:dist proj)
                    c-from (php/max 0 (php/- col hw))
                    c-to   (php/min (php/- vw 1) (php/+ col hw))
-                   h      (php/min vh (php/intval (php// proj-dist
-                                                         (php/* (php/max 0.5 d) char-aspect))))
+                   h      (sprite-h vh d 1.0)
                    mid    (php/+ (php/intdiv (php/- vh h) 2) (php/intdiv h 2))
                    r-top  (php/max 0 (php/- mid (php/intdiv h 6)))
                    r-bot  (php/min vh (php/+ mid (php/intdiv h 6) 1))]


### PR DESCRIPTION
## What

Behavior-preserving idiomatic cleanup across `core/` and `io/render`. No frame-budget or render-output change; hot paths (cast-ray, RLE emit, inner row loop) untouched.

Driven by a clean-code review pass aimed at Clojure/Phel best practices: replace manual `loop/recur` accumulators with `reduce`, dedup repeated logic into shared helpers, prefer idiomatic forms.

## Changes

- **core/enemy**: `alive-count-of-type`, `min-alive-dist` -> `reduce`
- **core/enemy_ai**: collapse identical `:dormant`/`:wander` branches in `wake-by-noise`
- **core/combat**: extract `decay-timer` helper (13 repeated `max 0 / - dt` expressions)
- **core/level**: extract `spawn-unique-pickups` (armor-shards + ammo-boxes were duplicated verbatim), `pack->level` helper (coercion was duplicated), `specs-total-hp` -> `reduce`, drop unused `px`/`py` from `maybe-spawn-heart`
- **core/map**: `count-secrets` via `filter`, `toggle-switch` via `some`/`reduce`, `border-row`/`interior-row` via `into []`
- **core/state**: `move-player`/`turn-player` via `assoc-in` (was `update merge`)
- **core/physics**: flatten nested `let` -> single `let` in `apply-physics`
- **io/render**: `sprite-h` helper for the repeated projected-height formula (5 sites), drop 7 trivial `scaled-cells` wrappers for direct calls

Net `-65` lines.

## Test plan

- `composer ci` green (format-check + lint + test + build)
- Full suite passes, no count regression

## Deferred (follow-up, intentionally out of scope)

- `core/combat` calling `play-sfx!` directly (real IO-boundary violation, long-standing; fix = thread sfx as data to the play loop)
- `core/engine` cache atoms (`offset-cache`, `pause-cast-cache`) - purity grey area
- render sprite-painter dedup, `pulse-pair`, dead `block-has-wall?` branch (needs play verify)
