### PR TITLE
ref(render): dedup badges, hoist constants, idiomatic helpers

### DIFF
--- a/src/io/render.phel
+++ b/src/io/render.phel
@@ -542,11 +542,11 @@
    the nearest π/4 sector. Public so the minimap layer and tests can
    share the same convention."
   [angle]
-  (let [q (mod (php/intval
-                (+ (/ (php/fmod (+ angle (* 4.0 php/M_PI)) (* 2.0 php/M_PI))
-                      (/ php/M_PI 4.0))
-                   0.5))
-               8)]
+  (let [q (php/% (php/intval
+                  (php/+ (php// (php/fmod (php/+ angle (php/* 4.0 php/M_PI)) (php/* 2.0 php/M_PI))
+                                (php// php/M_PI 4.0))
+                         0.5))
+                 8)]
     (cond
       (= q 0) "→"
       (= q 1) "↘"
@@ -824,12 +824,11 @@
          mag-col mag "\e[0m/" cap " "
          res-col "[" reserve "]\e[0m")))
 
-(defn- hud-line
+(def hud-line-str
   "Bottom-status row. Was the dump for pos/angle/fps + a cramped key
    legend; those moved to the F3 debug overlay and the pause menu.
    Now a single dim tagline so the bottom strip stays visually
    anchored without competing with the game info up top."
-  [_world _stats]
   "\e[0m\e[2mP to pause for controls · F3 for debug\e[0m")
 
 (defn project-enemy
@@ -1432,6 +1431,11 @@
           (recur (php/+ col 1))))))
   parts)
 
+(def blood-drop-codes
+  "256-color codes for the 3-row blood-drop tail: bright -> mid -> dim
+   red. Same red gradient family as shade-table-blood."
+  [196 124 52])
+
 (defn- paint-blood-drops
   "Ambient ceiling-drip overlay: paint a short trail of fading red
    glyphs at every active drop position. Columns are normalised
@@ -1446,9 +1450,7 @@
              (loop [k 0]
                (when (php/< k 3)
                  (let [r    (php/- row k)
-                       code (cond (php/=== k 0) 196
-                                  (php/=== k 1) 124
-                                  :else         52)]
+                       code (get blood-drop-codes k)]
                    (when (and (php/>= r 1) (php/<= r vh))
                      (buf-push parts (str "\e[" r ";" col "H\e[38;5;" code ";1m▌\e[0m"))))
                  (recur (php/+ k 1)))))))
@@ -1639,34 +1641,36 @@
     (buf-push parts (str "\e[2;1H" styled)))
   parts)
 
+(defn- paint-timed-badge
+  "Centred top-of-screen powerup banner while the `secs-key` timer is
+   ticking. `label` is the word, `sgr` the colour run, `row` the
+   terminal row, `freq` the pulse rate. Shared by the berserk + invuln
+   banners; row decides their stacking order when both fire at once."
+  [parts ^float t stats vw secs-key label sgr ^int row ^float freq]
+  (let [secs (or (get stats secs-key) 0.0)]
+    (when (and (php/> secs 0.0) (pulse t freq))
+      (let [text (str " " label " " (php/intval (php/ceil secs)) "s ")
+            col  (php/max 1 (php/- (php/intdiv vw 2)
+                                   (php/intdiv (php/strlen text) 2)))]
+        (buf-push parts (str "\e[" row ";" col "H" sgr text "\e[0m")))))
+  parts)
+
 (defn- paint-berserk-badge
   "Centred top-of-screen `BERSERK Ns` banner while :berserk-secs is
    ticking. Pulses red so the rage state is unmistakeable. Sits on
    row 3 (under the row-2 game-info strip) so it doesn't fight the
    compass / hearts."
   [parts ^float t stats vw]
-  (let [secs (or (get stats :berserk-secs) 0.0)]
-    (when (and (php/> secs 0.0) (pulse t 6.0))
-      (let [text  (str " BERSERK " (php/intval (php/ceil secs)) "s ")
-            label (str "\e[48;5;52;38;5;226;1m" text "\e[0m")
-            col   (php/max 1 (php/- (php/intdiv vw 2)
-                                    (php/intdiv (php/strlen text) 2)))]
-        (buf-push parts (str "\e[3;" col "H" label)))))
-  parts)
+  (paint-timed-badge parts t stats vw :berserk-secs "BERSERK"
+                     "\e[48;5;52;38;5;226;1m" 3 6.0))
 
 (defn- paint-invuln-badge
   "Centred top-of-screen `INVULN Ns` banner while :invuln-secs is
    active. Bright cyan on dark blue. Painted on row 4 so it stacks
    below the berserk banner when both fire at once."
   [parts ^float t stats vw]
-  (let [secs (or (get stats :invuln-secs) 0.0)]
-    (when (and (php/> secs 0.0) (pulse t 5.0))
-      (let [text  (str " INVULN " (php/intval (php/ceil secs)) "s ")
-            label (str "\e[48;5;19;38;5;51;1m" text "\e[0m")
-            col   (php/max 1 (php/- (php/intdiv vw 2)
-                                    (php/intdiv (php/strlen text) 2)))]
-        (buf-push parts (str "\e[4;" col "H" label)))))
-  parts)
+  (paint-timed-badge parts t stats vw :invuln-secs "INVULN"
+                     "\e[48;5;19;38;5;51;1m" 4 5.0))
 
 (defn- paint-empty-click
   "Trigger pulled on an empty mag: blink a centred prompt above the
@@ -2413,7 +2417,7 @@
         blood-cols                         (build-blood-cols vw bloody? (get stats :hurt-side))
         ehead                              enemy-head
         ebody                              enemy-body
-        elegs                              enemy-body
+        elegs                              enemy-body ; intentional: default legs = body colour (no separate legs def)
         ;; Pause-aware clock: render samples its blinks/pulses from
         ;; this instead of wall time so every time-driven animation
         ;; freezes the moment the game is paused (issue #7).
@@ -2827,7 +2831,7 @@
       (when (get stats :debug?)
         (buf-push parts (hud-debug-line world stats))
         (buf-push parts "\n"))
-      (buf-push parts (hud-line world stats))
+      (buf-push parts hud-line-str)
       (dotimes [i visible-mh]
                (buf-push parts (str "\e[" (php/+ map-row i) ";" map-col "H" (buf-get mrows i))))
       ;; Overlay chain: each helper returns the parts buffer because


### PR DESCRIPTION
## What

Cold-path-only follow-up to #99. No render-output or frame-budget change; hot paths untouched.

## Changes

- `hud-line` -> `hud-line-str` constant (was a fn that returned a literal regardless of args; removes a per-frame call)
- `blood-drop-codes` def replaces the inline `196/124/52` cond ladder
- `paint-timed-badge` helper collapses the berserk + invuln badge copy-paste
- `direction-char` uses `php/` arithmetic for pipeline consistency
- `elegs`: clarify the intentional default (legs = body colour, no separate legs def)

## Test plan

- `composer ci` green (format + lint + test + build), 1415 tests pass

## Not in scope (later pass)

render #5 (unify 3 SGR-strip helpers), #6 (`render-start-menu` via `render-end-screen`), #9 (`rows->ansi-at`), #1 (sprite-painter dedup), #8 (pulse-pair), #10 (dead `block-has-wall?` branch). Plus the `core/combat` `play-sfx!` IO-boundary fix.