### PR TITLE
feat(settings): configurable music/sfx volume + defaults page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 
 ### Added
 
+- Settings page (#107). Configurable bg-music + sfx volume, default minimap, default difficulty. Reach it from the start menu (`s`) or in-game (`o`, freezes like pause); arrows adjust, `o`/`esc` close. Persists to `$HOME/.phel-doom-settings.json`; volume rides `afplay -v` (macOS).
 - Half-heart health + per-type hit damage. 10 HP pool drawn as 5 hearts (`♥`/`◖`/`·`). Hits cost by attacker: light melee 1 (half heart), heavy + casters 2, cyber boss 3. Armor absorbs a whole hit; heart pickup heals a full heart; soulsphere over-caps to 14.
 - Deterministic demo record / replay (#64). `--record=FILE` / `--demo=FILE`, on a new seeded Park-Miller RNG (`core/rng`) replacing the unseedable `random_int` / `mt_rand`.
 - Mid-level quick-save / load (#63). `F5` / `F9`, whole world to a versioned tagged-JSON slot (1-9), fog re-reveals on load.

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Override tag: `DOCKER_IMG=mytag make docker-build`. Host PHP is the inner loop; 
 | `r`            | Reload                       |
 | `1` / `2` / `3` | Switch weapon                |
 | `m` / `n`      | Minimap / sound toggle       |
+| `o`            | Settings (volume, minimap)   |
 | `p`            | Pause                        |
 | `h` / `ESC`    | Info menu + pause            |
 | `F3`           | Debug overlay                |

--- a/docs/README.md
+++ b/docs/README.md
@@ -50,6 +50,7 @@ src/core/                    ; pure logic (no IO)
   projectile.phel            projectiles (not used yet)
   perf.phel                  big-screen perf checks
   difficulty.phel            easy/normal/hard/nightmare
+  settings.phel              options model (volume, defaults)
   rng.phel                   deterministic seeding
 src/glue/                    ; pure wiring (core + io)
   controls.phel              bytes to move commands
@@ -58,6 +59,7 @@ src/io/                      ; side effects
   render.phel                ANSI emit + overlays
   sound.phel                 afplay/paplay shell-out
   scores.phel                JSON persistence
+  settings.phel              options load/save (JSON)
   savegame.phel              game state save/load
   ambient.phel               background loops
   demo.phel                  attract mode

--- a/docs/audio.md
+++ b/docs/audio.md
@@ -18,6 +18,13 @@ Every shot plays the weapon's `:fire-sfx` unconditionally (hit or miss). Kill cu
 
 Each call shells out backgrounded (`&`). N key toggles `:sound-on`; mute is instant, in-flight sfx finish. `PHEL_DOOM_SILENT=1` env var (set by `composer test`) gates all output (deterministic suite).
 
+## Volume
+
+The settings page (see `docs/settings.md`) drives two levels via `afplay -v` (macOS only; other players ignore `-v`):
+
+- SFX: `set-sfx-scalar!` stores a 0..1 multiplier on the sound state atom; `play-sfx!` scales every event volume by it. 0 mutes sfx with no bell fallback.
+- Music: `set-music-volume!` updates the drone `-v` and restarts the loop so the change is immediate. 0 stops the bed.
+
 ## Ambient drone
 
 Low pulsing background loop for dread (no shipped asset).

--- a/docs/input.md
+++ b/docs/input.md
@@ -67,15 +67,17 @@ In tmux: `set -g extended-keys on` + `setw -g xterm-keys on`.
 
 ## One-shot actions (rising edges)
 
-`key-states` snaps all tracked keys each frame: `m` (map), `sp` (fire), `p` (pause), `n` (sound), `e` (about-face), `f` (action/secret), `f3` (debug), `r` (reload), `h` (help), `esc` (help alias), `k1-k5` (weapon select), `f5` (save), `f9` (load).
+`key-states` snaps all tracked keys each frame: `m` (map), `sp` (fire), `p` (pause), `n` (sound), `e` (about-face), `f` (action/secret), `f3` (debug), `r` (reload), `h` (help), `esc` (help alias), `k1-k5` (weapon select), `f5` (save), `f9` (load), `o` (settings), and the four arrows (`up` / `down` / `left` / `right`) for menu navigation.
 
-`rising-edges` computes deltas: `:fire` (space pressed), `:fire-held` (space held), `:toggle-map`, `:toggle-pause`, `:toggle-sound`, `:toggle-debug`, `:toggle-help` (h or esc), `:reload`, `:about-face`, `:action`, `:select-weapon1-5`, `:save`, `:load`.
+`rising-edges` computes deltas: `:fire` (space pressed), `:fire-held` (space held), `:toggle-map`, `:toggle-pause`, `:toggle-sound`, `:toggle-debug`, `:toggle-help` (h or esc), `:reload`, `:about-face`, `:action`, `:select-weapon1-5`, `:save`, `:load`, `:open-settings` (o), and `:nav-up` / `:nav-down` / `:nav-left` / `:nav-right`.
 
 F5 / F9 fire in `game-loop` (side-effect layer), not `tick-world`, so pure tick stays effect-free. See [savegame.md](savegame.md).
 
 Edges consumed by: `:fire` -> `tick-shooting`; `:reload` -> ammo refill; `:action` -> secrets; `:select-weapon*` -> `switch-weapon`; toggles -> `handle-toggles`.
 
 Note: `h` and `esc` are aliased to `:toggle-help` (pause-coupled info panel).
+
+The settings overlay (see [settings.md](settings.md)) consumes `:open-settings` (toggle) plus the four nav edges while it is open; `o` / `esc` close it. The arrow edges are read as rising-edge one-shots there (one move per press), distinct from the held-counter movement path.
 
 ## Architecture
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -1,0 +1,33 @@
+# Settings
+
+Player-configurable options: bg-music volume, sfx volume, the default minimap state, and the default difficulty. Persisted to `$HOME/.phel-doom-settings.json` (plain JSON, inspect or wipe by hand) so choices survive restarts.
+
+## Layers
+
+- `src/core/settings.phel` (pure): the data model. Defaults, `coerce-settings` (clamp + validate loaded values), cursor movement (`move-cursor`), value adjustment (`adjust`), and the percent -> playback-scalar mappings (`music-volume`, `sfx-scalar`).
+- `src/io/settings.phel` (io): `load-settings` / `save-settings!`. Mirrors `io/scores`: load + save errors are swallowed so a bad file never blocks the game. Difficulty is stored as a bare string and keyword-ised on the way in.
+- `commands/play.phel`: wires the page into the start menu + the in-game overlay and applies the volumes to `io/sound` + `io/ambient`.
+
+## Fields
+
+| Field | Kind | Values | Effect |
+|-------|------|--------|--------|
+| Music | volume | 0..100% (step 10) | Drone `afplay -v` level. 0% stops the bed. 60% = 0.30, the historical default. |
+| SFX | volume | 0..100% (step 10) | Global multiplier on every `play-sfx!` event volume. 0% mutes sfx without touching the N toggle. |
+| Minimap | toggle | on / off | Default `:show-map` at run start; editing it live updates the current frame. |
+| Difficulty | enum | easy / normal / hard / nightmare | Default for the run. `--difficulty` on the CLI overrides it. |
+
+Volumes map through `core/settings`: `music-volume` = `(pct / 100) * music-ceiling` (ceiling 0.5 so a maxed bed never masks footsteps); `sfx-scalar` = `pct / 100`.
+
+## Reaching the page
+
+- Start menu: press `s` to open the settings screen, edit, then `o` / `esc` to return.
+- In game: press `o` to open the overlay. The game freezes (like the H info menu) while it is up.
+
+Navigation: `up` / `down` move the cursor, `left` / `right` adjust the selected field, `o` / `esc` close. Volume + minimap edits take effect immediately; difficulty applies from the next run (it is baked per level at build time). Closing persists the file.
+
+The settings map rides on the world (`:settings` / `:settings-cursor` / `:settings?`) so `frame-stats` can paint it and edits carry across level cuts.
+
+## Platform note
+
+Volume control rides on `afplay -v`, which is macOS-only. `paplay` / `aplay` / `play` ignore `-v`, so on other hosts the sliders still persist and the N sound toggle still works, but moving a volume slider does not change the audible level.

--- a/src/commands/play.phel
+++ b/src/commands/play.phel
@@ -15,8 +15,10 @@
   (:require phel-doom.core.enemy    :refer [advance tick-scare rear-attacker?])
   (:require phel-doom.core.projectile :refer [tick-projectiles])
   (:require phel-doom.core.weapons  :refer [effective-reserve-cap give-weapon switch-weapon weapon-spec weapon-order weapons])
-  (:require phel-doom.io.sound    :refer [play-sfx! mute-for!])
-  (:require phel-doom.io.ambient  :refer [start-ambient! stop-ambient! sync-ambient!])
+  (:require phel-doom.io.sound    :refer [play-sfx! mute-for! set-sfx-scalar!])
+  (:require phel-doom.io.ambient  :refer [start-ambient! stop-ambient! sync-ambient! set-music-volume!])
+  (:require phel-doom.core.settings :refer [adjust move-cursor field-at music-volume sfx-scalar])
+  (:require phel-doom.io.settings :refer [load-settings save-settings!])
   (:require phel-doom.io.savegame :refer [save-game! load-game])
   (:require phel-doom.io.demo     :as demo)
   (:require phel-doom.core.rng    :as rng)
@@ -25,7 +27,7 @@
   (:require phel-doom.io.scores   :refer [update-scores!])
   (:require phel-doom.io.render   :refer [render! clear-screen
                                           read-perf-snapshot
-                                          render-start-menu
+                                          render-start-menu render-settings!
                                           render-death-screen render-victory-screen])
   (:require phel-doom.io.input    :refer [init-input! restore! drain-keys]))
 
@@ -106,6 +108,56 @@
                           (assoc :paused (not (:help? after-debug))))
                       after-debug)]
     (if (:about-face edges) (about-face after-help) after-help)))
+
+;; =====================================================================
+;; § Settings overlay (issue #107)
+;;
+;; The options page freezes the game (like the H info menu) and routes
+;; the arrow edges to cursor + value navigation. Volume changes apply
+;; live through the io/sound + io/ambient atoms; the minimap default
+;; drives :show-map immediately. Settings live on the world under
+;; :settings / :settings-cursor / :settings? so frame-stats can paint
+;; them and they carry across level cuts; close persists to disk.
+;; =====================================================================
+
+(defn- apply-audio-settings!
+  "Push the current settings' volumes into the sfx + ambient layers."
+  [settings]
+  (set-sfx-scalar!   (sfx-scalar settings))
+  (set-music-volume! (music-volume settings)))
+
+(defn- open-settings
+  "Enter the options overlay: freeze the frame and reset the cursor."
+  [world]
+  (assoc world :settings? true :paused true :settings-cursor 0))
+
+(defn- close-settings!
+  "Leave the overlay, persist the settings to disk, and unfreeze."
+  [world]
+  (save-settings! (:settings world))
+  (assoc world :settings? false :paused false))
+
+(defn- step-settings!
+  "Apply one frame of overlay navigation: up/down move the cursor,
+   left/right adjust the selected field. Volume edits take effect
+   immediately; the minimap field mirrors into :show-map so the change
+   is visible the moment it's made."
+  [world edges]
+  (let [cur       (or (:settings-cursor world) 0)
+        cur'      (cond
+                    (:nav-up edges)   (move-cursor cur -1)
+                    (:nav-down edges) (move-cursor cur 1)
+                    :else             cur)
+        fkey      (:key (field-at cur'))
+        adjust?   (or (:nav-left edges) (:nav-right edges))
+        dir       (if (:nav-right edges) 1 -1)
+        settings  (:settings world)
+        settings' (if adjust? (adjust settings fkey dir) settings)]
+    (when adjust? (apply-audio-settings! settings'))
+    (assoc world
+           :settings-cursor cur'
+           :settings        settings'
+           :show-map        (boolean (:minimap settings')))))
 
 (defn- boss-down?
   "True on a boss-locked level once the cyberdemon is dead — combat
@@ -623,7 +675,12 @@
    ;; can branch.
    :enemy                (or (:enemy world) :imp)
    :save-flash-secs      (or (:save-flash-secs world) 0.0)
-   :save-flash-msg       (:save-flash-msg world)})
+   :save-flash-msg       (:save-flash-msg world)
+   ;; Settings overlay (issue #107): the render layer paints the box
+   ;; from these when :settings? is set.
+   :settings?            (boolean (:settings? world))
+   :settings             (:settings world)
+   :settings-cursor      (or (:settings-cursor world) 0)})
 
 (defn- ms-since
   "Whole-millisecond delta between two microtime samples. Args tagged
@@ -681,6 +738,9 @@
      ;; reset every level cut.
      :show-map      (boolean (:show-map world))
      :sound-on      (boolean (:sound-on world))
+     ;; Settings edited mid-run carry to the next level so the options
+     ;; page keeps showing the player's current choices.
+     :settings      (:settings world)
      :survived-s    (php/intval (php/- now t-start))}))
 
 (defn- play-door-sfx [world]
@@ -773,29 +833,52 @@
               ms        (or (:ms frame) live-ms)
               now-keys  (key-states keys)
               edges     (rising-edges now-keys prev-keys)
-              ticked    (tick-world world keys (php// ms 1000.0) edges)
-              ;; F5 / F9 quick-save / load run here (file IO), outside
-              ;; the pure tick. Load swaps the whole world; both stamp a
-              ;; brief HUD flash so the player sees it took.
-              world'    (handle-save-load ticked edges)]
-          (when (and (:heartbeat-tick? world') (:sound-on world'))
-            (play-sfx! :heartbeat 0.35))
-          (when (and (:silence-tick? world') (:sound-on world'))
-            (mute-for! 0.4))
-          ;; N toggled sound this frame: start / stop the ambient drone
-          ;; to match. Comparing the flag (not the edge) also catches
-          ;; any other path that flips :sound-on.
-          (when (php/!== (:sound-on world) (:sound-on world'))
-            (sync-ambient! (:sound-on world')))
+              ;; ESC has its own edge here (rising-edges folds it into
+              ;; :toggle-help); the settings overlay uses it to close.
+              esc-edge  (and (:esc now-keys) (not (:esc prev-keys)))
+              open?     (boolean (:settings? world))]
           (cond
-            (:end? frame)              :quit
-            (str/contains? keys "q")   :quit
-            (php/<= (:lives world') 0) (result-game-over world' t-start now)
-            (on-door? world')          (door-result      world' t-start now)
-            :else                      (recur world' now ms
-                                              (fps-from-ms ms)
-                                              now-keys
-                                              [rows cols])))))))
+            (:end? frame)                     :quit
+            (str/contains? keys "q")          :quit
+
+            ;; --- Settings overlay: open / navigate / close. While it's
+            ;; up the game is frozen (no tick), so movement + AI hold.
+            (or open? (:open-settings edges))
+            (let [world' (cond
+                           (and open? (or (:open-settings edges) esc-edge))
+                           (close-settings! world)
+
+                           (not open?)
+                           (open-settings world)
+
+                           :else
+                           (step-settings! world edges))]
+              (recur world' now ms (fps-from-ms ms) now-keys [rows cols]))
+
+            ;; --- Normal gameplay frame.
+            :else
+            (let [ticked (tick-world world keys (php// ms 1000.0) edges)
+                  ;; F5 / F9 quick-save / load run here (file IO),
+                  ;; outside the pure tick. Load swaps the whole world;
+                  ;; both stamp a brief HUD flash so the player sees it
+                  ;; took.
+                  world' (handle-save-load ticked edges)]
+              (when (and (:heartbeat-tick? world') (:sound-on world'))
+                (play-sfx! :heartbeat 0.35))
+              (when (and (:silence-tick? world') (:sound-on world'))
+                (mute-for! 0.4))
+              ;; N toggled sound this frame: start / stop the ambient
+              ;; drone to match. Comparing the flag (not the edge) also
+              ;; catches any other path that flips :sound-on.
+              (when (php/!== (:sound-on world) (:sound-on world'))
+                (sync-ambient! (:sound-on world')))
+              (cond
+                (php/<= (:lives world') 0) (result-game-over world' t-start now)
+                (on-door? world')          (door-result      world' t-start now)
+                :else                      (recur world' now ms
+                                                  (fps-from-ms ms)
+                                                  now-keys
+                                                  [rows cols])))))))))
 
 ;; =====================================================================
 ;; § End screens (death / victory)
@@ -883,7 +966,7 @@
    (from --level / -l) sets where the run begins — 1..num-levels,
    clamped. Death + retry reset to L1 (the start-level only seeds
    the initial loop entry)."
-  [diff god? armory? full-map? start-level init-seed]
+  [diff god? armory? full-map? start-level init-seed init-settings]
   (loop [level       (php/max 1 (php/min num-levels (or start-level 1)))
          lives       max-lives
          carry-kills 0
@@ -900,8 +983,12 @@
          ;; default (pistol).
          weapon      nil
          wstate      nil
-         show-map?   false
-         sound-on?   true]
+         ;; Minimap starts in the settings-page default; sound starts on.
+         show-map?   (boolean (:minimap init-settings))
+         sound-on?   true
+         ;; Live settings map carried across levels so the options page
+         ;; reflects mid-run edits; restarts reset to the loaded value.
+         settings    init-settings]
     (rng/seed! seed)
     (let [w0     (build-world level lives bp-level diff owned)
           ;; God mode + carried user toggles + weapon ammo are
@@ -910,7 +997,8 @@
           w1     (if god? (assoc w0 :god? true) w0)
           w1a    (if armory? (assoc w1 :armory? true) w1)
           w1b    (if full-map? (assoc w1a :full-map? true) w1a)
-          w2     (assoc w1b :show-map show-map? :sound-on sound-on?)
+          w2     (assoc w1b :show-map show-map? :sound-on sound-on?
+                        :settings settings :settings? false :settings-cursor 0)
           w3     (if (nil? weapon)
                    w2
                    (let [stash  (or wstate (:weapon-state w2))
@@ -940,14 +1028,15 @@
                  (or (:weapon result) :pistol)
                  (or (:weapon-state result) {})
                  (boolean (:show-map result))
-                 (boolean (:sound-on result))))
+                 (boolean (:sound-on result))
+                 (or (:settings result) init-settings)))
 
         (and (map? result) (:victory result))
         (let [[k t]           (carry-on carry-kills carry-time result)
               [kind new-seed] (handle-end victory-loop k t result seed true)]
           (cond
-            (= kind :fresh) (recur 1 max-lives 0 0 (rng/fresh-seed) 0 #{:pistol} nil nil true true)
-            (= kind :same)  (recur 1 max-lives 0 0 new-seed 0 #{:pistol} nil nil true true)
+            (= kind :fresh) (recur 1 max-lives 0 0 (rng/fresh-seed) 0 #{:pistol} nil nil true true init-settings)
+            (= kind :same)  (recur 1 max-lives 0 0 new-seed 0 #{:pistol} nil nil true true init-settings)
             :else           nil))
 
         (and (map? result) (:game-over result))
@@ -956,10 +1045,10 @@
               died-on         (or (:level result) 1)]
           (cond
             ;; r: try the level you died on again with a fresh map.
-            (= kind :fresh) (recur died-on max-lives 0 0 (rng/fresh-seed) 0 #{:pistol} nil nil true true)
+            (= kind :fresh) (recur died-on max-lives 0 0 (rng/fresh-seed) 0 #{:pistol} nil nil true true init-settings)
             ;; R: replay the exact level you died on (same seed + same
             ;; level number reproduces identical geometry + enemies).
-            (= kind :same)  (recur died-on max-lives 0 0 new-seed 0 #{:pistol} nil nil true true)
+            (= kind :same)  (recur died-on max-lives 0 0 new-seed 0 #{:pistol} nil nil true true init-settings)
             :else           nil))
 
         :else
@@ -971,24 +1060,80 @@
   (println "  written in \e[1mPhel Lang\e[0m  https://phel-lang.org/")
   (println))
 
+(defn- settings-screen!
+  "Interactive settings sub-loop reached from the start menu (s).
+   Renders the standalone options screen and edits `settings0` until
+   the player presses o/esc to go back. Volume edits apply live; the
+   final map is persisted and returned so the caller starts the run
+   with the player's choices."
+  [settings0]
+  (loop [settings settings0
+         cursor   0
+         prev     initial-key-snapshot
+         dims     [0 0]]
+    (let [[rows cols] (term-size)]
+      (redraw-if-resized dims rows cols)
+      (render-settings! cols rows settings cursor)
+      (php/usleep menu-frame-us)
+      (let [keys     (drain-keys)
+            now      (key-states keys)
+            edges    (rising-edges now prev)
+            esc-edge (and (:esc now) (not (:esc prev)))]
+        (if (or (:open-settings edges) esc-edge)
+          (do (save-settings! settings)
+              (apply-audio-settings! settings)
+              settings)
+          (let [cursor'   (cond
+                            (:nav-up edges)   (move-cursor cursor -1)
+                            (:nav-down edges) (move-cursor cursor 1)
+                            :else             cursor)
+                fkey      (:key (field-at cursor'))
+                adjust?   (or (:nav-left edges) (:nav-right edges))
+                dir       (if (:nav-right edges) 1 -1)
+                settings' (if adjust? (adjust settings fkey dir) settings)]
+            (when adjust? (apply-audio-settings! settings'))
+            (recur settings' cursor' now [rows cols])))))))
+
 (defn- show-start-menu!
-  "Block until the user presses any key on the start screen. Re-draws
-   each frame so terminal resizes don't leave a stale half-painted box."
-  []
-  (loop [dims [0 0]]
+  "Block on the start screen until the player starts or quits. Re-draws
+   each frame so terminal resizes don't leave a stale half-painted box.
+   `s` opens the settings screen (returning here afterwards); `q` quits;
+   any other key starts the run. Returns :quit, or the (possibly
+   edited) settings map to start with."
+  [settings0]
+  (loop [settings settings0
+         dims     [0 0]]
     (let [[rows cols] (term-size)]
       (redraw-if-resized dims rows cols)
       (render-start-menu cols rows)
       (php/usleep menu-frame-us)
       (let [keys (drain-keys)]
-        (if (= keys "")
-          (recur [rows cols])
-          (when (str/contains? keys "q")
-            :quit))))))
+        (cond
+          (= keys "")              (recur settings [rows cols])
+          (str/contains? keys "q") :quit
+          ;; 's' opens settings, then drops back to the menu so the
+          ;; player still has to press a key to start.
+          (str/contains? keys "s") (recur (settings-screen! settings) [rows cols])
+          :else                    settings)))))
+
+(def difficulty-keywords
+  "Valid --difficulty values; an explicit CLI flag must name one of
+   these to override the settings-page default."
+  #{:easy :normal :hard :nightmare})
+
+(defn- resolve-difficulty
+  "Pick the run difficulty: an explicit, valid --difficulty CLI value
+   wins; otherwise fall back to the settings-page default. `cli-raw` is
+   the raw option string (\"\" when unset)."
+  [cli-raw settings]
+  (let [d (and cli-raw (not (= cli-raw "")) (keyword cli-raw))]
+    (if (contains? difficulty-keywords d)
+      d
+      (:difficulty settings))))
 
 (defn- run-play [ctx]
   (init-input!)
-  (let [diff        (cli/opt ctx "difficulty")
+  (let [diff-raw    (cli/opt ctx "difficulty")
         god?        (cli/opt ctx "god")
         armory?     (cli/opt ctx "armory")
         full-map?   (cli/opt ctx "full-map")
@@ -1008,21 +1153,31 @@
                       (demo/read-demo demo-path))
         ;; Replay reproduces the recorded seed; record / normal start
         ;; from a fresh seed (recorded so the run can be replayed).
-        init-seed   (if replay (:seed replay) (rng/fresh-seed))]
+        init-seed   (if replay (:seed replay) (rng/fresh-seed))
+        ;; Persisted settings (volumes + minimap / difficulty defaults).
+        ;; Apply the volumes up front so the start menu + ambient drone
+        ;; honour them before the first frame.
+        settings0   (load-settings)]
+    (apply-audio-settings! settings0)
     (cond
       replay  (demo/start-replay! (:seed replay) (:frames replay))
       record? (demo/start-record! init-seed)
       :else   (demo/reset-off!))
-    (if (and (nil? replay) (= (show-start-menu!) :quit))
-      (do (restore!)
+    ;; Replay skips the menu (and its settings edits); a normal run goes
+    ;; through the start menu, which may edit + persist the settings.
+    (let [menu (if replay settings0 (show-start-menu! settings0))]
+      (if (= menu :quit)
+        (do (restore!)
+            (clear-screen)
+            0)
+        (let [settings menu
+              diff     (resolve-difficulty diff-raw settings)]
           (clear-screen)
-          0)
-      (do (clear-screen)
           ;; Ambient drone runs for the whole gameplay session (across
           ;; levels + end screens). N-toggle starts/stops it mid-run;
           ;; teardown always stops it so no loop process is orphaned.
           (start-ambient!)
-          (run-levels diff god? armory? full-map? lv init-seed)
+          (run-levels diff god? armory? full-map? lv init-seed settings)
           (stop-ambient!)
           (when record? (demo/save-recording! record-path))
           (demo/reset-off!)
@@ -1030,7 +1185,7 @@
           (clear-screen)
           (cli/success ctx "Thanks for playing.")
           (print-credits)
-          0))))
+          0)))))
 
 (def play-command
   {:name "play"
@@ -1040,9 +1195,8 @@
    :opts [{:name    "difficulty"
            :short   "d"
            :mode    :optional
-           :doc     "easy | normal | hard | nightmare (default normal)"
-           :default "normal"
-           :coerce  :keyword}
+           :doc     "easy | normal | hard | nightmare (overrides the settings-page default)"
+           :default ""}
           {:name "god"
            :short "g"
            :mode  :none

--- a/src/commands/play.phel
+++ b/src/commands/play.phel
@@ -17,7 +17,7 @@
   (:require phel-doom.core.weapons  :refer [effective-reserve-cap give-weapon switch-weapon weapon-spec weapon-order weapons])
   (:require phel-doom.io.sound    :refer [play-sfx! mute-for! set-sfx-scalar!])
   (:require phel-doom.io.ambient  :refer [start-ambient! stop-ambient! sync-ambient! set-music-volume!])
-  (:require phel-doom.core.settings :refer [adjust move-cursor field-at music-volume sfx-scalar])
+  (:require phel-doom.core.settings :refer [navigate music-volume sfx-scalar valid-difficulty?])
   (:require phel-doom.io.settings :refer [load-settings save-settings!])
   (:require phel-doom.io.savegame :refer [save-game! load-game])
   (:require phel-doom.io.demo     :as demo)
@@ -126,38 +126,41 @@
   (set-sfx-scalar!   (sfx-scalar settings))
   (set-music-volume! (music-volume settings)))
 
+(defn- nav-dirs
+  "Translate the nav rising-edges into the [cursor-dir value-dir] pair
+   core/settings.navigate expects (-1 / 0 / +1 each)."
+  [edges]
+  [(cond (:nav-up edges)   -1 (:nav-down edges)  1 :else 0)
+   (cond (:nav-left edges) -1 (:nav-right edges) 1 :else 0)])
+
 (defn- open-settings
-  "Enter the options overlay: freeze the frame and reset the cursor."
+  "Enter the options overlay and freeze the frame. The cursor keeps its
+   previous position (build-world seeds it at 0) so re-opening lands on
+   the field the player last touched."
   [world]
-  (assoc world :settings? true :paused true :settings-cursor 0))
+  (assoc world :settings? true :paused true))
 
 (defn- close-settings!
-  "Leave the overlay, persist the settings to disk, and unfreeze."
+  "Leave the overlay, persist the settings to disk, and unfreeze. Audio
+   was already pushed live on each adjustment, so close only saves."
   [world]
   (save-settings! (:settings world))
   (assoc world :settings? false :paused false))
 
 (defn- step-settings!
-  "Apply one frame of overlay navigation: up/down move the cursor,
-   left/right adjust the selected field. Volume edits take effect
-   immediately; the minimap field mirrors into :show-map so the change
-   is visible the moment it's made."
+  "Apply one frame of overlay navigation via core/settings.navigate:
+   up/down move the cursor, left/right adjust the selected field. Volume
+   edits take effect immediately; the minimap field mirrors into
+   :show-map so the change is visible the moment it's made."
   [world edges]
-  (let [cur       (or (:settings-cursor world) 0)
-        cur'      (cond
-                    (:nav-up edges)   (move-cursor cur -1)
-                    (:nav-down edges) (move-cursor cur 1)
-                    :else             cur)
-        fkey      (:key (field-at cur'))
-        adjust?   (or (:nav-left edges) (:nav-right edges))
-        dir       (if (:nav-right edges) 1 -1)
-        settings  (:settings world)
-        settings' (if adjust? (adjust settings fkey dir) settings)]
-    (when adjust? (apply-audio-settings! settings'))
+  (let [[cursor-dir value-dir]              (nav-dirs edges)
+        {:keys [cursor settings adjusted?]}
+        (navigate (:settings world) (or (:settings-cursor world) 0) cursor-dir value-dir)]
+    (when adjusted? (apply-audio-settings! settings))
     (assoc world
-           :settings-cursor cur'
-           :settings        settings'
-           :show-map        (boolean (:minimap settings')))))
+           :settings-cursor cursor
+           :settings        settings
+           :show-map        (boolean (:minimap settings)))))
 
 (defn- boss-down?
   "True on a boss-locked level once the cyberdemon is dead — combat
@@ -833,8 +836,10 @@
               ms        (or (:ms frame) live-ms)
               now-keys  (key-states keys)
               edges     (rising-edges now-keys prev-keys)
-              ;; ESC has its own edge here (rising-edges folds it into
-              ;; :toggle-help); the settings overlay uses it to close.
+              ;; ESC closes the settings overlay. rising-edges only folds
+              ;; ESC into :toggle-help (the h-aliased info panel), so the
+              ;; overlay needs its own naked-ESC edge to close on ESC
+              ;; without also toggling help.
               esc-edge  (and (:esc now-keys) (not (:esc prev-keys)))
               open?     (boolean (:settings? world))]
           (cond
@@ -1078,21 +1083,18 @@
       (let [keys     (drain-keys)
             now      (key-states keys)
             edges    (rising-edges now prev)
+            ;; ESC closes the page directly. We can't use the :toggle-help
+            ;; edge here: that aliases h+esc for the in-game info panel,
+            ;; which has nothing to do with the options screen.
             esc-edge (and (:esc now) (not (:esc prev)))]
         (if (or (:open-settings edges) esc-edge)
-          (do (save-settings! settings)
-              (apply-audio-settings! settings)
-              settings)
-          (let [cursor'   (cond
-                            (:nav-up edges)   (move-cursor cursor -1)
-                            (:nav-down edges) (move-cursor cursor 1)
-                            :else             cursor)
-                fkey      (:key (field-at cursor'))
-                adjust?   (or (:nav-left edges) (:nav-right edges))
-                dir       (if (:nav-right edges) 1 -1)
-                settings' (if adjust? (adjust settings fkey dir) settings)]
-            (when adjust? (apply-audio-settings! settings'))
-            (recur settings' cursor' now [rows cols])))))))
+          ;; Volumes were applied live on each adjust; close just saves.
+          (save-settings! settings)
+          (let [[cursor-dir value-dir]              (nav-dirs edges)
+                {:keys [cursor settings adjusted?]}
+                (navigate settings cursor cursor-dir value-dir)]
+            (when adjusted? (apply-audio-settings! settings))
+            (recur settings cursor now [rows cols])))))))
 
 (defn- show-start-menu!
   "Block on the start screen until the player starts or quits. Re-draws
@@ -1116,18 +1118,14 @@
           (str/contains? keys "s") (recur (settings-screen! settings) [rows cols])
           :else                    settings)))))
 
-(def difficulty-keywords
-  "Valid --difficulty values; an explicit CLI flag must name one of
-   these to override the settings-page default."
-  #{:easy :normal :hard :nightmare})
-
 (defn- resolve-difficulty
   "Pick the run difficulty: an explicit, valid --difficulty CLI value
    wins; otherwise fall back to the settings-page default. `cli-raw` is
-   the raw option string (\"\" when unset)."
+   the raw option string (\"\" when unset). Validity is checked against
+   core/settings, the single source of truth for the difficulty list."
   [cli-raw settings]
   (let [d (and cli-raw (not (= cli-raw "")) (keyword cli-raw))]
-    (if (contains? difficulty-keywords d)
+    (if (valid-difficulty? d)
       d
       (:difficulty settings))))
 

--- a/src/core/settings.phel
+++ b/src/core/settings.phel
@@ -1,0 +1,134 @@
+(ns phel-doom.core.settings)
+
+;; ---------------------------------------------------------------------
+;; Settings model (pure).
+;;
+;; The player-facing options page: bg-music volume, sfx volume, the
+;; default minimap state, and the default difficulty. Volumes are
+;; stored as 0..100 percentages (step 10) so the slider math is integer
+;; and the persisted JSON is human-readable.
+;;
+;; This namespace owns the DATA: defaults, coercion of loaded values,
+;; cursor movement, value adjustment, and the percent -> playback-scalar
+;; mapping. It performs no IO: io/settings loads + saves the map, and
+;; commands/play applies the resulting volumes to io/sound + io/ambient.
+;; ---------------------------------------------------------------------
+
+(def default-settings
+  "Out-of-the-box options. Music sits under the sfx by default (the
+   drone is a bed, not a lead). Minimap starts hidden; difficulty
+   normal."
+  {:music 60 :sfx 90 :minimap false :difficulty :normal})
+
+(def difficulty-choices
+  "Difficulty keywords the enum field cycles through, easiest first.
+   Mirrors the --difficulty CLI option."
+  [:easy :normal :hard :nightmare])
+
+(def pct-step
+  "Percent a volume field moves per left/right press."
+  10)
+
+(def music-ceiling
+  "afplay -v value the drone plays at when Music is 100%. Capped below
+   1.0 so a maxed bed still never masks footsteps / shots. 60% (the
+   default) maps to 0.30, matching the old hardcoded ambient volume."
+  0.5)
+
+(def page-fields
+  "Ordered field descriptors driving both navigation and rendering.
+   `:kind` selects the adjust + paint behaviour (:pct slider, :bool
+   toggle, :enum cycle)."
+  [{:key :music      :label "Music"      :kind :pct}
+   {:key :sfx        :label "SFX"        :kind :pct}
+   {:key :minimap    :label "Minimap"    :kind :bool}
+   {:key :difficulty :label "Difficulty" :kind :enum}])
+
+(defn field-count
+  "How many rows the settings page has."
+  []
+  (count page-fields))
+
+(defn field-at
+  "Field descriptor at cursor index `idx`, or nil when out of range."
+  [idx]
+  (get page-fields idx))
+
+(defn- clamp-pct [n]
+  (php/max 0 (php/min 100 (php/intval n))))
+
+(defn- index-of [v coll]
+  (loop [i 0 cs coll]
+    (cond
+      (empty? cs)      -1
+      (= (first cs) v) i
+      :else            (recur (php/+ i 1) (rest cs)))))
+
+(defn- valid-difficulty? [d]
+  (php/>= (index-of d difficulty-choices) 0))
+
+(defn coerce-settings
+  "Normalise a loaded (or partial) settings map against the defaults:
+   clamp volumes into 0..100, force minimap to a bool, and fall back to
+   :normal for an unrecognised difficulty. Always returns a complete,
+   valid map, so callers downstream never have to re-validate."
+  [raw]
+  (let [m (or raw {})
+        d (get m :difficulty (:difficulty default-settings))]
+    {:music      (clamp-pct (get m :music (:music default-settings)))
+     :sfx        (clamp-pct (get m :sfx (:sfx default-settings)))
+     :minimap    (boolean (get m :minimap (:minimap default-settings)))
+     :difficulty (if (valid-difficulty? d) d :normal)}))
+
+(defn move-cursor
+  "Step the page cursor by `dir` (+1 down / -1 up), wrapping at both
+   ends so the selection never falls off the page."
+  [idx dir]
+  (let [n (field-count)]
+    (php/% (php/+ (php/+ idx dir) n) n)))
+
+(defn- cycle-difficulty [cur dir]
+  (let [n  (count difficulty-choices)
+        i  (index-of cur difficulty-choices)
+        i' (if (php/< i 0) 0 i)]
+    (get difficulty-choices (php/% (php/+ (php/+ i' dir) n) n))))
+
+(defn- field-kind [field-key]
+  (loop [fs page-fields]
+    (cond
+      (empty? fs)                     nil
+      (= (:key (first fs)) field-key) (:kind (first fs))
+      :else                           (recur (rest fs)))))
+
+(defn adjust
+  "Adjust `field-key` on `settings` by `dir` (+1 right / -1 left):
+   volumes move by `pct-step` (clamped), minimap toggles (dir ignored),
+   difficulty cycles. Returns the new settings map; an unknown field
+   leaves it untouched."
+  [settings field-key dir]
+  (let [kind (field-kind field-key)]
+    (cond
+      (= kind :pct)
+      (update settings field-key
+              (fn [v] (clamp-pct (php/+ (php/intval v) (php/* dir pct-step)))))
+
+      (= kind :bool)
+      (update settings field-key not)
+
+      (= kind :enum)
+      (update settings field-key (fn [v] (cycle-difficulty v dir)))
+
+      :else          settings)))
+
+(defn music-volume
+  "afplay -v playback value [0.0, music-ceiling] for the current Music
+   percent. 0% returns 0.0 (the ambient layer treats that as 'stop the
+   drone')."
+  [settings]
+  (php/* (php// (php/intval (:music settings)) 100.0) music-ceiling))
+
+(defn sfx-scalar
+  "Per-event playback scalar [0.0, 1.0] for the current SFX percent.
+   io/sound multiplies each effect's volume by this."
+  [settings]
+  (php// (php/intval (:sfx settings)) 100.0))

--- a/src/core/settings.phel
+++ b/src/core/settings.phel
@@ -64,7 +64,11 @@
       (= (first cs) v) i
       :else            (recur (php/+ i 1) (rest cs)))))
 
-(defn- valid-difficulty? [d]
+(defn valid-difficulty?
+  "True when `d` is one of the difficulty-choices keywords. Exposed so
+   the CLI override path can validate a --difficulty value against the
+   single source of truth."
+  [d]
   (php/>= (index-of d difficulty-choices) 0))
 
 (defn coerce-settings
@@ -119,6 +123,21 @@
       (update settings field-key (fn [v] (cycle-difficulty v dir)))
 
       :else          settings)))
+
+(defn navigate
+  "Apply one page-navigation step. `cursor-dir` moves the selection
+   (-1 up, +1 down, 0 none, wrapping); `value-dir` adjusts the selected
+   field (-1 left, +1 right, 0 none). Returns
+   `{:cursor _ :settings _ :adjusted? _}` so the caller can push the
+   new volumes only when something actually changed. Pure: the live
+   audio/minimap effects stay in the caller (commands/play)."
+  [settings cursor cursor-dir value-dir]
+  (let [cursor'   (if (php/=== cursor-dir 0) cursor (move-cursor cursor cursor-dir))
+        adjusted? (not (php/=== value-dir 0))
+        settings' (if adjusted?
+                    (adjust settings (:key (field-at cursor')) value-dir)
+                    settings)]
+    {:cursor cursor' :settings settings' :adjusted? adjusted?}))
 
 (defn music-volume
   "afplay -v playback value [0.0, music-ceiling] for the current Music

--- a/src/glue/controls.phel
+++ b/src/glue/controls.phel
@@ -287,7 +287,8 @@
 (def initial-key-snapshot
   "First-frame snapshot — nothing held yet."
   {:m false :sp false :p false :n false :e false :f false :f3 false :r false :h false
-   :esc false :k1 false :k2 false :k3 false :k4 false})
+   :esc false :k1 false :k2 false :k3 false :k4 false
+   :o false :up false :down false :left false :right false})
 
 (defn- f3-pressed? [keys]
   ;; F3 across terminals: xterm/macOS Terminal/iTerm2 send `\eOR`;
@@ -346,6 +347,17 @@
     (or (str/contains? stripped plain)
         (= 1 (php/preg_match kitty-re keys)))))
 
+(defn- arrow-pressed?
+  "True when an arrow key with CSI final byte `letter` (A=up B=down
+   C=right D=left) is present in `keys` this frame. Matches the legacy
+   form (`\\e[A`), modified arrows (`\\e[1;2A`), and the kitty-enhanced
+   arrow form (`\\e[1;m:eD`) in one shot — the settings page consumes
+   these as rising-edge menu navigation. Release events (`:3`) are
+   harmless here: a held arrow keeps the key true so no new edge fires
+   until it's let go and pressed again."
+  [keys letter]
+  (= 1 (php/preg_match (str "/\\x1b\\[[\\d;:]*" letter "/") keys)))
+
 (defn key-states
   "Which of the tracked one-shot keys appear in `keys` this frame.
    Codes are ASCII codepoints for the matching lowercase letter /
@@ -368,7 +380,14 @@
    :k2 (key-pressed? keys "2" 50)
    :k3 (key-pressed? keys "3" 51)
    :k4 (key-pressed? keys "4" 52)
-   :k5 (key-pressed? keys "5" 53)})
+   :k5 (key-pressed? keys "5" 53)
+   ;; Settings page: 'o' opens the options overlay; the arrows drive
+   ;; cursor + slider navigation while it's open.
+   :o     (key-pressed? keys "o" 111)
+   :up    (arrow-pressed? keys "A")
+   :down  (arrow-pressed? keys "B")
+   :right (arrow-pressed? keys "C")
+   :left  (arrow-pressed? keys "D")})
 
 (defn rising-edges
   "Build the edges map tick consumes — truthy only for keys that just
@@ -404,4 +423,12 @@
    ;; F5 quick-save / F9 quick-load (issue #63). Handled in game-loop
    ;; (file IO), not tick-world, so the pure tick stays effect-free.
    :save           (and (:f5 now) (not (:f5 prev)))
-   :load           (and (:f9 now) (not (:f9 prev)))})
+   :load           (and (:f9 now) (not (:f9 prev)))
+   ;; Settings page (issue #107). `:open-settings` toggles the options
+   ;; overlay; the four nav edges step the cursor (up/down) and adjust
+   ;; the selected value (left/right) one move per press.
+   :open-settings  (and (:o now)    (not (:o prev)))
+   :nav-up         (and (:up now)   (not (:up prev)))
+   :nav-down       (and (:down now) (not (:down prev)))
+   :nav-left       (and (:left now) (not (:left prev)))
+   :nav-right      (and (:right now) (not (:right prev)))})

--- a/src/io/ambient.phel
+++ b/src/io/ambient.phel
@@ -32,11 +32,13 @@
    the sfx, not over them."
   0.18)
 
-(def afplay-volume
-  "Playback volume passed to afplay's -v (other players ignore it).
-   Quieter than the synthesised gain so the bed never masks footsteps
-   / shots."
-  "0.30")
+(def volume
+  "Current afplay -v playback value for the drone (other players ignore
+   it). Quieter than the synthesised gain so the bed never masks
+   footsteps / shots. Default 0.30 matches the historical hardcoded
+   level (= 60% Music in the settings page). set-music-volume! drives
+   it live from the options page; 0.0 means 'no bed'."
+  (atom 0.30))
 
 (def proc
   "Session state for the loop process: `:pid` of the backgrounded
@@ -107,18 +109,22 @@
    the file. `& echo $!` prints the shell's PID so the caller can track
    + kill it."
   [player path ^int ppid]
-  (let [vol (if (php/=== player "afplay") (str " -v " afplay-volume) "")]
+  (let [vol (if (php/=== player "afplay")
+              (str " -v " (php/number_format @volume 3))
+              "")]
     (str "sh -c 'while kill -0 " ppid " 2>/dev/null; do "
          player vol " " (php/escapeshellarg path) " >/dev/null 2>&1; "
          "done' >/dev/null 2>&1 & echo $!")))
 
 (defn start-ambient!
   "Begin the drone loop if it isn't already running. No-op under
-   PHEL_DOOM_SILENT, when no audio player is on PATH, or when the WAV
-   can't be written. Idempotent: a second call while running does
+   PHEL_DOOM_SILENT, when no audio player is on PATH, when the WAV
+   can't be written, or when the music volume is 0 (the player muted
+   the bed in settings). Idempotent: a second call while running does
    nothing."
   []
   (when (and (not (silent?))
+             (php/> @volume 0.0)
              (nil? (:pid @proc)))
     (let [player (audio-player)]
       (when player
@@ -143,6 +149,21 @@
       (php/exec (str "kill " pid " 2>/dev/null"))
       (php/exec (str "pkill -f " (php/escapeshellarg (drone-path)) " 2>/dev/null"))
       (swap! proc assoc :pid nil))))
+
+(defn set-music-volume!
+  "Set the drone playback volume (clamped [0.0, 1.0]) from the settings
+   page. When the drone is already running, restart it so the new -v
+   takes effect immediately: a volume of 0 stops the bed, any positive
+   value relaunches at the new level. When nothing is running, just
+   store the value so the next start-ambient! uses it."
+  [^float v]
+  (let [cv       (php/max 0.0 (php/min 1.0 v))
+        running? (boolean (:pid @proc))]
+    (reset! volume cv)
+    (when running?
+      (stop-ambient!)
+      (when (php/> cv 0.0)
+        (start-ambient!)))))
 
 (defn sync-ambient!
   "Start or stop the drone to match the sound-on flag. Called when the

--- a/src/io/render.phel
+++ b/src/io/render.phel
@@ -3,7 +3,8 @@
   (:require phel-doom.core.engine  :refer [cast-frame max-depth proj-dist])
   (:require phel-doom.core.perf    :refer [render-scale])
   (:require phel-doom.core.map     :refer [find-door-cell])
-  (:require phel-doom.core.weapons :refer [weapon-order weapons]))
+  (:require phel-doom.core.weapons :refer [weapon-order weapons])
+  (:require phel-doom.core.settings :refer [page-fields]))
 
 ;; =====================================================================
 ;; § Hot-loop buffer macros
@@ -1097,6 +1098,7 @@
                         (bord "  1 / 2 / 3 / 4 switch weapon slot")
                         (bord "  m             toggle minimap")
                         (bord "  n             toggle sound")
+                        (bord "  o             settings (volume)")
                         (bord "  F3            debug overlay")
                         (bord "  p             pause / resume")
                         (bord "  h / ESC      close this menu")
@@ -1168,6 +1170,95 @@
           (recur (php/+ i 1)
                  (str acc "\e[" (php/+ row0 i) ";" col0 "H\e[40;97m"
                       (get rows i) "\e[0m")))))))
+
+(def settings-inner-width
+  "Interior character width of each settings-overlay row. Wide enough
+   to fit the longest value (`Difficulty  ◀ nightmare ▶`) plus the
+   nav-hint footer without wrapping."
+  36)
+
+(def settings-slider-cells
+  "Number of slider cells in a volume row; each cell is 10%."
+  10)
+
+(defn- settings-slider
+  "Render a 0..100 percent as a fixed-width filled/empty bar."
+  [pct]
+  (let [filled (php/intdiv (php/max 0 (php/min 100 pct)) 10)
+        empty  (php/- settings-slider-cells filled)]
+    (str (php/str_repeat "█" filled) (php/str_repeat "░" empty))))
+
+(defn- settings-value-str
+  "Visible (colour-free) value cell for a settings row, framed by the
+   ◀ ▶ adjust arrows: a slider + percent for volumes, ON/OFF for the
+   minimap toggle, the difficulty name for the enum."
+  [kind val]
+  (cond
+    (= kind :pct)
+    (str "◀ " (settings-slider (php/intval val)) " ▶ "
+         (php/str_pad (str (php/intval val) "%") 4 " " php/STR_PAD_LEFT))
+
+    (= kind :bool)
+    (if val "◀  ON  ▶" "◀  OFF ▶")
+
+    (= kind :enum)
+    (str "◀ " (name val) " ▶")
+
+    :else          (php/strval val)))
+
+(defn- settings-row
+  "One settings field as a full bordered row. The selected row paints
+   bold yellow with a ▸ marker; others stay plain white. The visible
+   body carries no inline SGR so the trailing pad math (mb_strlen)
+   counts display columns, not escape bytes."
+  [field settings selected? w]
+  (let [k       (:key field)
+        label   (:label field)
+        marker  (if selected? "▸ " "  ")
+        value   (settings-value-str (:kind field) (get settings k))
+        label-w 11
+        labeled (str " " marker label
+                     (php/str_repeat " " (php/max 0 (php/- label-w (php/mb_strlen label)))))
+        body    (str labeled value)
+        sgr     (if selected? "\e[1;93m" "\e[97m")
+        pad     (php/str_repeat " " (php/max 0 (php/- w (php/mb_strlen body))))]
+    (str "│" sgr body "\e[40;97m" pad "│")))
+
+(defn- settings-menu-string
+  "Build the settings / options overlay as one ANSI string with
+   absolute cursor moves. `cursor` is the selected field index. Pure:
+   caller pushes the result into the parts array. Reads the field list
+   from core/settings so the page and the model never drift."
+  [vw vh settings cursor]
+  (let [w           settings-inner-width
+        bar         (php/str_repeat "─" w)
+        blnk        (str "│" (pause-pad "" w) "│")
+        rows-head   [(str "┌" bar "┐")
+                     blnk
+                     (str "│\e[1;93m" (pause-pad "            SETTINGS" w) "\e[40;97m│")
+                     blnk]
+        rows-fields (apply vector
+                           (map-indexed
+                            (fn [i field]
+                              (settings-row field settings (php/=== i cursor) w))
+                            page-fields))
+        rows-foot   [blnk
+                     (str "├" bar "┤")
+                     blnk
+                     (str "│\e[2;97m" (pause-pad "  ↑↓ select   ←→ adjust   o/esc close" w) "\e[22;40;97m│")
+                     blnk
+                     (str "└" bar "┘")]
+        rows        (apply vector (concat rows-head rows-fields rows-foot))
+        cnt         (count rows)
+        col0        (php/max 1 (php/- (php/+ (php/intdiv vw 2) 1)
+                                      (php/intdiv (php/+ w 2) 2)))
+        row0        (php/max 1 (php/intdiv (php/max 1 (php/- vh cnt)) 2))]
+    (loop [i 0 acc ""]
+      (if (php/>= i cnt)
+        acc
+        (recur (php/+ i 1)
+               (str acc "\e[" (php/+ row0 i) ";" col0 "H\e[40;97m"
+                    (get rows i) "\e[0m"))))))
 
 (defn- layout
   "Viewport fills the whole terminal. The minimap is an overlay in the
@@ -2915,6 +3006,12 @@
         ;; pressed H). H + P are independent flags.
         (when (get stats :help?)
           (buf-push p20 (help-menu-string vw vh stats)))
+        ;; Settings overlay sits above everything: while it's open the
+        ;; game is frozen and the options box is the focused surface.
+        (when (get stats :settings?)
+          (buf-push p20 (settings-menu-string vw vh
+                                              (get stats :settings)
+                                              (get stats :settings-cursor))))
         (php/implode "" p20)))))
 
 ;; --- DO NOT swap `print` / `println` for `php/fwrite` in render! ---
@@ -3197,6 +3294,7 @@
                   (pad-visible "    \e[93mr      \e[40;97m   reload" w)
                   (pad-visible "    \e[93m1 2 3  \e[40;97m   switch weapon slot" w)
                   (pad-visible "    \e[93mh      \e[40;97m   info menu (stats + weapons)" w)
+                  (pad-visible "    \e[93mo      \e[40;97m   settings (volume, minimap)" w)
                   (pad-visible "    \e[93mm  n   \e[40;97m   toggle minimap / sound" w)
                   (pad-visible "    \e[93mp F3 q \e[40;97m   pause / debug / quit" w)
                   blank]
@@ -3218,6 +3316,7 @@
                   blank]
         footer   [:sep blank
                   (pad-visible "      \e[2;97mpress any key to start\e[40;97m" w)
+                  (pad-visible "      \e[2;97m\e[93ms\e[2;97m for settings\e[40;97m" w)
                   blank]]
     (apply vector
            (cond
@@ -3266,6 +3365,24 @@
               (buf-push parts (str "\e[" row ";" col0
                                    "H\e[40;97m│" item "\e[40;97m│\e[0m"))))
           (recur (php/+ i 1)))))
+    (print (php/implode "" parts))
+    (php/flush)))
+
+(defn render-settings!
+  "Full-screen wash + centred settings box, for the start-menu options
+   screen (no game frame behind it). `settings` is the live map and
+   `cursor` the selected field index. The in-game overlay reuses the
+   same box via render!'s :settings? branch; this entry just adds the
+   background wash so it reads as a standalone screen."
+  [cols rows settings cursor]
+  (let [parts (buf-mk)
+        wash  "\e[48;5;233m"]
+    (buf-push parts "\e[H")
+    (loop [r 1]
+      (when (php/<= r rows)
+        (buf-push parts (str "\e[" r ";1H" wash (php/str_repeat " " cols)))
+        (recur (php/+ r 1))))
+    (buf-push parts (settings-menu-string cols rows settings cursor))
     (print (php/implode "" parts))
     (php/flush)))
 

--- a/src/io/settings.phel
+++ b/src/io/settings.phel
@@ -46,6 +46,9 @@
    bare keyword name (\"normal\", not \":normal\"). Returns the settings
    so callers can thread it. Swallows write failures."
   [settings]
+  ;; Re-coerce defensively: save-settings! is public, so a caller could
+  ;; hand it a partial / out-of-range map. Clamping here keeps the file
+  ;; on disk always valid, matching what load-settings will accept back.
   (let [s   (coerce-settings settings)
         arr (php/array)]
     (php/aset arr "music"      (:music s))

--- a/src/io/settings.phel
+++ b/src/io/settings.phel
@@ -1,0 +1,56 @@
+(ns phel-doom.io.settings
+  (:require phel-doom.core.settings :refer [coerce-settings default-settings]))
+
+;; ---------------------------------------------------------------------
+;; Settings persistence in $HOME/.phel-doom-settings.json.
+;;
+;; Mirrors io/scores: plain JSON a user can inspect / wipe by hand,
+;; load + save errors swallowed (a bad settings file should never stop
+;; the game from starting — it just falls back to defaults).
+;;
+;; The pure shape + validation lives in core/settings (coerce-settings);
+;; this layer only reads / writes the file and converts the difficulty
+;; keyword to / from its JSON string form.
+;; ---------------------------------------------------------------------
+
+(defn- settings-path []
+  (str (or (php/getenv "HOME") ".") "/.phel-doom-settings.json"))
+
+(defn- read-from [arr key fallback]
+  (let [v (php/aget arr key)]
+    (if (or (nil? v) (php/=== v false)) fallback v)))
+
+(defn load-settings
+  "Read the persisted settings file, returning the coerced defaults
+   when it's missing or malformed. Difficulty is stored as a string and
+   keyword-ised on the way in; coerce-settings clamps + validates the
+   whole map so the result is always complete and safe to apply."
+  []
+  (let [path (settings-path)]
+    (if (php/file_exists path)
+      (let [content (php/file_get_contents path)]
+        (if (or (php/=== content false) (php/=== content ""))
+          (coerce-settings default-settings)
+          (let [data (php/json_decode content true)]
+            (if (php/is_array data)
+              (coerce-settings
+               {:music      (read-from data "music"   (:music default-settings))
+                :sfx        (read-from data "sfx"      (:sfx default-settings))
+                :minimap    (read-from data "minimap"  (:minimap default-settings))
+                :difficulty (keyword (read-from data "difficulty" "normal"))})
+              (coerce-settings default-settings)))))
+      (coerce-settings default-settings))))
+
+(defn save-settings!
+  "Write `settings` back to the JSON file. Difficulty is stored as its
+   bare keyword name (\"normal\", not \":normal\"). Returns the settings
+   so callers can thread it. Swallows write failures."
+  [settings]
+  (let [s   (coerce-settings settings)
+        arr (php/array)]
+    (php/aset arr "music"      (:music s))
+    (php/aset arr "sfx"        (:sfx s))
+    (php/aset arr "minimap"    (:minimap s))
+    (php/aset arr "difficulty" (name (:difficulty s)))
+    (php/file_put_contents (settings-path) (php/json_encode arr))
+    s))

--- a/src/io/sound.phel
+++ b/src/io/sound.phel
@@ -49,8 +49,19 @@
 
 (def state
   "Memoised session state: the resolved player binary and per-event
-   sound files for this host. nil entries mean 'not yet resolved'."
-  (atom {:player nil :sounds nil :probed false}))
+   sound files for this host. nil entries mean 'not yet resolved'.
+   `:sfx-scalar` (default 1.0) is a global volume multiplier the
+   settings page drives via set-sfx-scalar!; every play-sfx! event
+   volume is scaled by it."
+  (atom {:player nil :sounds nil :probed false :sfx-scalar 1.0}))
+
+(defn set-sfx-scalar!
+  "Set the global sfx volume multiplier (clamped to [0.0, 1.0]). Called
+   from the settings page so SFX volume changes take effect on the next
+   sound. 0.0 effectively mutes per-event sfx without touching the N
+   sound toggle."
+  [^float scalar]
+  (swap! state assoc :sfx-scalar (php/max 0.0 (php/min 1.0 scalar))))
 
 (defn- which
   "Return the path of `bin` if it's on PATH, else nil."
@@ -152,10 +163,16 @@
                               (ensure-probed!)
                               (let [s    @state
                                     p    (:player s)
-                                    path (and (:sounds s) (get (:sounds s) evt))]
+                                    path (and (:sounds s) (get (:sounds s) evt))
+                                    vol  (php/* volume (or (:sfx-scalar s) 1.0))]
                                 (cond
+                                  ;; SFX volume turned to 0 in settings:
+                                  ;; stay fully silent, no bell fallback.
+                                  (php/<= vol 0.0)
+                                  nil
+
                                   (and p path (php/file_exists path))
-                                  (play-file-async! p path volume)
+                                  (play-file-async! p path vol)
 
                                   (= evt :heartbeat)
                                   nil

--- a/tests/core/settings-test.phel
+++ b/tests/core/settings-test.phel
@@ -3,6 +3,7 @@
   (:require phel-doom.core.settings :refer [default-settings difficulty-choices
                                             page-fields field-count field-at
                                             coerce-settings move-cursor adjust
+                                            navigate valid-difficulty?
                                             music-volume sfx-scalar music-ceiling]))
 
 ;; ---------------------------------------------------------------------
@@ -104,3 +105,41 @@
 
 (deftest test-difficulty-choices-easiest-first
   (is (= [:easy :normal :hard :nightmare] difficulty-choices)))
+
+(deftest test-valid-difficulty-guards-the-keyword-list
+  (is (= true  (valid-difficulty? :nightmare)))
+  (is (= true  (valid-difficulty? :easy)))
+  (is (= false (valid-difficulty? :ultraviolence)))
+  (is (= false (valid-difficulty? nil))))
+
+;; ---------------------------------------------------------------------
+;; navigate: shared cursor-move + value-adjust used by both the start
+;; menu and the in-game overlay.
+;; ---------------------------------------------------------------------
+
+(deftest test-navigate-moves-cursor-without-adjusting
+  (let [r (navigate default-settings 0 1 0)]
+    (is (= 1 (:cursor r)) "cursor-dir +1 steps down")
+    (is (= false (:adjusted? r)) "no value change")
+    (is (= default-settings (:settings r)))))
+
+(deftest test-navigate-adjusts-selected-field
+  ;; cursor 0 = Music; value-dir +1 raises it a step, flags adjusted.
+  (let [r (navigate default-settings 0 0 1)]
+    (is (= 0 (:cursor r)))
+    (is (= 70 (:music (:settings r))))
+    (is (= true (:adjusted? r)))))
+
+(deftest test-navigate-moves-then-adjusts-the-new-field
+  ;; Move to SFX (cursor 1) AND adjust in the same step: the adjust
+  ;; targets the field the cursor lands on, not the one it left.
+  (let [r (navigate default-settings 0 1 -1)]
+    (is (= 1 (:cursor r)))
+    (is (= 80 (:sfx (:settings r))) "SFX 90 -> 80")
+    (is (= 60 (:music (:settings r))) "Music untouched")))
+
+(deftest test-navigate-noop-when-both-dirs-zero
+  (let [r (navigate default-settings 2 0 0)]
+    (is (= 2 (:cursor r)))
+    (is (= false (:adjusted? r)))
+    (is (= default-settings (:settings r)))))

--- a/tests/core/settings-test.phel
+++ b/tests/core/settings-test.phel
@@ -1,0 +1,106 @@
+(ns phel-doom-tests.core.settings-test
+  (:require phel.test :refer [deftest is])
+  (:require phel-doom.core.settings :refer [default-settings difficulty-choices
+                                            page-fields field-count field-at
+                                            coerce-settings move-cursor adjust
+                                            music-volume sfx-scalar music-ceiling]))
+
+;; ---------------------------------------------------------------------
+;; Defaults + page shape
+;; ---------------------------------------------------------------------
+
+(deftest test-default-settings-shape
+  (is (= 60 (:music default-settings)))
+  (is (= 90 (:sfx default-settings)))
+  (is (= false (:minimap default-settings)))
+  (is (= :normal (:difficulty default-settings))))
+
+(deftest test-page-has-four-fields-in-order
+  (is (= 4 (field-count)))
+  (is (= [:music :sfx :minimap :difficulty]
+         (map :key page-fields))))
+
+(deftest test-field-at-returns-descriptor-or-nil
+  (is (= :music (:key (field-at 0))))
+  (is (= :difficulty (:key (field-at 3))))
+  (is (nil? (field-at 4)))
+  (is (nil? (field-at -1))))
+
+;; ---------------------------------------------------------------------
+;; coerce-settings: clamp + validate loaded values
+;; ---------------------------------------------------------------------
+
+(deftest test-coerce-fills-missing-from-defaults
+  (is (= default-settings (coerce-settings {})))
+  (is (= default-settings (coerce-settings nil))))
+
+(deftest test-coerce-clamps-volumes-into-0-100
+  (let [s (coerce-settings {:music 250 :sfx -40 :minimap true :difficulty :hard})]
+    (is (= 100 (:music s)) "music clamps to 100")
+    (is (= 0 (:sfx s)) "sfx clamps to 0")))
+
+(deftest test-coerce-rejects-unknown-difficulty
+  (is (= :normal (:difficulty (coerce-settings {:difficulty :ultraviolence}))))
+  (is (= :nightmare (:difficulty (coerce-settings {:difficulty :nightmare})))))
+
+(deftest test-coerce-forces-minimap-bool
+  (is (= true  (:minimap (coerce-settings {:minimap 1}))))
+  (is (= false (:minimap (coerce-settings {:minimap nil})))))
+
+;; ---------------------------------------------------------------------
+;; move-cursor: wraps both ends
+;; ---------------------------------------------------------------------
+
+(deftest test-move-cursor-steps-and-wraps
+  (is (= 1 (move-cursor 0 1)))
+  (is (= 0 (move-cursor 1 -1)))
+  (is (= 3 (move-cursor 0 -1)) "up from the first field wraps to the last")
+  (is (= 0 (move-cursor 3 1)) "down from the last field wraps to the first"))
+
+;; ---------------------------------------------------------------------
+;; adjust: per-kind value changes
+;; ---------------------------------------------------------------------
+
+(deftest test-adjust-volume-steps-by-ten-and-clamps
+  (is (= 70 (:music (adjust default-settings :music 1))))
+  (is (= 50 (:music (adjust default-settings :music -1))))
+  ;; From 90, one step up lands on 100; a further step clamps there.
+  (is (= 100 (:music (adjust (assoc default-settings :music 90) :music 1))))
+  (is (= 100 (:music (adjust (assoc default-settings :music 100) :music 1)))
+      "music clamps at 100")
+  (is (= 0 (:sfx (adjust (assoc default-settings :sfx 10) :sfx -1))))
+  (is (= 0 (:sfx (adjust (assoc default-settings :sfx 0) :sfx -1))) "clamps at 0"))
+
+(deftest test-adjust-minimap-toggles-regardless-of-direction
+  (is (= true  (:minimap (adjust default-settings :minimap 1))))
+  (is (= true  (:minimap (adjust default-settings :minimap -1))))
+  (is (= false (:minimap (adjust (assoc default-settings :minimap true) :minimap 1)))))
+
+(deftest test-adjust-difficulty-cycles-and-wraps
+  (is (= :hard      (:difficulty (adjust default-settings :difficulty 1))))
+  (is (= :easy      (:difficulty (adjust default-settings :difficulty -1))))
+  (is (= :easy      (:difficulty (adjust (assoc default-settings :difficulty :nightmare) :difficulty 1)))
+      "nightmare wraps forward to easy")
+  (is (= :nightmare (:difficulty (adjust (assoc default-settings :difficulty :easy) :difficulty -1)))
+      "easy wraps back to nightmare"))
+
+(deftest test-adjust-unknown-field-is-noop
+  (is (= default-settings (adjust default-settings :nope 1))))
+
+;; ---------------------------------------------------------------------
+;; Volume mappings consumed by io/sound + io/ambient
+;; ---------------------------------------------------------------------
+
+(deftest test-music-volume-maps-percent-to-afplay-scalar
+  (is (= 0.0 (music-volume (assoc default-settings :music 0))))
+  (is (= music-ceiling (music-volume (assoc default-settings :music 100))))
+  ;; 60% default keeps parity with the old hardcoded 0.30 ambient level.
+  (is (= 0.3 (music-volume (assoc default-settings :music 60)))))
+
+(deftest test-sfx-scalar-maps-percent-to-unit-interval
+  (is (= 0.0 (sfx-scalar (assoc default-settings :sfx 0))))
+  (is (= 1.0 (sfx-scalar (assoc default-settings :sfx 100))))
+  (is (= 0.9 (sfx-scalar (assoc default-settings :sfx 90)))))
+
+(deftest test-difficulty-choices-easiest-first
+  (is (= [:easy :normal :hard :nightmare] difficulty-choices)))

--- a/tests/glue/controls-test.phel
+++ b/tests/glue/controls-test.phel
@@ -301,3 +301,59 @@
   (let [w' (refresh-from-keys blank-world "w")]
     (is (php/> (:fwd    (:moves w')) 0))
     (is (= 0 (:sprint (:moves w'))))))
+
+;; ---------------------------------------------------------------------
+;; Settings page (issue #107): the 'o' key opens the options overlay
+;; and the arrow keys drive cursor + slider navigation as rising-edge
+;; one-shots. Arrow detection covers the legacy (`\e[A`), modified
+;; (`\e[1;2A`), and kitty-enhanced (`\e[1;m:eA`) forms.
+;; ---------------------------------------------------------------------
+
+(deftest test-key-states-detects-o
+  (is (= true  (:o (key-states "o"))))
+  (is (= false (:o (key-states ""))))
+  ;; F3's SS3 sequence carries an uppercase 'O' that must NOT match.
+  (is (= false (:o (key-states "\eOR")))))
+
+(deftest test-key-states-detects-arrows
+  (is (= true (:up    (key-states "\e[A"))))
+  (is (= true (:down  (key-states "\e[B"))))
+  (is (= true (:right (key-states "\e[C"))))
+  (is (= true (:left  (key-states "\e[D")))))
+
+(deftest test-key-states-detects-modified-and-kitty-arrows
+  ;; SHIFT+up (`\e[1;2A`) and a kitty-enhanced up press (`\e[1;1:1A`).
+  (is (= true (:up (key-states "\e[1;2A"))))
+  (is (= true (:up (key-states "\e[1;1:1A")))))
+
+(deftest test-key-states-arrows-are-independent
+  (let [s (key-states "\e[A")]
+    (is (= true  (:up s)))
+    (is (= false (:down s)))
+    (is (= false (:left s)))
+    (is (= false (:right s)))))
+
+(deftest test-rising-edges-open-settings-fires-on-fresh-o
+  (let [edges (rising-edges (assoc initial-key-snapshot :o true)
+                            initial-key-snapshot)]
+    (is (= true (:open-settings edges))))
+  ;; Held 'o' must not re-open.
+  (let [held (assoc initial-key-snapshot :o true)]
+    (is (= false (:open-settings (rising-edges held held))))))
+
+(deftest test-rising-edges-nav-keys-fire-once
+  (is (= true (:nav-up    (rising-edges (assoc initial-key-snapshot :up true)    initial-key-snapshot))))
+  (is (= true (:nav-down  (rising-edges (assoc initial-key-snapshot :down true)  initial-key-snapshot))))
+  (is (= true (:nav-left  (rising-edges (assoc initial-key-snapshot :left true)  initial-key-snapshot))))
+  (is (= true (:nav-right (rising-edges (assoc initial-key-snapshot :right true) initial-key-snapshot)))))
+
+(deftest test-rising-edges-nav-does-not-refire-while-held
+  (let [held (assoc initial-key-snapshot :right true)]
+    (is (= false (:nav-right (rising-edges held held))))))
+
+(deftest test-initial-key-snapshot-covers-settings-keys
+  (is (= false (:o     initial-key-snapshot)))
+  (is (= false (:up    initial-key-snapshot)))
+  (is (= false (:down  initial-key-snapshot)))
+  (is (= false (:left  initial-key-snapshot)))
+  (is (= false (:right initial-key-snapshot))))

--- a/tests/io/ambient-test.phel
+++ b/tests/io/ambient-test.phel
@@ -1,6 +1,7 @@
 (ns phel-doom-tests.io.ambient-test
   (:require phel.test :refer [deftest is])
-  (:require phel-doom.io.ambient :refer [drone-wav-bytes sync-ambient! proc]))
+  (:require phel-doom.io.ambient :refer [drone-wav-bytes sync-ambient! proc
+                                         volume set-music-volume!]))
 
 ;; ---------------------------------------------------------------------
 ;; drone-wav-bytes: pure PCM WAV synthesis. No IO — safe to assert on
@@ -35,3 +36,20 @@
   (is (nil? (:pid @proc)) "no loop process spawned while silent")
   (sync-ambient! false)
   (is (nil? (:pid @proc)) "stop stays a no-op too"))
+
+;; ---------------------------------------------------------------------
+;; set-music-volume!: settings drive the drone -v level. With no loop
+;; running (the suite never spawns one), it just stores a clamped value
+;; in the volume atom; restarts only happen when a pid is live.
+;; ---------------------------------------------------------------------
+
+(deftest test-set-music-volume-stores-clamped-value
+  (set-music-volume! 0.42)
+  (is (= 0.42 @volume) "stores the value")
+  (set-music-volume! 5.0)
+  (is (= 1.0 @volume) "clamps above 1.0")
+  (set-music-volume! -2.0)
+  (is (= 0.0 @volume) "clamps below 0.0")
+  ;; Restore the historical default so test ordering can't leak state.
+  (set-music-volume! 0.30)
+  (is (= 0.30 @volume)))

--- a/tests/io/sound-test.phel
+++ b/tests/io/sound-test.phel
@@ -1,6 +1,6 @@
 (ns phel-doom-tests.io.sound-test
   (:require phel.test :refer [deftest is])
-  (:require phel-doom.io.sound :refer [play-sfx!]))
+  (:require phel-doom.io.sound :refer [play-sfx! set-sfx-scalar! state]))
 
 ;; play-sfx! returns nil under PHEL_DOOM_SILENT=1 — that's the
 ;; contract `composer test` relies on so the test suite never shells
@@ -35,3 +35,16 @@
 
 (deftest test-bfg-fire-event-is-silent-under-test-env
   (is (= nil (play-sfx! :shoot-bfg))))
+
+(deftest test-set-sfx-scalar-stores-clamped-multiplier
+  ;; The settings page drives this; play-sfx! multiplies each event's
+  ;; volume by it. Clamp keeps the afplay -v argument well-formed.
+  (set-sfx-scalar! 0.5)
+  (is (= 0.5 (:sfx-scalar @state)))
+  (set-sfx-scalar! 9.0)
+  (is (= 1.0 (:sfx-scalar @state)) "clamps above 1.0")
+  (set-sfx-scalar! -3.0)
+  (is (= 0.0 (:sfx-scalar @state)) "clamps below 0.0")
+  ;; Restore the default so other tests / the live game are unaffected.
+  (set-sfx-scalar! 1.0)
+  (is (= 1.0 (:sfx-scalar @state))))


### PR DESCRIPTION
## What

A settings page for audio + game defaults, requested to control the bg-terror music volume (and more).

**Configurable:** bg-music volume, sfx volume, default minimap, default difficulty.

**Reach it:**
- Start menu: press `s`
- In-game: press `o` (freezes the frame like the H info menu)

Navigation: `↑↓` select, `←→` adjust, `o`/`esc` close. Volume + minimap apply live; difficulty applies from the next run. Persists to `$HOME/.phel-doom-settings.json`.

```
┌─ SETTINGS ─────────────────────────┐
│   Music      ◀ ████░░░░░░ ▶  40%    │
│   SFX        ◀ ██████████ ▶ 100%    │
│ ▸ Minimap    ◀  ON  ▶               │
│   Difficulty ◀ nightmare ▶          │
│   ↑↓ select   ←→ adjust   o/esc close│
└────────────────────────────────────┘
```

## Layers

- `core/settings.phel` (pure): defaults, `coerce-settings`, `move-cursor`, `adjust`, `music-volume` / `sfx-scalar`.
- `io/settings.phel`: load/save JSON (mirrors `io/scores`, errors swallowed).
- `io/sound` + `io/ambient`: live volume via `set-sfx-scalar!` / `set-music-volume!`.
- `io/render`: overlay box + standalone start-menu screen.
- `glue/controls`: `o` key + arrow-nav rising edges.
- `commands/play`: overlay loop, world-carried settings, start-menu entry; CLI `--difficulty` overrides the settings default.

## Note

Volume rides `afplay -v` (macOS). `paplay`/`aplay`/`play` ignore `-v`, so on other hosts the sliders persist and the `N` toggle still works, but moving a volume slider does not change the audible level.

## Tests

- `tests/core/settings-test.phel`: defaults, coerce/clamp/validate, cursor wrap, adjust per-kind, volume mappings.
- `controls-test`: `o` + arrow detection (legacy/modified/kitty) and nav rising edges.
- `sound-test` / `ambient-test`: scalar + volume clamping.
- Headless-verified: io round-trip against a temp `$HOME`, overlay render output.

`composer ci` green: format + lint clean, 1540 tests pass, build OK.

Closes #107