### PR TITLE
feat(settings): fold options into the pause page + fix box borders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 
 ### Added
 
-- Settings page (#107). Configurable bg-music + sfx volume, default minimap, default difficulty. It IS the pause screen: press `p` in-game (or `s` on the start menu); arrows adjust, `p`/`esc` resume. Persists to `$HOME/.phel-doom-settings.json`; volume rides `afplay -v` (macOS).
+- Settings page (#107). Configurable bg-music + sfx volume, default minimap, default difficulty. It IS the pause screen: press `p` in-game (or `s` on the start menu); arrows adjust, `p` resumes (on the start menu, `esc` goes back). Persists to `$HOME/.phel-doom-settings.json`; volume rides `afplay -v` (macOS).
 - Half-heart health + per-type hit damage. 10 HP pool drawn as 5 hearts (`♥`/`◖`/`·`). Hits cost by attacker: light melee 1 (half heart), heavy + casters 2, cyber boss 3. Armor absorbs a whole hit; heart pickup heals a full heart; soulsphere over-caps to 14.
 - Deterministic demo record / replay (#64). `--record=FILE` / `--demo=FILE`, on a new seeded Park-Miller RNG (`core/rng`) replacing the unseedable `random_int` / `mt_rand`.
 - Mid-level quick-save / load (#63). `F5` / `F9`, whole world to a versioned tagged-JSON slot (1-9), fog re-reveals on load.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 
 ### Added
 
-- Settings page (#107). Configurable bg-music + sfx volume, default minimap, default difficulty. Reach it from the start menu (`s`) or in-game (`o`, freezes like pause); arrows adjust, `o`/`esc` close. Persists to `$HOME/.phel-doom-settings.json`; volume rides `afplay -v` (macOS).
+- Settings page (#107). Configurable bg-music + sfx volume, default minimap, default difficulty. It IS the pause screen: press `p` in-game (or `s` on the start menu); arrows adjust, `p`/`esc` resume. Persists to `$HOME/.phel-doom-settings.json`; volume rides `afplay -v` (macOS).
 - Half-heart health + per-type hit damage. 10 HP pool drawn as 5 hearts (`♥`/`◖`/`·`). Hits cost by attacker: light melee 1 (half heart), heavy + casters 2, cyber boss 3. Armor absorbs a whole hit; heart pickup heals a full heart; soulsphere over-caps to 14.
 - Deterministic demo record / replay (#64). `--record=FILE` / `--demo=FILE`, on a new seeded Park-Miller RNG (`core/rng`) replacing the unseedable `random_int` / `mt_rand`.
 - Mid-level quick-save / load (#63). `F5` / `F9`, whole world to a versioned tagged-JSON slot (1-9), fog re-reveals on load.

--- a/README.md
+++ b/README.md
@@ -44,8 +44,7 @@ Override tag: `DOCKER_IMG=mytag make docker-build`. Host PHP is the inner loop; 
 | `r`            | Reload                       |
 | `1` / `2` / `3` | Switch weapon                |
 | `m` / `n`      | Minimap / sound toggle       |
-| `o`            | Settings (volume, minimap)   |
-| `p`            | Pause                        |
+| `p`            | Pause + settings (volume)    |
 | `h` / `ESC`    | Info menu + pause            |
 | `F3`           | Debug overlay                |
 | `q`            | Quit                         |

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Override tag: `DOCKER_IMG=mytag make docker-build`. Host PHP is the inner loop; 
 | `r`            | Reload                       |
 | `1` / `2` / `3` | Switch weapon                |
 | `m` / `n`      | Minimap / sound toggle       |
-| `p`            | Pause + settings (volume)    |
+| `p`            | Pause + settings             |
 | `h` / `ESC`    | Info menu + pause            |
 | `F3`           | Debug overlay                |
 | `q`            | Quit                         |

--- a/docs/input.md
+++ b/docs/input.md
@@ -67,9 +67,9 @@ In tmux: `set -g extended-keys on` + `setw -g xterm-keys on`.
 
 ## One-shot actions (rising edges)
 
-`key-states` snaps all tracked keys each frame: `m` (map), `sp` (fire), `p` (pause), `n` (sound), `e` (about-face), `f` (action/secret), `f3` (debug), `r` (reload), `h` (help), `esc` (help alias), `k1-k5` (weapon select), `f5` (save), `f9` (load), `o` (settings), and the four arrows (`up` / `down` / `left` / `right`) for menu navigation.
+`key-states` snaps all tracked keys each frame: `m` (map), `sp` (fire), `p` (pause), `n` (sound), `e` (about-face), `f` (action/secret), `f3` (debug), `r` (reload), `h` (help), `esc` (help alias), `k1-k5` (weapon select), `f5` (save), `f9` (load), and the four arrows (`up` / `down` / `left` / `right`) for menu navigation.
 
-`rising-edges` computes deltas: `:fire` (space pressed), `:fire-held` (space held), `:toggle-map`, `:toggle-pause`, `:toggle-sound`, `:toggle-debug`, `:toggle-help` (h or esc), `:reload`, `:about-face`, `:action`, `:select-weapon1-5`, `:save`, `:load`, `:open-settings` (o), and `:nav-up` / `:nav-down` / `:nav-left` / `:nav-right`.
+`rising-edges` computes deltas: `:fire` (space pressed), `:fire-held` (space held), `:toggle-map`, `:toggle-pause`, `:toggle-sound`, `:toggle-debug`, `:toggle-help` (h or esc), `:reload`, `:about-face`, `:action`, `:select-weapon1-5`, `:save`, `:load`, and `:nav-up` / `:nav-down` / `:nav-left` / `:nav-right`.
 
 F5 / F9 fire in `game-loop` (side-effect layer), not `tick-world`, so pure tick stays effect-free. See [savegame.md](savegame.md).
 
@@ -77,7 +77,7 @@ Edges consumed by: `:fire` -> `tick-shooting`; `:reload` -> ammo refill; `:actio
 
 Note: `h` and `esc` are aliased to `:toggle-help` (pause-coupled info panel).
 
-The settings overlay (see [settings.md](settings.md)) consumes `:open-settings` (toggle) plus the four nav edges while it is open; `o` / `esc` close it. The arrow edges are read as rising-edge one-shots there (one move per press), distinct from the held-counter movement path.
+The settings page (see [settings.md](settings.md)) is the pause overlay: while `:paused` (and not in the `h` info panel) the four nav edges drive cursor + value navigation. The arrow edges are read as rising-edge one-shots there (one move per press), distinct from the held-counter movement path.
 
 ## Architecture
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -21,12 +21,14 @@ Volumes map through `core/settings`: `music-volume` = `(pct / 100) * music-ceili
 
 ## Reaching the page
 
-- Start menu: press `s` to open the settings screen, edit, then `o` / `esc` to return.
-- In game: press `o` to open the overlay. The game freezes (like the H info menu) while it is up.
+The settings page IS the pause screen, so there is only one overlay layer to learn (the `h` info panel stays a separate read-only reference).
 
-Navigation: `up` / `down` move the cursor, `left` / `right` adjust the selected field, `o` / `esc` close. Volume + minimap edits take effect immediately; difficulty applies from the next run (it is baked per level at build time). Closing persists the file.
+- In game: press `p` (pause). The game freezes and the options appear; `p` resumes.
+- Start menu: press `s` to open the settings screen, edit, then `esc` to return.
 
-The settings map rides on the world (`:settings` / `:settings-cursor` / `:settings?`) so `frame-stats` can paint it and edits carry across level cuts.
+Navigation: `up` / `down` move the cursor, `left` / `right` adjust the selected field. Volume + minimap edits take effect immediately; difficulty applies from the next run (it is baked per level at build time). Resuming (`p`, or `esc` on the start-menu screen) persists the file.
+
+The settings map rides on the world (`:settings` / `:settings-cursor`) so `frame-stats` can paint it and edits carry across level cuts. The render layer keys the overlay off `:paused`.
 
 ## Platform note
 

--- a/src/commands/play.phel
+++ b/src/commands/play.phel
@@ -110,14 +110,16 @@
     (if (:about-face edges) (about-face after-help) after-help)))
 
 ;; =====================================================================
-;; § Settings overlay (issue #107)
+;; § Settings page (issue #107)
 ;;
-;; The options page freezes the game (like the H info menu) and routes
-;; the arrow edges to cursor + value navigation. Volume changes apply
-;; live through the io/sound + io/ambient atoms; the minimap default
-;; drives :show-map immediately. Settings live on the world under
-;; :settings / :settings-cursor / :settings? so frame-stats can paint
-;; them and they carry across level cuts; close persists to disk.
+;; The settings page IS the pause screen: pressing P freezes the game
+;; AND shows the adjustable options, so there is only one overlay layer
+;; to learn (the H info panel stays a separate read-only reference).
+;; While paused, the arrows move the cursor / change a value; volumes
+;; apply live through the io/sound + io/ambient atoms and the minimap
+;; field mirrors into :show-map. The settings ride on the world under
+;; :settings / :settings-cursor so frame-stats can paint them and they
+;; carry across level cuts; resuming (P) persists to disk.
 ;; =====================================================================
 
 (defn- apply-audio-settings!
@@ -133,22 +135,8 @@
   [(cond (:nav-up edges)   -1 (:nav-down edges)  1 :else 0)
    (cond (:nav-left edges) -1 (:nav-right edges) 1 :else 0)])
 
-(defn- open-settings
-  "Enter the options overlay and freeze the frame. The cursor keeps its
-   previous position (build-world seeds it at 0) so re-opening lands on
-   the field the player last touched."
-  [world]
-  (assoc world :settings? true :paused true))
-
-(defn- close-settings!
-  "Leave the overlay, persist the settings to disk, and unfreeze. Audio
-   was already pushed live on each adjustment, so close only saves."
-  [world]
-  (save-settings! (:settings world))
-  (assoc world :settings? false :paused false))
-
 (defn- step-settings!
-  "Apply one frame of overlay navigation via core/settings.navigate:
+  "Apply one frame of pause-page navigation via core/settings.navigate:
    up/down move the cursor, left/right adjust the selected field. Volume
    edits take effect immediately; the minimap field mirrors into
    :show-map so the change is visible the moment it's made."
@@ -679,9 +667,9 @@
    :enemy                (or (:enemy world) :imp)
    :save-flash-secs      (or (:save-flash-secs world) 0.0)
    :save-flash-msg       (:save-flash-msg world)
-   ;; Settings overlay (issue #107): the render layer paints the box
-   ;; from these when :settings? is set.
-   :settings?            (boolean (:settings? world))
+   ;; Settings page (issue #107): the pause overlay paints the box from
+   ;; these. The page IS the pause screen, so the render layer keys off
+   ;; :paused; the cursor + values ride along here.
    :settings             (:settings world)
    :settings-cursor      (or (:settings-cursor world) 0)})
 
@@ -835,39 +823,29 @@
               keys      (or (:keys frame) "")
               ms        (or (:ms frame) live-ms)
               now-keys  (key-states keys)
-              edges     (rising-edges now-keys prev-keys)
-              ;; ESC closes the settings overlay. rising-edges only folds
-              ;; ESC into :toggle-help (the h-aliased info panel), so the
-              ;; overlay needs its own naked-ESC edge to close on ESC
-              ;; without also toggling help.
-              esc-edge  (and (:esc now-keys) (not (:esc prev-keys)))
-              open?     (boolean (:settings? world))]
+              edges     (rising-edges now-keys prev-keys)]
           (cond
-            (:end? frame)                     :quit
-            (str/contains? keys "q")          :quit
+            (:end? frame)            :quit
+            (str/contains? keys "q") :quit
 
-            ;; --- Settings overlay: open / navigate / close. While it's
-            ;; up the game is frozen (no tick), so movement + AI hold.
-            (or open? (:open-settings edges))
-            (let [world' (cond
-                           (and open? (or (:open-settings edges) esc-edge))
-                           (close-settings! world)
-
-                           (not open?)
-                           (open-settings world)
-
-                           :else
-                           (step-settings! world edges))]
-              (recur world' now ms (fps-from-ms ms) now-keys [rows cols]))
-
-            ;; --- Normal gameplay frame.
             :else
-            (let [ticked (tick-world world keys (php// ms 1000.0) edges)
+            (let [ticked0 (tick-world world keys (php// ms 1000.0) edges)
+                  ;; Pause IS the settings page: while paused (and not
+                  ;; in the H info panel), the arrows tune the options
+                  ;; shown in the overlay. tick-world already froze the
+                  ;; gameplay step, so this only edits settings.
+                  ticked  (if (and (:paused ticked0) (not (:help? ticked0)))
+                            (step-settings! ticked0 edges)
+                            ticked0)
                   ;; F5 / F9 quick-save / load run here (file IO),
                   ;; outside the pure tick. Load swaps the whole world;
                   ;; both stamp a brief HUD flash so the player sees it
                   ;; took.
-                  world' (handle-save-load ticked edges)]
+                  world'  (handle-save-load ticked edges)]
+              ;; Resuming out of the pause/settings page persists the
+              ;; player's choices (volumes were already applied live).
+              (when (and (:paused world) (not (:paused world')))
+                (save-settings! (:settings world')))
               (when (and (:heartbeat-tick? world') (:sound-on world'))
                 (play-sfx! :heartbeat 0.35))
               (when (and (:silence-tick? world') (:sound-on world'))
@@ -1003,7 +981,7 @@
           w1a    (if armory? (assoc w1 :armory? true) w1)
           w1b    (if full-map? (assoc w1a :full-map? true) w1a)
           w2     (assoc w1b :show-map show-map? :sound-on sound-on?
-                        :settings settings :settings? false :settings-cursor 0)
+                        :settings settings :settings-cursor 0)
           w3     (if (nil? weapon)
                    w2
                    (let [stash  (or wstate (:weapon-state w2))
@@ -1068,7 +1046,7 @@
 (defn- settings-screen!
   "Interactive settings sub-loop reached from the start menu (s).
    Renders the standalone options screen and edits `settings0` until
-   the player presses o/esc to go back. Volume edits apply live; the
+   the player presses ESC to go back. Volume edits apply live; the
    final map is persisted and returned so the caller starts the run
    with the player's choices."
   [settings0]
@@ -1083,11 +1061,11 @@
       (let [keys     (drain-keys)
             now      (key-states keys)
             edges    (rising-edges now prev)
-            ;; ESC closes the page directly. We can't use the :toggle-help
-            ;; edge here: that aliases h+esc for the in-game info panel,
-            ;; which has nothing to do with the options screen.
+            ;; Naked-ESC edge: rising-edges only folds ESC into
+            ;; :toggle-help (the in-game info panel), which has nothing
+            ;; to do with this pre-game screen, so derive it here.
             esc-edge (and (:esc now) (not (:esc prev)))]
-        (if (or (:open-settings edges) esc-edge)
+        (if esc-edge
           ;; Volumes were applied live on each adjust; close just saves.
           (save-settings! settings)
           (let [[cursor-dir value-dir]              (nav-dirs edges)

--- a/src/commands/play.phel
+++ b/src/commands/play.phel
@@ -150,6 +150,19 @@
            :settings        settings
            :show-map        (boolean (:minimap settings)))))
 
+(defn resumed-pause?
+  "True when the pause/settings page just closed this frame (was paused,
+   now isn't). The cue to persist the player's settings to disk."
+  [before after]
+  (and (:paused before) (not (:paused after))))
+
+(defn- persist-settings!
+  "Write the world's current settings out. Called whenever the player
+   leaves the pause/settings page (resume or quit) so edits are never
+   lost; volumes were already applied live."
+  [world]
+  (save-settings! (:settings world)))
+
 (defn- boss-down?
   "True on a boss-locked level once the cyberdemon is dead — combat
    stamps `:boss` into `:held-keys` on the killing blow. Used to stop
@@ -825,8 +838,11 @@
               now-keys  (key-states keys)
               edges     (rising-edges now-keys prev-keys)]
           (cond
-            (:end? frame)            :quit
-            (str/contains? keys "q") :quit
+            ;; Quitting straight from the pause/settings page still
+            ;; persists edits (q never hits the resume transition).
+            (or (:end? frame) (str/contains? keys "q"))
+            (do (when (:paused world) (persist-settings! world))
+                :quit)
 
             :else
             (let [ticked0 (tick-world world keys (php// ms 1000.0) edges)
@@ -844,8 +860,8 @@
                   world'  (handle-save-load ticked edges)]
               ;; Resuming out of the pause/settings page persists the
               ;; player's choices (volumes were already applied live).
-              (when (and (:paused world) (not (:paused world')))
-                (save-settings! (:settings world')))
+              (when (resumed-pause? world world')
+                (persist-settings! world'))
               (when (and (:heartbeat-tick? world') (:sound-on world'))
                 (play-sfx! :heartbeat 0.35))
               (when (and (:silence-tick? world') (:sound-on world'))

--- a/src/glue/controls.phel
+++ b/src/glue/controls.phel
@@ -288,7 +288,7 @@
   "First-frame snapshot — nothing held yet."
   {:m false :sp false :p false :n false :e false :f false :f3 false :r false :h false
    :esc false :k1 false :k2 false :k3 false :k4 false
-   :o false :up false :down false :left false :right false})
+   :up false :down false :left false :right false})
 
 (defn- f3-pressed? [keys]
   ;; F3 across terminals: xterm/macOS Terminal/iTerm2 send `\eOR`;
@@ -381,9 +381,8 @@
    :k3 (key-pressed? keys "3" 51)
    :k4 (key-pressed? keys "4" 52)
    :k5 (key-pressed? keys "5" 53)
-   ;; Settings page: 'o' opens the options overlay; the arrows drive
-   ;; cursor + slider navigation while it's open.
-   :o     (key-pressed? keys "o" 111)
+   ;; Settings page: the arrows drive cursor + slider navigation while
+   ;; the pause overlay is open.
    :up    (arrow-pressed? keys "A")
    :down  (arrow-pressed? keys "B")
    :right (arrow-pressed? keys "C")
@@ -424,10 +423,9 @@
    ;; (file IO), not tick-world, so the pure tick stays effect-free.
    :save           (and (:f5 now) (not (:f5 prev)))
    :load           (and (:f9 now) (not (:f9 prev)))
-   ;; Settings page (issue #107). `:open-settings` toggles the options
-   ;; overlay; the four nav edges step the cursor (up/down) and adjust
-   ;; the selected value (left/right) one move per press.
-   :open-settings  (and (:o now)    (not (:o prev)))
+   ;; Settings page (issue #107). The pause overlay is the options page;
+   ;; the four nav edges step the cursor (up/down) and adjust the
+   ;; selected value (left/right) one move per press.
    :nav-up         (and (:up now)   (not (:up prev)))
    :nav-down       (and (:down now) (not (:down prev)))
    :nav-left       (and (:left now) (not (:left prev)))

--- a/src/io/render.phel
+++ b/src/io/render.phel
@@ -885,14 +885,6 @@
                            acc)))))]
     (sort-by (fn [x] (php/- 0.0 (:dist x))) raw)))
 
-(def pause-inner-width
-  "Character width of each interior row of the pause menu (between the
-   left and right borders). Every row pads to this width so the box
-   aligns cleanly regardless of label length. Picked to fit the
-   widest entry in the controls list (`  F3     debug overlay`) plus
-   trailing breathing room."
-  32)
-
 (defn- pause-pad
   "Pad `text` to `width` with trailing spaces. Re-applies the pause
    menu's dark BG before padding so trailing spaces don't fall on
@@ -1098,9 +1090,8 @@
                         (bord "  1 / 2 / 3 / 4 switch weapon slot")
                         (bord "  m             toggle minimap")
                         (bord "  n             toggle sound")
-                        (bord "  o             settings (volume)")
                         (bord "  F3            debug overlay")
-                        (bord "  p             pause / resume")
+                        (bord "  p             pause + settings")
                         (bord "  h / ESC      close this menu")
                         (bord "  q             quit")])
         closer-rows   (to-php-array [blnk (str "└" bar "┘")])
@@ -1127,45 +1118,6 @@
           row0 (php/max 1 (php/intdiv (php/max 1 (php/- vh n)) 2))]
       (loop [i 0 acc ""]
         (if (php/>= i n)
-          acc
-          (recur (php/+ i 1)
-                 (str acc "\e[" (php/+ row0 i) ";" col0 "H\e[40;97m"
-                      (get rows i) "\e[0m")))))))
-
-(defn- pause-menu-string
-  "Build the pause overlay as a single ANSI string with absolute cursor
-   moves. Pure: caller pushes it into the parts array."
-  [vw vh sound-on?]
-  (let [rows
-        (let [w pause-inner-width]
-          (let [bar  (php/str_repeat "─" w)
-                blnk (str "│" (pause-pad "" w) "│")]
-            ;; Minimal post-refactor: PAUSED title + credits. The full
-            ;; controls reference lives in the H info menu now, so the
-            ;; pause overlay stays a quick visual confirmation of the
-            ;; freeze rather than a wall of text. `sound-on?` kept in
-            ;; the signature so callers don't need to change; not used.
-            [(str "┌" bar "┐")
-             blnk
-             (str "│\e[1;93m" (pause-pad "             PAUSED" w) "\e[40;97m│")
-             blnk
-             (str "│\e[2;97m" (pause-pad "   H for info  ·  ESC resumes" w) "\e[22;40;97m│")
-             blnk
-             (str "├" bar "┤")
-             blnk
-             ;; Dim text (\e[2) leaks through pause-pad's \e[40;97m
-             ;; because BG/FG SGR does not reset the intensity attribute.
-             ;; Explicit \e[22 (normal intensity) before the right border
-             ;; keeps the `│` bright white like every other row.
-             (str "│\e[2;97m" (pause-pad "  phel-doom by Chemaclass" w) "\e[22;40;97m│")
-             (str "│\e[2;97m" (pause-pad "  written in Phel Lang"   w) "\e[22;40;97m│")
-             blnk
-             (str "└" bar "┘")]))]
-    (let [col0 (php/max 1 (php/- (php/+ (php/intdiv vw 2) 1)
-                                 (php/intdiv (php/+ pause-inner-width 2) 2)))
-          row0 (php/max 1 (php/- (php/intdiv vh 2) 4))]
-      (loop [i 0 acc ""]
-        (if (php/>= i (count rows))
           acc
           (recur (php/+ i 1)
                  (str acc "\e[" (php/+ row0 i) ";" col0 "H\e[40;97m"
@@ -1225,17 +1177,19 @@
     (str "│" sgr body "\e[40;97m" pad "│")))
 
 (defn- settings-menu-string
-  "Build the settings / options overlay as one ANSI string with
-   absolute cursor moves. `cursor` is the selected field index. Pure:
-   caller pushes the result into the parts array. Reads the field list
-   from core/settings so the page and the model never drift."
-  [vw vh settings cursor]
+  "Build the settings page as one ANSI string with absolute cursor
+   moves, centred in the viewport. `cursor` is the selected field
+   index; `footer` is the context hint row (resume vs back). This is
+   the in-game PAUSE overlay and the start-menu options screen share
+   the same box. Pure: caller pushes the result into the parts array.
+   Reads the field list from core/settings so page + model never drift."
+  [vw vh settings cursor footer]
   (let [w           settings-inner-width
         bar         (php/str_repeat "─" w)
         blnk        (str "│" (pause-pad "" w) "│")
         rows-head   [(str "┌" bar "┐")
                      blnk
-                     (str "│\e[1;93m" (pause-pad "            SETTINGS" w) "\e[40;97m│")
+                     (str "│\e[1;93m" (pause-pad "              SETTINGS" w) "\e[40;97m│")
                      blnk]
         rows-fields (apply vector
                            (map-indexed
@@ -1245,7 +1199,7 @@
         rows-foot   [blnk
                      (str "├" bar "┤")
                      blnk
-                     (str "│\e[2;97m" (pause-pad "  ↑↓ select   ←→ adjust   o/esc close" w) "\e[22;40;97m│")
+                     (str "│\e[2;97m" (pause-pad (str "  " footer) w) "\e[22;40;97m│")
                      blnk
                      (str "└" bar "┘")]
         rows        (apply vector (concat rows-head rows-fields rows-foot))
@@ -2999,19 +2953,17 @@
             p19b        (paint-locked-bump        p19 stats vw vh)
             p19c        (paint-enemy-hp-flashes   p19b world vw vh)
             p20         (paint-save-flash         p19c stats vw vh)]
-        (when (get stats :paused)
-          (buf-push p20 (pause-menu-string vw vh (get stats :sound-on))))
-        ;; Help overlay paints last so it sits on top of the pause
-        ;; menu when both are toggled at once (player paused, then
-        ;; pressed H). H + P are independent flags.
-        (when (get stats :help?)
-          (buf-push p20 (help-menu-string vw vh stats)))
-        ;; Settings overlay sits above everything: while it's open the
-        ;; game is frozen and the options box is the focused surface.
-        (when (get stats :settings?)
+        ;; Pause (P) IS the settings page: freezing the game and the
+        ;; options live in one overlay so there's only one layer to
+        ;; learn. The H info panel can still sit on top of it (player
+        ;; paused, then pressed H); it paints last so it wins.
+        (when (and (get stats :paused) (not (get stats :help?)))
           (buf-push p20 (settings-menu-string vw vh
                                               (get stats :settings)
-                                              (get stats :settings-cursor))))
+                                              (get stats :settings-cursor)
+                                              "↑↓ move   ←→ change   p resume")))
+        (when (get stats :help?)
+          (buf-push p20 (help-menu-string vw vh stats)))
         (php/implode "" p20)))))
 
 ;; --- DO NOT swap `print` / `println` for `php/fwrite` in render! ---
@@ -3294,9 +3246,9 @@
                   (pad-visible "    \e[93mr      \e[40;97m   reload" w)
                   (pad-visible "    \e[93m1 2 3  \e[40;97m   switch weapon slot" w)
                   (pad-visible "    \e[93mh      \e[40;97m   info menu (stats + weapons)" w)
-                  (pad-visible "    \e[93mo      \e[40;97m   settings (volume, minimap)" w)
                   (pad-visible "    \e[93mm  n   \e[40;97m   toggle minimap / sound" w)
-                  (pad-visible "    \e[93mp F3 q \e[40;97m   pause / debug / quit" w)
+                  (pad-visible "    \e[93mp      \e[40;97m   pause + settings (volume)" w)
+                  (pad-visible "    \e[93mF3 q   \e[40;97m   debug / quit" w)
                   blank]
         howto    [:sep blank
                   (pad-visible "  \e[1mHOW TO PLAY\e[40;97m" w)
@@ -3371,8 +3323,8 @@
 (defn render-settings!
   "Full-screen wash + centred settings box, for the start-menu options
    screen (no game frame behind it). `settings` is the live map and
-   `cursor` the selected field index. The in-game overlay reuses the
-   same box via render!'s :settings? branch; this entry just adds the
+   `cursor` the selected field index. The in-game pause overlay reuses
+   the same box via render!'s :paused branch; this entry just adds the
    background wash so it reads as a standalone screen."
   [cols rows settings cursor]
   (let [parts (buf-mk)
@@ -3382,7 +3334,8 @@
       (when (php/<= r rows)
         (buf-push parts (str "\e[" r ";1H" wash (php/str_repeat " " cols)))
         (recur (php/+ r 1))))
-    (buf-push parts (settings-menu-string cols rows settings cursor))
+    (buf-push parts (settings-menu-string cols rows settings cursor
+                                          "↑↓ move   ←→ change   esc back"))
     (print (php/implode "" parts))
     (php/flush)))
 

--- a/src/io/render.phel
+++ b/src/io/render.phel
@@ -827,10 +827,10 @@
 
 (def hud-line-str
   "Bottom-status row. Was the dump for pos/angle/fps + a cramped key
-   legend; those moved to the F3 debug overlay and the pause menu.
+   legend; those moved to the F3 debug overlay and the H info menu.
    Now a single dim tagline so the bottom strip stays visually
    anchored without competing with the game info up top."
-  "\e[0m\e[2mP to pause for controls · F3 for debug\e[0m")
+  "\e[0m\e[2mP pause + settings · H info · F3 debug\e[0m")
 
 (defn project-enemy
   "Project one enemy into screen space relative to the player. Returns
@@ -899,7 +899,7 @@
 
 (def help-inner-width
   "Default character width of each interior row of the H info menu —
-   wider than the pause menu to fit the weapon-stats table
+   wider than the settings page to fit the weapon-stats table
    comfortably. Clamped down to fit narrow terminals."
   44)
 
@@ -3050,7 +3050,7 @@
 ;; ---------------------------------------------------------------------
 ;; End-of-game screens (death / victory).
 ;;
-;; Same box geometry as the pause menu but full-screen washed in either
+;; Same box geometry as the settings page but full-screen washed in either
 ;; dark red (death) or dark green (victory). Both screens share
 ;; render-end-screen — the only thing each variant supplies is the
 ;; wash colour and the 32-wide row strings.
@@ -3247,7 +3247,7 @@
                   (pad-visible "    \e[93m1 2 3  \e[40;97m   switch weapon slot" w)
                   (pad-visible "    \e[93mh      \e[40;97m   info menu (stats + weapons)" w)
                   (pad-visible "    \e[93mm  n   \e[40;97m   toggle minimap / sound" w)
-                  (pad-visible "    \e[93mp      \e[40;97m   pause + settings (volume)" w)
+                  (pad-visible "    \e[93mp      \e[40;97m   pause + settings menu" w)
                   (pad-visible "    \e[93mF3 q   \e[40;97m   debug / quit" w)
                   blank]
         howto    [:sep blank

--- a/tests/commands/play-test.phel
+++ b/tests/commands/play-test.phel
@@ -4,7 +4,7 @@
   (:require phel-doom.core.enemy  :refer [new-enemy])
   (:require phel-doom.core.level  :refer [build-world])
   (:require phel-doom.core.rng    :as rng)
-  (:require phel-doom.commands.play  :refer [tick-world]))
+  (:require phel-doom.commands.play  :refer [tick-world resumed-pause?]))
 
 (def open-grid
   (apply vector
@@ -208,3 +208,14 @@
     (is (= (:player a) (:player b)) "player state identical after 40 frames")
     (is (= (:enemies a) (:enemies b)) "enemy state identical")
     (is (= (:game-time a) (:game-time b)))))
+
+;; ---------------------------------------------------------------------
+;; resumed-pause? (issue #107): true only on the paused -> unpaused
+;; edge, the cue to persist settings when the player leaves the page.
+;; ---------------------------------------------------------------------
+
+(deftest test-resumed-pause-fires-only-on-close-edge
+  (is (= true  (resumed-pause? {:paused true}  {:paused false})) "p closes the page")
+  (is (= false (resumed-pause? {:paused false} {:paused true}))  "opening is not a resume")
+  (is (= false (resumed-pause? {:paused true}  {:paused true}))  "still paused")
+  (is (= false (resumed-pause? {:paused false} {:paused false})) "never paused"))

--- a/tests/glue/controls-test.phel
+++ b/tests/glue/controls-test.phel
@@ -303,17 +303,11 @@
     (is (= 0 (:sprint (:moves w'))))))
 
 ;; ---------------------------------------------------------------------
-;; Settings page (issue #107): the 'o' key opens the options overlay
-;; and the arrow keys drive cursor + slider navigation as rising-edge
+;; Settings page (issue #107): the pause overlay is the options page;
+;; the arrow keys drive cursor + slider navigation as rising-edge
 ;; one-shots. Arrow detection covers the legacy (`\e[A`), modified
 ;; (`\e[1;2A`), and kitty-enhanced (`\e[1;m:eA`) forms.
 ;; ---------------------------------------------------------------------
-
-(deftest test-key-states-detects-o
-  (is (= true  (:o (key-states "o"))))
-  (is (= false (:o (key-states ""))))
-  ;; F3's SS3 sequence carries an uppercase 'O' that must NOT match.
-  (is (= false (:o (key-states "\eOR")))))
 
 (deftest test-key-states-detects-arrows
   (is (= true (:up    (key-states "\e[A"))))
@@ -333,14 +327,6 @@
     (is (= false (:left s)))
     (is (= false (:right s)))))
 
-(deftest test-rising-edges-open-settings-fires-on-fresh-o
-  (let [edges (rising-edges (assoc initial-key-snapshot :o true)
-                            initial-key-snapshot)]
-    (is (= true (:open-settings edges))))
-  ;; Held 'o' must not re-open.
-  (let [held (assoc initial-key-snapshot :o true)]
-    (is (= false (:open-settings (rising-edges held held))))))
-
 (deftest test-rising-edges-nav-keys-fire-once
   (is (= true (:nav-up    (rising-edges (assoc initial-key-snapshot :up true)    initial-key-snapshot))))
   (is (= true (:nav-down  (rising-edges (assoc initial-key-snapshot :down true)  initial-key-snapshot))))
@@ -352,7 +338,6 @@
     (is (= false (:nav-right (rising-edges held held))))))
 
 (deftest test-initial-key-snapshot-covers-settings-keys
-  (is (= false (:o     initial-key-snapshot)))
   (is (= false (:up    initial-key-snapshot)))
   (is (= false (:down  initial-key-snapshot)))
   (is (= false (:left  initial-key-snapshot)))


### PR DESCRIPTION
## Why

Follow-up to #108. The settings page was a third overlay opened with `o` — stacked on top of pause (`p`) and the info panel (`h`). Too many "pages", and the open key was undiscoverable. Also the overlay's footer text overflowed the box, so the right border drifted out of alignment.

## What

**The pause screen IS the settings page.** Press `p` in-game → game freezes and the options appear; `p` resumes. One in-game overlay to learn. The `h` info panel stays a separate read-only reference and now points at "p pause + settings".

- Removed the dedicated `o` key + `:settings?` flag. While `:paused` (and not in help) the arrows tune the options; resuming persists.
- One shared box builder for the pause overlay and the start-menu screen (footer parametrised).
- **Border fix:** old footer `o/esc close` was 37 cols in a 36-wide box → right border drifted. Verified every row now measures exactly inner-width + 2:

```
┌────────────────────────────────────┐
│              SETTINGS              │
│   Music      ◀ ███░░░░░░░ ▶  30%   │
│   SFX        ◀ ██████████ ▶ 100%   │
│   Minimap    ◀  ON  ▶              │
│ ▸ Difficulty ◀ nightmare ▶         │
│  ↑↓ move   ←→ change   p resume    │
└────────────────────────────────────┘
```

Start menu still opens settings via `s` (esc to return).

## Tests

`composer ci` green: format + lint clean, 1550 tests pass, build OK. Border alignment verified headlessly (every rendered row = 38 display cols at inner-width 36).