### PR TITLE
fix(controls): accept SS3 arrows so settings nav works

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 
 ### Fixed
 
+- Settings page arrows did nothing under SS3 application-cursor mode (tmux / alt-screen); arrow detection + in-game turning now accept both `\eOA` and `\e[A` forms.
 - Mixed-level enemies spawned at 1 HP; now use catalog HP (`default-lives-for`).
 - `R` (restart same map) reproduces geometry + spawns via `core/rng`.
 - Weapon report went silent on a connecting hit; every shot now plays its fire sound + kill cue.

--- a/src/glue/controls.phel
+++ b/src/glue/controls.phel
@@ -97,13 +97,19 @@
       :else                   world)))
 
 (def arrow-escape-keys
-  "Search-side PHP array for php/str_replace: arrow-key CSI escapes."
-  (php/array "\e[A" "\e[B" "\e[D" "\e[C"))
+  "Search-side PHP array for php/str_replace: arrow-key escapes in both
+   the CSI (`\\e[A`) and SS3 application-cursor-key (`\\eOA`) forms, so
+   in-game turning works whether or not the terminal is in app-cursor
+   mode (tmux / the alternate screen flip it on a lot)."
+  (php/array "\e[A" "\e[B" "\e[D" "\e[C"
+             "\eOA" "\eOB" "\eOD" "\eOC"))
 
 (def arrow-escape-replacements
   "Replace-side PHP array for php/str_replace: single-byte stand-ins
-   for ↑↓←→ so refresh-from-keys can walk the input one byte at a time."
-  (php/array "^"    "_"    "<"    ">"))
+   for ↑↓←→ so refresh-from-keys can walk the input one byte at a time.
+   Both arrow encodings collapse to the same four stand-ins."
+  (php/array "^"    "_"    "<"    ">"
+             "^"    "_"    "<"    ">"))
 
 (defn- normalise-arrows [keys]
   (php/str_replace arrow-escape-keys arrow-escape-replacements keys))
@@ -348,15 +354,17 @@
         (= 1 (php/preg_match kitty-re keys)))))
 
 (defn- arrow-pressed?
-  "True when an arrow key with CSI final byte `letter` (A=up B=down
-   C=right D=left) is present in `keys` this frame. Matches the legacy
-   form (`\\e[A`), modified arrows (`\\e[1;2A`), and the kitty-enhanced
-   arrow form (`\\e[1;m:eD`) in one shot — the settings page consumes
-   these as rising-edge menu navigation. Release events (`:3`) are
-   harmless here: a held arrow keeps the key true so no new edge fires
-   until it's let go and pressed again."
+  "True when an arrow key with final byte `letter` (A=up B=down C=right
+   D=left) is present in `keys` this frame. Matches all three encodings
+   a terminal may send: the CSI form (`\\e[A`), modified / kitty-enhanced
+   CSI (`\\e[1;2A`, `\\e[1;m:eD`), AND the SS3 application-cursor-key
+   form (`\\eOA`) that many terminals + tmux emit in the alternate
+   screen. The settings page consumes these as rising-edge menu
+   navigation. Release events (`:3`) are harmless: a held arrow keeps
+   the key true so no new edge fires until it's let go and pressed
+   again."
   [keys letter]
-  (= 1 (php/preg_match (str "/\\x1b\\[[\\d;:]*" letter "/") keys)))
+  (= 1 (php/preg_match (str "/\\x1b(?:\\[[\\d;:]*|O)" letter "/") keys)))
 
 (defn key-states
   "Which of the tracked one-shot keys appear in `keys` this frame.

--- a/tests/glue/controls-test.phel
+++ b/tests/glue/controls-test.phel
@@ -320,6 +320,26 @@
   (is (= true (:up (key-states "\e[1;2A"))))
   (is (= true (:up (key-states "\e[1;1:1A")))))
 
+(deftest test-ss3-arrow-drives-in-game-turn
+  ;; The same SS3 form must also feed the movement path so turning
+  ;; works under app-cursor mode, not just menu nav.
+  (let [w' (refresh-from-keys blank-world "\eOD")]
+    (is (php/> (:turn-left (:moves w')) 0)))
+  (let [w' (refresh-from-keys blank-world "\eOC")]
+    (is (php/> (:turn-right (:moves w')) 0))))
+
+(deftest test-key-states-detects-ss3-application-cursor-arrows
+  ;; Many terminals / tmux send SS3 arrows (`\eOA`..`\eOD`) in the
+  ;; alternate screen instead of CSI. Menu nav must still work.
+  (is (= true (:up    (key-states "\eOA"))))
+  (is (= true (:down  (key-states "\eOB"))))
+  (is (= true (:right (key-states "\eOC"))))
+  (is (= true (:left  (key-states "\eOD"))))
+  ;; F3's SS3 sequence `\eOR` shares the `\eO` prefix but a different
+  ;; final byte, so it must NOT register as an arrow.
+  (is (= false (:up   (key-states "\eOR"))))
+  (is (= true  (:f3   (key-states "\eOR")))))
+
 (deftest test-key-states-arrows-are-independent
   (let [s (key-states "\e[A")]
     (is (= true  (:up s)))


### PR DESCRIPTION
## Bug

In the settings page (start menu `s`, or in-game pause), the arrow keys did nothing — couldn't move the cursor or change a value.

## Cause

Arrow detection (`arrow-pressed?`) and in-game turning (`normalise-arrows`) only matched the **CSI** arrow form (`\e[A`). Many terminals + tmux send arrows as **SS3 application-cursor** sequences (`\eOA`/`\eOB`/`\eOC`/`\eOD`) in the alternate screen, which went unrecognised.

Confirmed headlessly: the full nav chain (key-states -> rising-edges -> navigate) works with `\e[A` bytes but the menu was receiving `\eO*` bytes.

## Fix

- `arrow-pressed?` matches CSI, modified/kitty CSI, **and** SS3.
- `normalise-arrows` maps the SS3 forms to the same movement stand-ins (so in-game turning is also robust to app-cursor mode).
- F3 (`\eOR`) shares the `\eO` prefix but a different final byte, so it still does not register as an arrow.

## Tests

New regressions: SS3 menu nav (`:up`/`:down`/`:left`/`:right` from `\eO*`), SS3 in-game turn, and the F3 non-collision. `composer ci` green: 1562 tests, lint + format clean, build OK.