### PR TITLE
fix(settings): WASD + all-encoding arrow nav; explicit start menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 
 ### Added
 
-- Settings page (#107). Pause screen (`p`, or `s` on the start menu) doubles as options: bg-music / sfx volume, default minimap + difficulty. Persists to `~/.phel-doom-settings.json` (volume via `afplay`, macOS).
+- Settings page (#107). Pause screen (`p`, or `s` on the start menu) doubles as options: bg-music / sfx volume, default minimap + difficulty. Navigate with arrows or WASD (hold to ramp). Persists to `~/.phel-doom-settings.json` (volume via `afplay`, macOS).
 - Half-heart health. 10 HP = 5 hearts (`♥`/`◖`/`·`); per-type hit damage (melee 1, casters 2, cyber 3); armor soaks a whole hit.
 - Demo record / replay (#64). `--record` / `--demo` on a seeded Park-Miller RNG.
 - Quick-save / load (#63). `F5` / `F9` to versioned JSON slots; fog re-reveals.
@@ -31,10 +31,11 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 - Caster tuning (#94). Slower, longer-telegraphed fireballs on a shorter cooldown; casters move slower than melee.
 - Progressive difficulty curve. Chase speed climbs L1-L9, eases at L10; archvile wired as a caster (L8); L6 / L7 gain casters; depth-scaled cooldown.
 - Per-level monster variety. L2-L5 mix melee into the headline type (L3 ~50/50); L1 stays pure imps.
+- Start menu uses explicit keys: ENTER starts, `s` settings, `q` quits (a stray key no longer launches the run).
 
 ### Fixed
 
-- Settings page arrows did nothing under SS3 application-cursor mode (tmux / alt-screen); arrow detection + in-game turning now accept both `\eOA` and `\e[A` forms.
+- Settings page navigation was dead on terminals whose arrows aren't plain CSI (SS3 / app-cursor under tmux, etc.). Nav now counts arrows in every encoding (CSI / SS3 / kitty) AND accepts WASD as a fallback; in-game arrow turning handles SS3 too.
 - Mixed-level enemies spawned at 1 HP; now use catalog HP (`default-lives-for`).
 - `R` (restart same map) reproduces geometry + spawns via `core/rng`.
 - Weapon report went silent on a connecting hit; every shot now plays its fire sound + kill cue.

--- a/docs/input.md
+++ b/docs/input.md
@@ -67,9 +67,9 @@ In tmux: `set -g extended-keys on` + `setw -g xterm-keys on`.
 
 ## One-shot actions (rising edges)
 
-`key-states` snaps all tracked keys each frame: `m` (map), `sp` (fire), `p` (pause), `n` (sound), `e` (about-face), `f` (action/secret), `f3` (debug), `r` (reload), `h` (help), `esc` (help alias), `k1-k5` (weapon select), `f5` (save), `f9` (load), and the four arrows (`up` / `down` / `left` / `right`) for menu navigation.
+`key-states` snaps all tracked keys each frame: `m` (map), `sp` (fire), `p` (pause), `n` (sound), `e` (about-face), `f` (action/secret), `f3` (debug), `r` (reload), `h` (help), `esc` (help alias), `k1-k5` (weapon select), `f5` (save), `f9` (load).
 
-`rising-edges` computes deltas: `:fire` (space pressed), `:fire-held` (space held), `:toggle-map`, `:toggle-pause`, `:toggle-sound`, `:toggle-debug`, `:toggle-help` (h or esc), `:reload`, `:about-face`, `:action`, `:select-weapon1-5`, `:save`, `:load`, and `:nav-up` / `:nav-down` / `:nav-left` / `:nav-right`.
+`rising-edges` computes deltas: `:fire` (space pressed), `:fire-held` (space held), `:toggle-map`, `:toggle-pause`, `:toggle-sound`, `:toggle-debug`, `:toggle-help` (h or esc), `:reload`, `:about-face`, `:action`, `:select-weapon1-5`, `:save`, `:load`.
 
 F5 / F9 fire in `game-loop` (side-effect layer), not `tick-world`, so pure tick stays effect-free. See [savegame.md](savegame.md).
 
@@ -77,7 +77,7 @@ Edges consumed by: `:fire` -> `tick-shooting`; `:reload` -> ammo refill; `:actio
 
 Note: `h` and `esc` are aliased to `:toggle-help` (pause-coupled info panel).
 
-The settings page (see [settings.md](settings.md)) is the pause overlay: while `:paused` (and not in the `h` info panel) the four nav edges drive cursor + value navigation. The arrow edges are read as rising-edge one-shots there (one move per press), distinct from the held-counter movement path.
+The settings page (see [settings.md](settings.md)) is the pause overlay. While `:paused` (and not in the `h` info panel) navigation is count-based via `nav-deltas`, not the one-shot edges above: it sums arrow presses (CSI / SS3 / kitty) and WASD in the drain string into net `{:cursor :value}` steps, so WASD is a fallback for unrecognised arrow encodings and a held key ramps a slider through OS key-repeat.
 
 ## Architecture
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -23,12 +23,12 @@ Volumes map through `core/settings`: `music-volume` = `(pct / 100) * music-ceili
 
 The settings page IS the pause screen, so there is only one overlay layer to learn (the `h` info panel stays a separate read-only reference).
 
+- Start menu: ENTER starts the run, `s` opens the settings screen (edit, then `esc` to return), `q` quits.
 - In game: press `p` (pause). The game freezes and the options appear; `p` resumes.
-- Start menu: press `s` to open the settings screen, edit, then `esc` to return.
 
-Navigation: `up` / `down` move the cursor, `left` / `right` adjust the selected field. Volume + minimap edits take effect immediately; difficulty applies from the next run (it is baked per level at build time). Resuming (`p`, or `esc` on the start-menu screen) persists the file.
+Navigation: `up` / `down` (or `w` / `s`) move the cursor, `left` / `right` (or `a` / `d`) adjust the selected field. WASD works as a fallback when a terminal's arrow encoding isn't recognised, and holding a key ramps a slider via OS key-repeat. Volume + minimap edits take effect immediately; difficulty applies from the next run (it is baked per level at build time). Resuming (`p`, or `esc` on the start-menu screen) persists the file.
 
-The settings map rides on the world (`:settings` / `:settings-cursor`) so `frame-stats` can paint it and edits carry across level cuts. The render layer keys the overlay off `:paused`.
+Input is count-based: `glue/controls.nav-deltas` turns the raw drain string into net `{:cursor :value}` steps (arrows in any encoding + WASD), which `core/settings.navigate` applies. The settings map rides on the world (`:settings` / `:settings-cursor`) so `frame-stats` can paint it and edits carry across level cuts. The render layer keys the overlay off `:paused`.
 
 ## Platform note
 

--- a/src/commands/play.phel
+++ b/src/commands/play.phel
@@ -8,7 +8,7 @@
                                             rebuild-pgrid toggle-debug toggle-map toggle-pause toggle-sound])
   (:require phel-doom.core.map      :refer [door? reveal-secret secret? switch? toggle-switch])
   (:require phel-doom.glue.controls :refer [refresh-from-keys key-states rising-edges
-                                            initial-key-snapshot])
+                                            initial-key-snapshot nav-deltas])
   (:require phel-doom.core.physics  :refer [apply-physics tick-heartbeat tick-flicker tick-blood-drops tick-door-face tick-stamina])
   (:require phel-doom.core.engine   :refer [mark-visible-cells])
   (:require phel-doom.core.combat   :refer [ammo-per-box arm-berserk berserk-seconds damage-step fire-anim-seconds invuln-seconds max-reserve reload reloading? reload-cooldown-seconds tick-armory tick-shooting])
@@ -128,22 +128,16 @@
   (set-sfx-scalar!   (sfx-scalar settings))
   (set-music-volume! (music-volume settings)))
 
-(defn- nav-dirs
-  "Translate the nav rising-edges into the [cursor-dir value-dir] pair
-   core/settings.navigate expects (-1 / 0 / +1 each)."
-  [edges]
-  [(cond (:nav-up edges)   -1 (:nav-down edges)  1 :else 0)
-   (cond (:nav-left edges) -1 (:nav-right edges) 1 :else 0)])
-
 (defn- step-settings!
-  "Apply one frame of pause-page navigation via core/settings.navigate:
-   up/down move the cursor, left/right adjust the selected field. Volume
-   edits take effect immediately; the minimap field mirrors into
-   :show-map so the change is visible the moment it's made."
-  [world edges]
-  (let [[cursor-dir value-dir]              (nav-dirs edges)
+  "Apply one frame of pause-page navigation from the raw input `keys`
+   via core/settings.navigate: up/down (or W/S) move the cursor,
+   left/right (or A/D) adjust the selected field. A held key ramps
+   through the OS key-repeat. Volume edits take effect immediately;
+   the minimap field mirrors into :show-map so the change shows at once."
+  [world keys]
+  (let [{:cursor cursor-steps :value value-steps} (nav-deltas keys)
         {:keys [cursor settings adjusted?]}
-        (navigate (:settings world) (or (:settings-cursor world) 0) cursor-dir value-dir)]
+        (navigate (:settings world) (or (:settings-cursor world) 0) cursor-steps value-steps)]
     (when adjusted? (apply-audio-settings! settings))
     (assoc world
            :settings-cursor cursor
@@ -847,11 +841,11 @@
             :else
             (let [ticked0 (tick-world world keys (php// ms 1000.0) edges)
                   ;; Pause IS the settings page: while paused (and not
-                  ;; in the H info panel), the arrows tune the options
-                  ;; shown in the overlay. tick-world already froze the
-                  ;; gameplay step, so this only edits settings.
+                  ;; in the H info panel), the arrows / WASD tune the
+                  ;; options shown in the overlay. tick-world already
+                  ;; froze the gameplay step, so this only edits settings.
                   ticked  (if (and (:paused ticked0) (not (:help? ticked0)))
-                            (step-settings! ticked0 edges)
+                            (step-settings! ticked0 keys)
                             ticked0)
                   ;; F5 / F9 quick-save / load run here (file IO),
                   ;; outside the pure tick. Load swaps the whole world;
@@ -1062,9 +1056,9 @@
 (defn- settings-screen!
   "Interactive settings sub-loop reached from the start menu (s).
    Renders the standalone options screen and edits `settings0` until
-   the player presses ESC to go back. Volume edits apply live; the
-   final map is persisted and returned so the caller starts the run
-   with the player's choices."
+   the player presses ESC to go back. Arrows or WASD navigate (held
+   keys ramp); volume edits apply live; the final map is persisted and
+   returned so the caller starts the run with the player's choices."
   [settings0]
   (loop [settings settings0
          cursor   0
@@ -1076,26 +1070,33 @@
       (php/usleep menu-frame-us)
       (let [keys     (drain-keys)
             now      (key-states keys)
-            edges    (rising-edges now prev)
-            ;; Naked-ESC edge: rising-edges only folds ESC into
-            ;; :toggle-help (the in-game info panel), which has nothing
-            ;; to do with this pre-game screen, so derive it here.
+            ;; Naked-ESC edge: key-states folds ESC into the h-aliased
+            ;; info panel in game, but this pre-game screen just needs
+            ;; "did ESC go down this frame" to go back.
             esc-edge (and (:esc now) (not (:esc prev)))]
         (if esc-edge
           ;; Volumes were applied live on each adjust; close just saves.
           (save-settings! settings)
-          (let [[cursor-dir value-dir]              (nav-dirs edges)
+          (let [{:cursor cursor-steps :value value-steps} (nav-deltas keys)
                 {:keys [cursor settings adjusted?]}
-                (navigate settings cursor cursor-dir value-dir)]
+                (navigate settings cursor cursor-steps value-steps)]
             (when adjusted? (apply-audio-settings! settings))
             (recur settings cursor now [rows cols])))))))
 
+(defn- start-pressed?
+  "True when `keys` carries an ENTER / Return (raw mode sends CR; some
+   terminals send LF). Space also starts, as a forgiving second key."
+  [keys]
+  (or (str/contains? keys "\r")
+      (str/contains? keys "\n")
+      (str/contains? keys " ")))
+
 (defn- show-start-menu!
-  "Block on the start screen until the player starts or quits. Re-draws
-   each frame so terminal resizes don't leave a stale half-painted box.
-   `s` opens the settings screen (returning here afterwards); `q` quits;
-   any other key starts the run. Returns :quit, or the (possibly
-   edited) settings map to start with."
+  "Block on the start screen until the player acts. Re-draws each frame
+   so terminal resizes don't leave a stale half-painted box. ENTER (or
+   space) starts; `s` opens settings (returning here after); `q` quits.
+   Other keys are ignored so a stray arrow can't launch the run by
+   accident. Returns :quit, or the (possibly edited) settings map."
   [settings0]
   (loop [settings settings0
          dims     [0 0]]
@@ -1105,12 +1106,10 @@
       (php/usleep menu-frame-us)
       (let [keys (drain-keys)]
         (cond
-          (= keys "")              (recur settings [rows cols])
           (str/contains? keys "q") :quit
-          ;; 's' opens settings, then drops back to the menu so the
-          ;; player still has to press a key to start.
           (str/contains? keys "s") (recur (settings-screen! settings) [rows cols])
-          :else                    settings)))))
+          (start-pressed? keys)    settings
+          :else                    (recur settings [rows cols]))))))
 
 (defn- resolve-difficulty
   "Pick the run difficulty: an explicit, valid --difficulty CLI value

--- a/src/core/settings.phel
+++ b/src/core/settings.phel
@@ -84,18 +84,21 @@
      :minimap    (boolean (get m :minimap (:minimap default-settings)))
      :difficulty (if (valid-difficulty? d) d :normal)}))
 
-(defn move-cursor
-  "Step the page cursor by `dir` (+1 down / -1 up), wrapping at both
-   ends so the selection never falls off the page."
-  [idx dir]
-  (let [n (field-count)]
-    (php/% (php/+ (php/+ idx dir) n) n)))
+(defn- wrap [i n]
+  (php/% (php/+ (php/% i n) n) n))
 
-(defn- cycle-difficulty [cur dir]
+(defn move-cursor
+  "Move the page cursor by `steps` (negative = up, positive = down),
+   wrapping at both ends. Any integer magnitude is allowed so a held
+   key's OS-repeat burst can move more than one row in a frame."
+  [idx steps]
+  (wrap (php/+ idx steps) (field-count)))
+
+(defn- cycle-difficulty [cur steps]
   (let [n  (count difficulty-choices)
         i  (index-of cur difficulty-choices)
         i' (if (php/< i 0) 0 i)]
-    (get difficulty-choices (php/% (php/+ (php/+ i' dir) n) n))))
+    (get difficulty-choices (wrap (php/+ i' steps) n))))
 
 (defn- field-kind [field-key]
   (loop [fs page-fields]
@@ -105,37 +108,41 @@
       :else                           (recur (rest fs)))))
 
 (defn adjust
-  "Adjust `field-key` on `settings` by `dir` (+1 right / -1 left):
-   volumes move by `pct-step` (clamped), minimap toggles (dir ignored),
-   difficulty cycles. Returns the new settings map; an unknown field
-   leaves it untouched."
-  [settings field-key dir]
+  "Adjust `field-key` on `settings` by `steps` (negative = left,
+   positive = right): volumes move `steps * pct-step` (clamped), the
+   minimap toggles when `steps` is odd, difficulty cycles by `steps`.
+   Any integer magnitude is allowed (a held key ramps a slider).
+   Returns the new settings map; an unknown field leaves it untouched."
+  [settings field-key steps]
   (let [kind (field-kind field-key)]
     (cond
       (= kind :pct)
       (update settings field-key
-              (fn [v] (clamp-pct (php/+ (php/intval v) (php/* dir pct-step)))))
+              (fn [v] (clamp-pct (php/+ (php/intval v) (php/* steps pct-step)))))
 
       (= kind :bool)
-      (update settings field-key not)
+      (if (php/=== 1 (php/abs (php/% steps 2)))
+        (update settings field-key not)
+        settings)
 
       (= kind :enum)
-      (update settings field-key (fn [v] (cycle-difficulty v dir)))
+      (update settings field-key (fn [v] (cycle-difficulty v steps)))
 
       :else          settings)))
 
 (defn navigate
-  "Apply one page-navigation step. `cursor-dir` moves the selection
-   (-1 up, +1 down, 0 none, wrapping); `value-dir` adjusts the selected
-   field (-1 left, +1 right, 0 none). Returns
-   `{:cursor _ :settings _ :adjusted? _}` so the caller can push the
-   new volumes only when something actually changed. Pure: the live
-   audio/minimap effects stay in the caller (commands/play)."
-  [settings cursor cursor-dir value-dir]
-  (let [cursor'   (if (php/=== cursor-dir 0) cursor (move-cursor cursor cursor-dir))
-        adjusted? (not (php/=== value-dir 0))
+  "Apply one frame of page navigation. `cursor-steps` moves the
+   selection (negative up / positive down, wrapping); `value-steps`
+   adjusts the selected field (negative left / positive right). Both
+   are signed integers, so a held key's repeats ramp a slider. Returns
+   `{:cursor _ :settings _ :adjusted? _}` so the caller pushes the new
+   volumes only when something changed. Pure: the live audio/minimap
+   effects stay in the caller (commands/play)."
+  [settings cursor cursor-steps value-steps]
+  (let [cursor'   (if (php/=== cursor-steps 0) cursor (move-cursor cursor cursor-steps))
+        adjusted? (not (php/=== value-steps 0))
         settings' (if adjusted?
-                    (adjust settings (:key (field-at cursor')) value-dir)
+                    (adjust settings (:key (field-at cursor')) value-steps)
                     settings)]
     {:cursor cursor' :settings settings' :adjusted? adjusted?}))
 

--- a/src/glue/controls.phel
+++ b/src/glue/controls.phel
@@ -293,8 +293,7 @@
 (def initial-key-snapshot
   "First-frame snapshot — nothing held yet."
   {:m false :sp false :p false :n false :e false :f false :f3 false :r false :h false
-   :esc false :k1 false :k2 false :k3 false :k4 false
-   :up false :down false :left false :right false})
+   :esc false :k1 false :k2 false :k3 false :k4 false})
 
 (defn- f3-pressed? [keys]
   ;; F3 across terminals: xterm/macOS Terminal/iTerm2 send `\eOR`;
@@ -353,18 +352,32 @@
     (or (str/contains? stripped plain)
         (= 1 (php/preg_match kitty-re keys)))))
 
-(defn- arrow-pressed?
-  "True when an arrow key with final byte `letter` (A=up B=down C=right
-   D=left) is present in `keys` this frame. Matches all three encodings
-   a terminal may send: the CSI form (`\\e[A`), modified / kitty-enhanced
-   CSI (`\\e[1;2A`, `\\e[1;m:eD`), AND the SS3 application-cursor-key
-   form (`\\eOA`) that many terminals + tmux emit in the alternate
-   screen. The settings page consumes these as rising-edge menu
-   navigation. Release events (`:3`) are harmless: a held arrow keeps
-   the key true so no new edge fires until it's let go and pressed
-   again."
+(defn- arrow-count
+  "How many times an arrow with final byte `letter` (A=up B=down C=right
+   D=left) appears in `keys`. Matches every encoding a terminal may
+   send: CSI (`\\e[A`), modified / kitty-enhanced CSI (`\\e[1;2A`,
+   `\\e[1;m:eD`), AND the SS3 application-cursor form (`\\eOA`) that many
+   terminals + tmux emit in the alternate screen. Counting (not a bool)
+   lets a held key's OS-repeat burst ramp a slider."
   [keys letter]
-  (= 1 (php/preg_match (str "/\\x1b(?:\\[[\\d;:]*|O)" letter "/") keys)))
+  (let [m (php/array)]
+    (php/preg_match_all (str "/\\x1b(?:\\[[\\d;:]*|O)" letter "/") keys m)))
+
+(defn nav-deltas
+  "Net menu-navigation intent in `keys` for the settings page, as
+   `{:cursor steps :value steps}` signed integers. Each arrow press
+   counts as one step toward its axis, and the WASD equivalents
+   (`w`/`s` cursor, `a`/`d` value) count too — so navigation works even
+   when a terminal's arrow encoding isn't recognised, and a held key
+   (arrow or WASD) ramps via OS key-repeat. Read straight off the drain
+   string, no rising-edge snapshot needed."
+  [keys]
+  (let [up    (php/+ (arrow-count keys "A") (php/substr_count keys "w"))
+        down  (php/+ (arrow-count keys "B") (php/substr_count keys "s"))
+        left  (php/+ (arrow-count keys "D") (php/substr_count keys "a"))
+        right (php/+ (arrow-count keys "C") (php/substr_count keys "d"))]
+    {:cursor (php/- down up)
+     :value  (php/- right left)}))
 
 (defn key-states
   "Which of the tracked one-shot keys appear in `keys` this frame.
@@ -388,13 +401,7 @@
    :k2 (key-pressed? keys "2" 50)
    :k3 (key-pressed? keys "3" 51)
    :k4 (key-pressed? keys "4" 52)
-   :k5 (key-pressed? keys "5" 53)
-   ;; Settings page: the arrows drive cursor + slider navigation while
-   ;; the pause overlay is open.
-   :up    (arrow-pressed? keys "A")
-   :down  (arrow-pressed? keys "B")
-   :right (arrow-pressed? keys "C")
-   :left  (arrow-pressed? keys "D")})
+   :k5 (key-pressed? keys "5" 53)})
 
 (defn rising-edges
   "Build the edges map tick consumes — truthy only for keys that just
@@ -430,11 +437,4 @@
    ;; F5 quick-save / F9 quick-load (issue #63). Handled in game-loop
    ;; (file IO), not tick-world, so the pure tick stays effect-free.
    :save           (and (:f5 now) (not (:f5 prev)))
-   :load           (and (:f9 now) (not (:f9 prev)))
-   ;; Settings page (issue #107). The pause overlay is the options page;
-   ;; the four nav edges step the cursor (up/down) and adjust the
-   ;; selected value (left/right) one move per press.
-   :nav-up         (and (:up now)   (not (:up prev)))
-   :nav-down       (and (:down now) (not (:down prev)))
-   :nav-left       (and (:left now) (not (:left prev)))
-   :nav-right      (and (:right now) (not (:right prev)))})
+   :load           (and (:f9 now) (not (:f9 prev)))})

--- a/src/io/render.phel
+++ b/src/io/render.phel
@@ -2961,7 +2961,7 @@
           (buf-push p20 (settings-menu-string vw vh
                                               (get stats :settings)
                                               (get stats :settings-cursor)
-                                              "↑↓ move   ←→ change   p resume")))
+                                              "↑↓ws move  ←→ad change  p resume")))
         (when (get stats :help?)
           (buf-push p20 (help-menu-string vw vh stats)))
         (php/implode "" p20)))))
@@ -3267,8 +3267,9 @@
                   (pad-visible "    Use it to navigate without the 2D map." w)
                   blank]
         footer   [:sep blank
-                  (pad-visible "      \e[2;97mpress any key to start\e[40;97m" w)
-                  (pad-visible "      \e[2;97m\e[93ms\e[2;97m for settings\e[40;97m" w)
+                  (pad-visible "      \e[93mENTER\e[40;97m  start game" w)
+                  (pad-visible "      \e[93ms\e[40;97m      settings" w)
+                  (pad-visible "      \e[93mq\e[40;97m      quit" w)
                   blank]]
     (apply vector
            (cond
@@ -3335,7 +3336,7 @@
         (buf-push parts (str "\e[" r ";1H" wash (php/str_repeat " " cols)))
         (recur (php/+ r 1))))
     (buf-push parts (settings-menu-string cols rows settings cursor
-                                          "↑↓ move   ←→ change   esc back"))
+                                          "↑↓ws move  ←→ad change  esc back"))
     (print (php/implode "" parts))
     (php/flush)))
 

--- a/tests/glue/controls-test.phel
+++ b/tests/glue/controls-test.phel
@@ -1,7 +1,8 @@
 (ns phel-doom-tests.glue.controls-test
   (:require phel.test :refer [deftest is])
   (:require phel-doom.glue.controls
-            :refer [key-states refresh-from-keys rising-edges initial-key-snapshot]))
+            :refer [key-states refresh-from-keys rising-edges initial-key-snapshot
+                    nav-deltas]))
 
 (def blank-moves
   {:fwd          0
@@ -303,62 +304,50 @@
     (is (= 0 (:sprint (:moves w'))))))
 
 ;; ---------------------------------------------------------------------
-;; Settings page (issue #107): the pause overlay is the options page;
-;; the arrow keys drive cursor + slider navigation as rising-edge
-;; one-shots. Arrow detection covers the legacy (`\e[A`), modified
-;; (`\e[1;2A`), and kitty-enhanced (`\e[1;m:eA`) forms.
+;; Settings page (issue #107): nav-deltas turns the raw drain string
+;; into net cursor / value steps. Arrows (CSI / SS3 / kitty) AND WASD
+;; both count, and counting (not a bool) means a held key's OS-repeat
+;; burst ramps a slider.
 ;; ---------------------------------------------------------------------
 
-(deftest test-key-states-detects-arrows
-  (is (= true (:up    (key-states "\e[A"))))
-  (is (= true (:down  (key-states "\e[B"))))
-  (is (= true (:right (key-states "\e[C"))))
-  (is (= true (:left  (key-states "\e[D")))))
+(deftest test-nav-deltas-csi-arrows
+  (is (= {:cursor 1  :value 0}  (nav-deltas "\e[B")) "down")
+  (is (= {:cursor -1 :value 0}  (nav-deltas "\e[A")) "up")
+  (is (= {:cursor 0  :value 1}  (nav-deltas "\e[C")) "right")
+  (is (= {:cursor 0  :value -1} (nav-deltas "\e[D")) "left"))
 
-(deftest test-key-states-detects-modified-and-kitty-arrows
-  ;; SHIFT+up (`\e[1;2A`) and a kitty-enhanced up press (`\e[1;1:1A`).
-  (is (= true (:up (key-states "\e[1;2A"))))
-  (is (= true (:up (key-states "\e[1;1:1A")))))
+(deftest test-nav-deltas-ss3-arrows
+  ;; SS3 application-cursor form (`\eO*`) common under tmux / alt-screen.
+  (is (= {:cursor 1 :value 0}  (nav-deltas "\eOB")))
+  (is (= {:cursor 0 :value -1} (nav-deltas "\eOD"))))
+
+(deftest test-nav-deltas-modified-and-kitty-arrows
+  (is (= {:cursor -1 :value 0} (nav-deltas "\e[1;2A")) "shift+up")
+  (is (= {:cursor -1 :value 0} (nav-deltas "\e[1;1:1A")) "kitty up press"))
+
+(deftest test-nav-deltas-wasd-fallback
+  ;; WASD navigates too, so the page works even when arrows aren't
+  ;; recognised by the terminal.
+  (is (= {:cursor 1  :value 0}  (nav-deltas "s")) "s = down")
+  (is (= {:cursor -1 :value 0}  (nav-deltas "w")) "w = up")
+  (is (= {:cursor 0  :value 1}  (nav-deltas "d")) "d = right")
+  (is (= {:cursor 0  :value -1} (nav-deltas "a")) "a = left"))
+
+(deftest test-nav-deltas-counts-repeats-for-ramp
+  ;; A held key's repeated bytes accumulate so a slider ramps.
+  (is (= {:cursor 0 :value 3}  (nav-deltas "ddd")))
+  (is (= {:cursor -2 :value 0} (nav-deltas "\e[A\e[A"))))
+
+(deftest test-nav-deltas-empty-and-non-nav
+  (is (= {:cursor 0 :value 0} (nav-deltas "")))
+  ;; F3's SS3 (`\eOR`) shares the `\eO` prefix but a different final
+  ;; byte, so it is not mistaken for an arrow.
+  (is (= {:cursor 0 :value 0} (nav-deltas "\eOR"))))
 
 (deftest test-ss3-arrow-drives-in-game-turn
-  ;; The same SS3 form must also feed the movement path so turning
-  ;; works under app-cursor mode, not just menu nav.
+  ;; The SS3 form also feeds the movement path so turning works under
+  ;; app-cursor mode, not just menu nav.
   (let [w' (refresh-from-keys blank-world "\eOD")]
     (is (php/> (:turn-left (:moves w')) 0)))
   (let [w' (refresh-from-keys blank-world "\eOC")]
     (is (php/> (:turn-right (:moves w')) 0))))
-
-(deftest test-key-states-detects-ss3-application-cursor-arrows
-  ;; Many terminals / tmux send SS3 arrows (`\eOA`..`\eOD`) in the
-  ;; alternate screen instead of CSI. Menu nav must still work.
-  (is (= true (:up    (key-states "\eOA"))))
-  (is (= true (:down  (key-states "\eOB"))))
-  (is (= true (:right (key-states "\eOC"))))
-  (is (= true (:left  (key-states "\eOD"))))
-  ;; F3's SS3 sequence `\eOR` shares the `\eO` prefix but a different
-  ;; final byte, so it must NOT register as an arrow.
-  (is (= false (:up   (key-states "\eOR"))))
-  (is (= true  (:f3   (key-states "\eOR")))))
-
-(deftest test-key-states-arrows-are-independent
-  (let [s (key-states "\e[A")]
-    (is (= true  (:up s)))
-    (is (= false (:down s)))
-    (is (= false (:left s)))
-    (is (= false (:right s)))))
-
-(deftest test-rising-edges-nav-keys-fire-once
-  (is (= true (:nav-up    (rising-edges (assoc initial-key-snapshot :up true)    initial-key-snapshot))))
-  (is (= true (:nav-down  (rising-edges (assoc initial-key-snapshot :down true)  initial-key-snapshot))))
-  (is (= true (:nav-left  (rising-edges (assoc initial-key-snapshot :left true)  initial-key-snapshot))))
-  (is (= true (:nav-right (rising-edges (assoc initial-key-snapshot :right true) initial-key-snapshot)))))
-
-(deftest test-rising-edges-nav-does-not-refire-while-held
-  (let [held (assoc initial-key-snapshot :right true)]
-    (is (= false (:nav-right (rising-edges held held))))))
-
-(deftest test-initial-key-snapshot-covers-settings-keys
-  (is (= false (:up    initial-key-snapshot)))
-  (is (= false (:down  initial-key-snapshot)))
-  (is (= false (:left  initial-key-snapshot)))
-  (is (= false (:right initial-key-snapshot))))


### PR DESCRIPTION
## Bug

In the settings page (start menu `s` / in-game pause `p`) the arrows moved neither cursor nor sliders. Render + persisted values were fine, so the input path was the culprit.

## Cause

Nav only recognised plain **CSI** arrows (`\e[A`). Terminals/tmux that send **SS3** application-cursor sequences (`\eOA`) or other encodings produced nothing the menu understood. Total dead nav (both axes) pointed at a detection miss, not a hold-vs-tap issue.

## Fix

- **`controls/nav-deltas`** (count-based): sums arrow presses in *every* encoding (CSI / SS3 / kitty) **and WASD** into net `{:cursor :value}` steps.
  - WASD (`w/s` cursor, `a/d` value) is a guaranteed fallback - those bytes always reach the game, so the page is navigable on any terminal.
  - Counting (not a bool) means a held key's OS-repeat burst **ramps a slider** (the hold-to-ramp you picked).
- **`core/settings.navigate` / `move-cursor` / `adjust`** now take signed integer steps (magnitude > 1 ramps; bool toggles on odd steps).
- **Start menu = explicit keys**: ENTER (or space) starts, `s` settings, `q` quits. Stray keys ignored, so an arrow can't accidentally launch the run.
- In-game arrow *turning* also accepts SS3 now.
- Removed the now-unused `:up/:down/:left/:right` key-states + `:nav-*` rising edges.

## Verified

- Headless: WASD + arrow nav move the cursor and ramp sliders (`dd` -> +20%, `ww` wraps); borders measure exactly 38 cols on every row with the new footer.
- `composer ci` green: 1553 tests, lint + format clean, build OK.

Closes the "cannot move the settings" report.