### PR TITLE
fix(settings): apply + persist start-menu options across recur

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 
 ## [Unreleased]
 
+### Fixed
+
+- Start-menu settings page (`s`) now applies + persists every edit. The page loop destructured nav results into locals named `settings`/`cursor`, shadowing the loop bindings so `recur` re-bound the originals and silently dropped each change.
+
 ## [0.7.0] - 2026-06-01
 
 ### Added

--- a/src/commands/play.phel
+++ b/src/commands/play.phel
@@ -1077,11 +1077,15 @@
         (if esc-edge
           ;; Volumes were applied live on each adjust; close just saves.
           (save-settings! settings)
+          ;; Destructure into NON-loop names: binding the result back to
+          ;; locals called `settings` / `cursor` (the loop vars) makes the
+          ;; recur re-bind the loop's ORIGINAL values, silently dropping
+          ;; every edit. Use `nav` + accessors so the recur threads the
+          ;; navigated map forward.
           (let [{:cursor cursor-steps :value value-steps} (nav-deltas keys)
-                {:keys [cursor settings adjusted?]}
-                (navigate settings cursor cursor-steps value-steps)]
-            (when adjusted? (apply-audio-settings! settings))
-            (recur settings cursor now [rows cols])))))))
+                nav                                       (navigate settings cursor cursor-steps value-steps)]
+            (when (:adjusted? nav) (apply-audio-settings! (:settings nav)))
+            (recur (:settings nav) (:cursor nav) now [rows cols])))))))
 
 (defn- start-pressed?
   "True when `keys` carries an ENTER / Return (raw mode sends CR; some


### PR DESCRIPTION
## 📚 Description

The start-menu settings page (`s`) let you move the cursor and the values changed on screen, but every edit (music / sfx / minimap / difficulty) was silently reverted the next frame and never persisted.

Root cause: `settings-screen!`'s page loop destructured `navigate`'s result into locals named `settings` / `cursor` - the same symbols as the `loop` bindings. At the `recur` site those names resolved to the loop's ORIGINAL values, not the shadowing `let` values, so each change was dropped. The in-game pause page was unaffected (it threads through `assoc world`, no loop-name collision).

Verified at runtime by driving the game through a pseudo-tty with paced input: music 50->30, minimap false->true, difficulty normal->hard, all persisted to `~/.phel-doom-settings.json`.

## 🔖 Changes

- Destructure nav result into a single `nav` map; read `(:settings nav)` / `(:cursor nav)` so `recur` threads the navigated state forward.
- CHANGELOG `## [Unreleased]` Fixed entry.