### PR TITLE
feat(render): plainer, deeper wall shading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 
 ## [Unreleased]
 
+### Changed
+
+- Plainer, deeper wall shading. Dropped the per-cell brick speckle for flat shaded stone, swapped the linear distance falloff for a gamma curve (brighter mids), and widened the EW/NS side-shading gap for sharper corners.
+
 ### Fixed
 
 - Start-menu settings page (`s`) now applies + persists every edit. The page loop destructured nav results into locals named `settings`/`cursor`, shadowing the loop bindings so `recur` re-bound the originals and silently dropped each change.

--- a/src/io/render.phel
+++ b/src/io/render.phel
@@ -2204,7 +2204,7 @@
    `haze-shift` int 0-23: how many shade-table steps to pull walls
                 toward black. Doors are kept bright as a nav cue."
   [vw vh haze-shift cast palette blood-cols]
-  (let [{:keys [dists hits sides hxs hys]}                             cast
+  (let [{:keys [dists hits sides]}                                     cast
         {:keys [stbl ctbl sky-c floor-c door-shade-now door-code-now
                 boss-door-shade-now boss-door-code-now]}               palette
         tops                                                           (buf-mk)
@@ -2244,34 +2244,20 @@
             :else
             (let [idx-raw (php/max 0
                                    (php/min 23
-                                            (php/+ (php/intval (php/* (php/- 1.0 (php/min 1.0 (php// dist max-depth))) 23))
-                                                   (if (php/=== (buf-get sides col) 0) 2 0))))
+                                            (php/+ (php/intval (php/* (php/pow (php/- 1.0 (php/min 1.0 (php// dist max-depth))) 0.6) 23))
+                                                   (if (php/=== (buf-get sides col) 0) 3 0))))
                   ;; Haze pulls every wall cell toward index 0 (black)
                   ;; by `haze-shift` steps. 0 = full visibility; values
                   ;; come from frame->string based on player lives.
                   idx     (php/max 0 (php/- idx-raw haze-shift))]
-              (let [wcode     (buf-get ctbl-l idx)
-                    plain     (buf-get stbl-l idx)
-                    hx        (buf-get hxs col)
-                    hy        (buf-get hys col)
-                    bhash     (mod (php/+ (php/* hx 73856093) (php/* hy 19349663)) 100)
+              (let [plain     (buf-get stbl-l idx)
                     shd-idx   (php/max 0 (php/- idx 3))
                     shd-bg    (buf-get stbl-l shd-idx)
                     edge-code (buf-get ctbl-l shd-idx)]
-                (buf-set normal col
-                         ;; Architectural brick texture: ~4% of wall
-                         ;; cells (was 14%; dropped the `·` dot variant
-                         ;; that read as bright noise rather than
-                         ;; mortar). Three glyphs left (▤▦▥) keep
-                         ;; mortar variety without speckling every
-                         ;; corridor.
-                         (if (php/< bhash 4)
-                           (let [dcode (buf-get ctbl-l (php/max 0 (php/- idx 5)))
-                                 glyph (cond (php/=== (mod bhash 3) 0) "▤"
-                                             (php/=== (mod bhash 3) 1) "▦"
-                                             :else                     "▥")]
-                             (str "\e[48;5;" wcode ";38;5;" dcode "m" glyph))
-                           plain))
+                ;; Flat plain wall cells: no per-cell brick speckle. Walls
+                ;; read as clean shaded stone; depth comes from the gamma
+                ;; distance falloff + stronger EW side-shading instead.
+                (buf-set normal col plain)
                 (buf-set top-edge   col (str "\e[48;5;" edge-code ";38;5;" sky-c-l "m▀"))
                 (buf-set bot-edge   col (str "\e[48;5;" floor-c-l ";38;5;" edge-code "m▀"))
                 (buf-set top-shadow col shd-bg)


### PR DESCRIPTION
## 📚 Description

Reworks how walls read in the 3D view: flatter, cleaner surfaces with stronger depth and corner cues. Removing the per-cell texture branch also trims a little per-column work (bench delta within noise).

## 🔖 Changes

- Drop the per-cell brick speckle (`▤▦▥`) so walls render as flat shaded stone.
- Swap the linear distance falloff for a gamma curve (exponent 0.6) - brighter mids so walls pop out of the dark.
- Widen the EW/NS side-shading gap (+2 -> +3) for sharper corners.
- Remove now-unused `hxs` / `hys` destructure + texture-only bindings.
- CHANGELOG `## [Unreleased]` Changed entry.