### PR TITLE
docs: sync wall-shading docs + fix stale docstrings

### DIFF
--- a/docs/rendering.md
+++ b/docs/rendering.md
@@ -45,12 +45,11 @@ overlays (cursor-positioned):
 
 ```
 shade-idx = clamp(0, 23,
-  distance-to-shade(dist)         ; base by distance
-  + (side == 0 ? 1 : 0)           ; vertical face darker
-  + cell-variation-hash(hx, hy))  ; ±1 mottling
+  gamma(distance-to-shade(dist))  ; base by distance, gamma 0.6 curve
+  + (side == 0 ? 3 : 0))          ; NS face brighter (directional light)
 ```
 
-Indexes `shade-table[0..23]`: pre-baked ANSI for 256-color grays (codes 232-255). One lookup per column.
+Walls are flat shaded stone (no per-cell mottling). The gamma 0.6 curve brightens mid-range so walls pop out of the dark; the `+3` NS-face bonus reads as directional lighting and sharpens corners. Indexes `shade-table[0..23]`: pre-baked ANSI for 256-color grays (codes 232-255). One lookup per column.
 
 Doors: `door-shade` (orange for unlocked, blue/red for keycards, bright red for boss-lock). Half-block edges mix door with sky/floor. Locked messages ("NEED BLUE KEY", "KILL THE BOSS") painted separately.
 

--- a/src/commands/play.phel
+++ b/src/commands/play.phel
@@ -208,7 +208,7 @@
 
 (defn- pickup-armors
   "Step-on triggers an armor pickup: bumps :armor by 1, capped at
-   `max-armor` (3) so the player can't farm an indestructible
+   `max-armor` (5) so the player can't farm an indestructible
    buffer. The next contact-damage hit consumes one armor unit
    instead of a life (see combat/take-damage). Pickup is always
    consumed even at cap to match the heart / gain-life pattern."

--- a/src/core/physics.phel
+++ b/src/core/physics.phel
@@ -270,7 +270,8 @@
 
 (defn tick-blood-drops
   "Ambient ceiling-drip effect: advance existing drops and (when
-   :lives <= 3) roll a per-frame chance to spawn a new one. Already-
+   :lives <= 6, i.e. 3 hearts of the 10-HP pool) roll a per-frame
+   chance to spawn a new one. Already-
    falling drops still finish their fall so the cue doesn't pop out
    mid-frame when the player heals back above the threshold. Columns
    are stored normalised (0..1) so the render layer can scale to

--- a/src/io/render.phel
+++ b/src/io/render.phel
@@ -2198,7 +2198,7 @@
    inside this fn and returned in a map; the caller destructures to
    keep the same names it used previously.
 
-   `cast`       ray-cast outputs {:dists :hits :sides :hxs :hys}
+   `cast`       ray-cast outputs {:dists :hits :sides}
    `palette`    {:stbl :ctbl :sky-c :floor-c :door-shade-now :door-code-now}
    `blood-cols` per-col directional blood mask (from build-blood-cols)
    `haze-shift` int 0-23: how many shade-table steps to pull walls
@@ -2590,8 +2590,7 @@
          :top-shadow        shades-top-shadow
          :bot-shadow        shades-bot-shadow}
         (compute-wall-shades vw vh haze-shift
-                             {:dists dists :hits hits :sides sides
-                              :hxs hxs    :hys hys}
+                             {:dists dists :hits hits :sides sides}
                              {:stbl stbl :ctbl ctbl
                               :sky-c sky-c :floor-c floor-c
                               :door-shade-now door-shade-now


### PR DESCRIPTION
## 📚 Description

Doc-sync follow-up to #113 (wall shading) plus two unrelated drifts surfaced during review.

## 🔖 Changes

- `docs/rendering.md`: shade-composition formula described the removed per-cell mottling and the old `+1` side bonus; now documents the flat gamma-0.6 curve + `+3` NS-face model.
- `render.phel`: drop dead `:hxs`/`:hys` from `compute-wall-shades` docstring + call-site map literal (no longer consumed since the speckle removal).
- `play.phel`: `pickup-armors` docstring said cap "(3)"; `max-armor` is 5.
- `physics.phel`: `tick-blood-drops` docstring said `:lives <= 3`; code triggers at `<= 6` (3 hearts of the 10-HP pool).