### PR TITLE
fix(weapons): make the chainsaw obtainable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 ### Fixed
 
 - Start-menu settings page (`s`) now applies + persists every edit. The page loop destructured nav results into locals named `settings`/`cursor`, shadowing the loop bindings so `recur` re-bound the originals and silently dropped each change.
+- Chainsaw (slot 4) is now obtainable. It was fully implemented but never granted: no level dropped it and the `--armory` set omitted it, so pressing `4` was always a no-op. L4 now seeds a chainsaw pickup and `--armory` owns every weapon.
 
 ## [0.7.0] - 2026-06-01
 

--- a/src/commands/play.phel
+++ b/src/commands/play.phel
@@ -969,7 +969,9 @@
          ;; Was a boolean before #68 part 3 - swapped to an int so
          ;; each pickup adds one base's reserve cap.
          bp-level    0
-         owned       (if armory? #{:pistol :shotgun :chaingun} #{:pistol})
+         ;; --armory owns EVERY weapon (README: "own every weapon");
+         ;; derive from weapon-order so a new slot is covered for free.
+         owned       (if armory? (set weapon-order) #{:pistol})
          ;; Active weapon + per-weapon mag/reserve stash carried
          ;; across level cuts so the player doesn't get reset to a
          ;; full pistol every door. Nil weapon = use build-world's

--- a/src/core/level.phel
+++ b/src/core/level.phel
@@ -376,15 +376,16 @@
 
 (defn- maybe-spawn-weapon-pickups
   "Per-level weapon drops. L2 always seeds a shotgun, L3 a chaingun,
-   L7 the rare BFG (issue #58). Each skipped if the player already owns
-   the weapon so a re-played level doesn't spam duplicate pickups.
-   Returns a vector of `{:x :y :weapon kw}` items."
+   L4 the chainsaw, L7 the rare BFG (issue #58). Each skipped if the
+   player already owns the weapon so a re-played level doesn't spam
+   duplicate pickups. Returns a vector of `{:x :y :weapon kw}` items."
   [grid level-num owned]
   (let [owned'     (or owned #{:pistol})
         candidates
         (cond
           (php/=== level-num 2) (if (contains? owned' :shotgun)  [] [:shotgun])
           (php/=== level-num 3) (if (contains? owned' :chaingun) [] [:chaingun])
+          (php/=== level-num 4) (if (contains? owned' :chainsaw) [] [:chainsaw])
           (php/=== level-num 7) (if (contains? owned' :bfg)      [] [:bfg])
           :else                 [])]
     (apply vector

--- a/tests/core/level-test.phel
+++ b/tests/core/level-test.phel
@@ -119,6 +119,18 @@
     (is (= 0 (count (:hearts w))))
     (is (= 10 (:lives w)))))
 
+(deftest test-build-world-l4-drops-chainsaw
+  ;; Regression: the chainsaw (slot 4) was fully implemented but never
+  ;; granted, so it was unreachable. L4 must seed a chainsaw pickup.
+  (let [saws (filter (fn [p] (= :chainsaw (:weapon p)))
+                     (:weapon-pickups (build-world 4 5)))]
+    (is (= 1 (count saws)))))
+
+(deftest test-build-world-l4-skips-chainsaw-when-owned
+  (let [saws (filter (fn [p] (= :chainsaw (:weapon p)))
+                     (:weapon-pickups (build-world 4 5 0 :normal #{:pistol :chainsaw})))]
+    (is (= 0 (count saws)))))
+
 ;; ---------------------------------------------------------------------
 ;; Slim-entry refactor regression: each level's `:enemy` kw is stamped
 ;; on every enemy, and the world's primary `:enemy` matches the level's


### PR DESCRIPTION
## 📚 Description

The chainsaw (slot 4) was fully implemented - catalog entry, `:no-ammo?` combat path, movement-lock physics, pickup sfx - but **unreachable**. No level dropped it (`maybe-spawn-weapon-pickups` seeded only shotgun/chaingun/bfg) and the `--armory` owned set was `#{:pistol :shotgun :chaingun}`. Since `give-weapon`/`switch-weapon` gate on ownership, pressing `4` was always a no-op. The README weapons table already advertises the chainsaw as 'found on map', so this makes that true.

## 🔖 Changes

- `level.phel`: L4 now seeds a chainsaw pickup (skipped if already owned, matching the other weapon drops).
- `play.phel`: `--armory` owned set derived from `weapon-order` (owns every weapon, incl. chainsaw + bfg) so a new slot is covered for free.
- Tests: L4 drops a chainsaw; suppressed when already owned.
- CHANGELOG Fixed entry.