### PR TITLE
fix(rng): make int! exclusive (0..n-1) like rand-int

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 
 - Start-menu settings page (`s`) now applies + persists every edit. The page loop destructured nav results into locals named `settings`/`cursor`, shadowing the loop bindings so `recur` re-bound the originals and silently dropped each change.
 - Chainsaw (slot 4) is now obtainable. It was fully implemented but never granted: no level dropped it and the `--armory` set omitted it, so pressing `4` was always a no-op. L4 now seeds a chainsaw pickup and `--armory` owns every weapon.
+- `rng/int!` is now exclusive (`0..n-1`, like `rand-int`) instead of off-by-one inclusive. Powerup spawn odds were skewed toward spawning (armor 2/3 not 1/2, berserk 2/9 not 1/8, etc.) and map placements could land one cell closer to the edge than intended. Both now match their documented values.
 
 ## [0.7.0] - 2026-06-01
 

--- a/src/core/level.phel
+++ b/src/core/level.phel
@@ -197,7 +197,7 @@
   "Roughly one in two levels carries an armor pickup. Picked up via
    `pickup-armors` in play.phel; absorbs the next contact-damage hit."
   [grid]
-  (if (zero? (mod (rng/int! 2) 2))
+  (if (zero? (rng/int! 2))
     (let [[ax ay] (random-spawn grid)]
       [{:x ax :y ay}])
     []))
@@ -206,7 +206,7 @@
   "Rare berserk sphere — ~1 in 8 levels (was 1 in 4, tuned down
    after v0.3 playtesting found powerups stacking too often)."
   [grid]
-  (if (php/=== 0 (mod (rng/int! 8) 8))
+  (if (php/=== 0 (rng/int! 8))
     (let [[bx by] (random-spawn grid)]
       [{:x bx :y by}])
     []))
@@ -214,7 +214,7 @@
 (defn- maybe-spawn-invuln
   "Very rare — ~1 in 12 levels."
   [grid]
-  (if (php/=== 0 (mod (rng/int! 12) 12))
+  (if (php/=== 0 (rng/int! 12))
     (let [[ix iy] (random-spawn grid)]
       [{:x ix :y iy}])
     []))
@@ -225,7 +225,7 @@
    back to `max-lives` over time, so the player gets a real defensive
    buffer for a stretch of fight."
   [grid]
-  (if (php/=== 0 (mod (rng/int! 10) 10))
+  (if (php/=== 0 (rng/int! 10))
     (let [[sx sy] (random-spawn grid)]
       [{:x sx :y sy}])
     []))
@@ -312,7 +312,7 @@
   (let [lvl (pack->level pack)]
     (if (or (php/>= lvl max-backpacks)
             (php/< level-num 2)
-            (php/!== 0 (mod (rng/int! 5) 5)))
+            (php/!== 0 (rng/int! 5)))
       []
       (let [[bx by] (random-spawn grid)]
         [{:x bx :y by}]))))

--- a/src/core/rng.phel
+++ b/src/core/rng.phel
@@ -50,12 +50,14 @@
   @state)
 
 (defn int!
-  "Random integer in 0..n inclusive (matches `rand-int` semantics).
-   Returns 0 for n <= 0."
+  "Random integer in 0..n-1 (exclusive upper bound, like `rand-int`).
+   Returns 0 for n <= 0. Was off-by-one (0..n inclusive), which skewed
+   every `(mod (int! N) N)` probability roll toward 0 and let map
+   placements land one cell closer to the edge than intended."
   [n]
   (if (php/<= n 0)
     0
-    (php/% (next-raw!) (php/+ n 1))))
+    (php/% (next-raw!) n)))
 
 (defn float!
   "Random float in [0, 1) (replacement for the old

--- a/tests/core/rng-test.phel
+++ b/tests/core/rng-test.phel
@@ -16,10 +16,17 @@
     (is (not (= a (rng/int! 1000000000))) "different seeds diverge")))
 
 (deftest test-int-in-range
+  ;; Exclusive upper bound, like rand-int: 0..n-1, never n.
   (rng/seed! 7)
   (dotimes [_ 60]
            (let [n (rng/int! 5)]
-             (is (and (php/>= n 0) (php/<= n 5))))))
+             (is (and (php/>= n 0) (php/< n 5))))))
+
+(deftest test-int-one-is-always-zero
+  ;; (int! 1) -> {0} only, never 1. Guards the off-by-one regression.
+  (rng/seed! 7)
+  (dotimes [_ 30]
+           (is (php/=== 0 (rng/int! 1)))))
 
 (deftest test-float-in-range
   (rng/seed! 7)


### PR DESCRIPTION
## 📚 Description

`rng/int!` returned `0..n` **inclusive** despite its docstring claiming `rand-int` semantics (exclusive `0..n-1`). This skewed two things:

1. **Powerup spawn odds.** Every roll used `(mod (rng/int! N) N)`; with the inclusive bug, value `0` and value `N` both map to `0`, doubling its odds. Real rates were ~`2/(N+1)`: armor **2/3** (doc says 1/2), berserk **2/9** (doc says 1/8), invuln/soulsphere/backpack similarly off.
2. **Map placement margins.** `(+ 2 (rng/int! (- w 4)))` and friends could land one cell closer to the edge than the intended margin.

Both callers were written assuming exclusive (rand-int) behavior, so fixing `int!` corrects them consistently.

## 🔖 Changes

- `rng.phel`: `int!` now `(php/% (next-raw!) n)` -> `0..n-1`. Docstring corrected.
- `level.phel`: dropped the now-redundant `(mod (rng/int! N) N)` wrappers on the 5 spawn rolls.
- `rng-test`: range test asserts exclusive bound; new `(int! 1) == 0` regression guard.
- CHANGELOG Fixed entry.

Note: this changes the RNG sequence, so old recorded demos (`--demo`) will replay differently. Full suite green (1585 assertions); map/level structural tests unaffected.