### PR TITLE
ref(combat): move play-sfx! to the io boundary

### DIFF
--- a/docs/audio.md
+++ b/docs/audio.md
@@ -8,6 +8,8 @@ One-shot SFX via `src/io/sound.phel` (shell-out) + ambient drone via `src/io/amb
 
 Combat raises events by name: `:shoot`, `:shoot-shotgun`, `:shoot-chaingun`, `:shoot-chainsaw`, `:shoot-bfg`, `:hit`, `:kill`, `:reload`, `:click`, `:door`, `:heartbeat`, `:berserk`, `:wound`.
 
+`core/combat` is pure: it enqueues `{:name :vol}` events on the world's per-frame `:sfx` queue rather than calling `play-sfx!`. `commands/play` drains the queue after `tick-world` and emits each event, gated on `:sound-on`. Keeps the effect at the io boundary.
+
 macOS maps to `.aiff`: Pop (pistol/kill), Blow (shotgun), Morse (chaingun), Purr (chainsaw), Glass (BFG), Sosumi (player-hurt), Basso (dry-fire), Funk (reload), Tink (door/pickup), Submarine (wound), Bottle (heartbeat), Hero (berserk).
 
 ## Per-weapon fire report

--- a/docs/combat.md
+++ b/docs/combat.md
@@ -1,6 +1,6 @@
 # Combat
 
-Hitscan + damage timing + i-frames. `src/core/combat.phel`. Only side effect: `play-sfx!`, gated by `(:sound-on world)`.
+Hitscan + damage timing + i-frames. `src/core/combat.phel`. Pure: no side effects. Sound cues (gun report, kill, pain, dry-fire click) are enqueued as `{:name :vol}` events on the world's per-frame `:sfx` queue; `commands/play` drains it after `tick-world` and emits via `play-sfx!`, gated by `(:sound-on world)`.
 
 ## Tunables
 

--- a/src/commands/play.phel
+++ b/src/commands/play.phel
@@ -518,7 +518,10 @@
    physics, collect pickups, advance enemies, resolve a shot, decay
    timers + apply contact damage."
   [world keys ^float dt edges]
-  (let [w0 (handle-toggles world edges)]
+  ;; Reset the per-frame combat sfx queue up front so events from
+  ;; core/combat accumulate fresh each tick; the game loop drains
+  ;; `:sfx` after this returns and emits them via io/sound.
+  (let [w0 (assoc (handle-toggles world edges) :sfx [])]
     (cond
       (:paused w0)                             w0
       ;; Hit-stop: a meaty kill stamped `:hit-stop-secs` last frame.
@@ -856,6 +859,13 @@
               ;; player's choices (volumes were already applied live).
               (when (resumed-pause? world world')
                 (persist-settings! world'))
+              ;; Drain the per-frame combat sfx queue that core/combat
+              ;; built (gun reports, kill cues, pain, dry-fire clicks).
+              ;; core/ stays effect-free; emission lives here, gated on
+              ;; :sound-on like every other cue.
+              (when (:sound-on world')
+                (doseq [ev (:sfx world')]
+                       (play-sfx! (:name ev) (:vol ev))))
               (when (and (:heartbeat-tick? world') (:sound-on world'))
                 (play-sfx! :heartbeat 0.35))
               (when (and (:silence-tick? world') (:sound-on world'))

--- a/src/core/combat.phel
+++ b/src/core/combat.phel
@@ -5,8 +5,7 @@
   (:require phel-doom.core.enemy-ai :refer [attacks? noise-wake])
   (:require phel-doom.core.physics  :refer [try-move])
   (:require phel-doom.core.state    :refer [max-lives])
-  (:require phel-doom.core.weapons  :refer [weapon-order weapon-spec weapons])
-  (:require phel-doom.io.sound      :refer [play-sfx!]))
+  (:require phel-doom.core.weapons  :refer [weapon-order weapon-spec weapons]))
 
 (def shot-knockback-distance
   "World units an enemy is shoved AWAY from the player on every shot
@@ -25,9 +24,19 @@
 
 ;; ---------------------------------------------------------------------
 ;; Combat: the hitscan trigger pull (fire-shot) and the damage / i-frame
-;; ticking (damage-step). Both consume and produce a world; only
-;; play-sfx! side-effects, gated by (:sound-on world).
+;; ticking (damage-step). Both consume and produce a world. Pure: sound
+;; effects are not played here. Combat enqueues `{:name :vol}` events on
+;; the world's per-frame `:sfx` queue via `push-sfx`; io (commands/play)
+;; drains it after tick-world and emits them, gated on (:sound-on world).
 ;; ---------------------------------------------------------------------
+
+(defn- push-sfx
+  "Append a sound event to the world's per-frame `:sfx` queue. Keeps
+   core/combat effect-free: the io layer drains `:sfx` after the tick
+   and plays each event (gated on :sound-on). `tick-world` clears the
+   queue at the start of every frame, so events never replay."
+  [world name ^float vol]
+  (update world :sfx (fn [s] (conj (or s []) {:name name :vol vol}))))
 
 ;; =====================================================================
 ;; § Tunables
@@ -388,11 +397,12 @@
         damaged (if (php/> armor 0)
                   (assoc world :armor (php/- armor 1))
                   (update world :lives (fn [l] (php/max 0 (php/- l dmg)))))]
-    (when (:sound-on world) (play-sfx! :hit vol))
-    (assoc (knockback damaged att)
-           :iframes    iframe-seconds
-           :flash-secs flash-seconds
-           :hurt-side  (attacker-side att (:x p) (:y p) (:angle p)))))
+    (push-sfx
+     (assoc (knockback damaged att)
+            :iframes    iframe-seconds
+            :flash-secs flash-seconds
+            :hurt-side  (attacker-side att (:x p) (:y p) (:angle p)))
+     :hit vol)))
 
 (defn hit-player-at
   "Apply one hit from a point source at world `(sx, sy)` for `dmg` HP —
@@ -581,24 +591,29 @@
 (defn- on-shot-miss [world]
   (assoc world :fire-anim fire-anim-seconds))
 
-(defn- play-shot-sfx [world killed? hit-pos]
-  (when (:sound-on world)
-    ;; Always fire the ACTIVE weapon's own report so every trigger pull
-    ;; sounds like the gun going off — hit or miss. Earlier this only
-    ;; played a gun sound on a MISS; a shot that connected swapped in the
-    ;; enemy reaction, so the weapon (esp. the shotgun) felt silent when
-    ;; you actually hit something. Per-weapon `:fire-sfx` (weapons spec)
-    ;; gives each gun a distinct voice; falls back to :shoot.
-    (play-sfx! (or (:fire-sfx (w-spec world)) :shoot) 1.0)
-    ;; Layer the kill cue ON TOP of the fire report so a kill keeps its
-    ;; punch, distance-attenuated. Wounds ride on the fire sound plus
-    ;; the floating HP digit + blood splatter — no separate thud.
-    (when killed?
-      (let [p  (:player world)
+(defn- enqueue-shot-sfx
+  "Append the shot's sound events to `out`'s :sfx queue and return it.
+   `src` is the pre-shot world (active weapon spec + player position).
+
+   Always queue the ACTIVE weapon's own report so every trigger pull
+   sounds like the gun going off — hit or miss. Earlier this only
+   played a gun sound on a MISS; a shot that connected swapped in the
+   enemy reaction, so the weapon (esp. the shotgun) felt silent when
+   you actually hit something. Per-weapon `:fire-sfx` (weapons spec)
+   gives each gun a distinct voice; falls back to :shoot.
+
+   On a kill, layer the kill cue ON TOP of the fire report so a kill
+   keeps its punch, distance-attenuated. Wounds ride on the fire sound
+   plus the floating HP digit + blood splatter — no separate thud."
+  [out src killed? hit-pos]
+  (let [fired (push-sfx out (or (:fire-sfx (w-spec src)) :shoot) 1.0)]
+    (if killed?
+      (let [p  (:player src)
             dx (php/- (:x hit-pos) (:x p))
             dy (php/- (:y hit-pos) (:y p))
             d  (php/sqrt (php/+ (php/* dx dx) (php/* dy dy)))]
-        (play-sfx! :kill (distance-volume d))))))
+        (push-sfx fired :kill (distance-volume d)))
+      fired)))
 
 (defn can-fire?
   "True when the active weapon is ready: cooldown elapsed, not jammed,
@@ -725,8 +740,9 @@
                        (assoc unlocked :hit-stop-secs
                               (if boss-killed? hit-stop-boss-seconds hit-stop-tough-seconds))
                        unlocked)]
-    (play-shot-sfx world killed? hit-pos)
-    (apply-heat (push-blood-fx (assoc juiced :fire-anim fire-anim-seconds) hit-pos))))
+    (enqueue-shot-sfx
+     (apply-heat (push-blood-fx (assoc juiced :fire-anim fire-anim-seconds) hit-pos))
+     world killed? hit-pos)))
 
 (defn fire-shot
   "Resolve one trigger pull end-to-end. Splash weapons (BFG) route to
@@ -743,10 +759,11 @@
           woken                       (noise-wake enemies' (:grid world) (:x p) (:y p))
           killed?                     (and hit?
                                            (false? (:alive (get woken idx))))]
-      (play-shot-sfx world killed? hit-pos)
-      (apply-heat (if hit?
-                    (on-shot-hit world woken hit-pos idx)
-                    (on-shot-miss (assoc world :enemies woken)))))))
+      (enqueue-shot-sfx
+       (apply-heat (if hit?
+                     (on-shot-hit world woken hit-pos idx)
+                     (on-shot-miss (assoc world :enemies woken))))
+       world killed? hit-pos))))
 
 (defn- empty-trigger-pull
   "Trigger pulled while mag = 0 AND no cooldown / jam in the way. Arm
@@ -756,8 +773,7 @@
    states already (jam label / fire-anim) so doubling up would be
    noisy."
   [world]
-  (when (:sound-on world) (play-sfx! :click 0.6))
-  (assoc world :empty-click-secs empty-click-seconds))
+  (push-sfx (assoc world :empty-click-secs empty-click-seconds) :click 0.6))
 
 (defn tick-shooting
   "Resolve a shot when the trigger is active this frame AND the

--- a/tests/core/combat-test.phel
+++ b/tests/core/combat-test.phel
@@ -237,6 +237,33 @@
                          false)]
     (is (= 0.0 (or (:empty-click-secs w) 0.0)))))
 
+;; ---------------------------------------------------------------------
+;; SFX events: combat is pure (no io require). Instead of playing sound,
+;; it enqueues {:name :vol} on the world's :sfx queue; io/play drains +
+;; emits. These pin that contract (io-boundary).
+;; ---------------------------------------------------------------------
+
+(defn- sfx-named [world name]
+  (filter (fn [e] (= name (:name e))) (:sfx world)))
+
+(deftest test-empty-trigger-enqueues-click-event
+  (let [w (tick-shooting {:mag 0 :fire-cooldown 0.0 :jam-secs 0.0
+                          :reload-cooldown 0.0 :ammo-reserve 20}
+                         true)]
+    (is (= 1 (count (sfx-named w :click))))))
+
+(deftest test-hit-player-enqueues-hit-event
+  (let [w  (new-world [[1 1 1] [1 0 1] [1 1 1]] (new-player 1.5 1.5 0.0))
+        w' (hit-player-at w 1.5 1.5 1)]
+    (is (= 1 (count (sfx-named w' :hit))))))
+
+(deftest test-fire-shot-enqueues-weapon-report
+  ;; A trigger pull that misses still queues the active weapon's report.
+  (let [w0 (new-world [[1 1 1] [1 0 1] [1 1 1]] (new-player 1.5 1.5 0.0))
+        w  (assoc w0 :mag 6 :weapon :pistol :fire-cooldown 0.0 :enemies [])
+        w' (tick-shooting w true)]
+    (is (pos? (count (:sfx w'))) "fire report queued")))
+
 (deftest test-tick-shooting-empty-mag-skip-when-jammed
   ;; Jam already has its own visual cue (paint-door-face / fire-anim).
   ;; Suppress the click so we don't double up.


### PR DESCRIPTION
## 📚 Description

`core/combat.phel` required `io/sound` and called `play-sfx!` directly (gun report, kill cue, pain, dry-fire click) - the **only** `core/` file breaking the io-boundary rule (`core/` -> `glue/` -> `io/`, never the reverse; see `.claude/rules/io-boundaries.md`).

Combat is now **pure**. It enqueues `{:name :vol}` events on the world's per-frame `:sfx` queue via a new `push-sfx` helper, mirroring the existing `:heartbeat-tick?` pattern. `tick-world` resets the queue each frame; `commands/play` drains it after the tick and emits via `play-sfx!`, gated on `:sound-on` exactly as before.

**No behavior change**: same events, same timing, same `:sound-on` gating, same distance attenuation. Pure refactor, so no CHANGELOG entry.

## 🔖 Changes

- `combat.phel`: drop the `io/sound` require; `push-sfx` helper; `apply-hit`/`empty-trigger-pull`/`fire-shot`/`bfg-fire` enqueue instead of play. `play-shot-sfx` (side-effecting, returned nil) becomes pure `enqueue-shot-sfx`.
- `play.phel`: `tick-world` clears `:sfx` per frame; game loop drains + emits.
- Tests pin the contract (fire report / hit / dry-fire enqueue events).
- `docs/combat.md` + `docs/audio.md` updated. `grep -rln 'require phel-doom.io' src/core/` now returns nothing.