### PR TITLE
ref: tidy two low-severity review findings

### DIFF
--- a/src/core/combat.phel
+++ b/src/core/combat.phel
@@ -479,6 +479,10 @@
   (cond
     (php/< roll (:ammo  loot-drop-chance)) :ammo
     (php/< roll (:armor loot-drop-chance)) :armor
+    ;; A heart only drops when it would actually heal. At full HP a roll
+    ;; in the heart band does NOT re-bucket to ammo/armor - it falls
+    ;; through to nil (no drop), by design (~3% of kills drop nothing
+    ;; that otherwise would have given a heart).
     (and (php/< roll (:heart loot-drop-chance))
          (php/< (or (:lives world) 0) max-lives)) :heart
     :else nil))

--- a/src/core/enemy_ai.phel
+++ b/src/core/enemy_ai.phel
@@ -68,13 +68,11 @@
    than the radius itself."
   3)
 
-(def bfs-steps
-  "Module-level constant for the 4-connected BFS neighbour offsets.
-   Lifted out of `bfs-cells`'s inner loop so the vector isn't
-   re-allocated on every queue iteration. Not intended for use from
-   other modules, but Phel `def` doesn't carry a private marker so
-   the convention is 'internal helpers live near their caller'."
-  [[1 0] [-1 0] [0 1] [0 -1]])
+;; 4-connected BFS neighbour offsets. Lifted out of `bfs-cells`'s inner
+;; loop so the vector isn't re-allocated on every queue iteration.
+;; Private (`def-` takes no docstring slot, so this note lives here):
+;; only `bfs-cells` in this ns uses it.
+(def- bfs-steps [[1 0] [-1 0] [0 1] [0 -1]])
 
 (def pain-stagger-secs
   "Seconds a freshly-painted enemy stays frozen. ~0.3s reads as a


### PR DESCRIPTION
## 📚 Description

Two low-severity cleanups from the review hunt. No behavior change.

The third flagged item (`scores.phel` ignoring `write-scores!`'s result) was a **false positive**: the module docstring already documents that *both* load and save errors are swallowed by design ('we'd rather lose a score than block a game from running'). No change.

## 🔖 Changes

- `enemy_ai.phel`: `bfs-steps` was a public `def` whose own comment claimed 'Phel `def` doesn't carry a private marker'. It does - `def-` (already used in `engine.phel`). Made private. Note: `def-` takes no docstring slot (string would become the value), so the explanation moved to a line comment.
- `combat.phel`: `roll-loot-kind` now comments that a heart roll at full HP falls through to nil instead of re-bucketing to ammo/armor - by design (~3% of kills).

Full suite green (1588).