### PR TITLE
docs: add def- no-docstring gotcha; simplify changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,13 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 
 ### Changed
 
-- Plainer, deeper wall shading. Dropped the per-cell brick speckle for flat shaded stone, swapped the linear distance falloff for a gamma curve (brighter mids), and widened the EW/NS side-shading gap for sharper corners.
+- Plainer, deeper wall shading: flat shaded stone (no brick speckle), gamma distance falloff for brighter mids, stronger corner contrast.
 
 ### Fixed
 
-- Start-menu settings page (`s`) now applies + persists every edit. The page loop destructured nav results into locals named `settings`/`cursor`, shadowing the loop bindings so `recur` re-bound the originals and silently dropped each change.
-- Chainsaw (slot 4) is now obtainable. It was fully implemented but never granted: no level dropped it and the `--armory` set omitted it, so pressing `4` was always a no-op. L4 now seeds a chainsaw pickup and `--armory` owns every weapon.
-- `rng/int!` is now exclusive (`0..n-1`, like `rand-int`) instead of off-by-one inclusive. Powerup spawn odds were skewed toward spawning (armor 2/3 not 1/2, berserk 2/9 not 1/8, etc.) and map placements could land one cell closer to the edge than intended. Both now match their documented values.
+- Start-menu settings (`s`) now apply and persist; music/sfx/minimap/difficulty edits were silently dropped.
+- Chainsaw (slot 4) is now obtainable: it drops on L4 and `--armory` includes it (was unreachable dead content).
+- Powerup spawn odds and map placement margins now match their documented values (`rng/int!` was off-by-one inclusive).
 
 ## [0.7.0] - 2026-06-01
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -100,6 +100,23 @@ A `let` inside a `loop` that destructures into a local sharing a loop-binding na
 
 Bit the start-menu options page (`settings-screen!`): every change applied live then reverted on the next frame.
 
+### `def-` takes no docstring slot
+
+`def` accepts `(def name "doc" value)`, but the private `def-` is `(def- name value)` only. Pass a docstring and it silently becomes the VALUE; the real value is dropped. Lint stays quiet, so it surfaces as a runtime type error far from the def.
+
+```phel
+;; BROKEN - bfs-steps is now the STRING, not the vector
+(def- bfs-steps
+  "4-connected BFS offsets."
+  [[1 0] [-1 0] [0 1] [0 -1]])   ; dropped -> later (+ int bfs-steps) blows up
+
+;; FIX - move the note to a line comment
+;; 4-connected BFS offsets.
+(def- bfs-steps [[1 0] [-1 0] [0 1] [0 -1]])
+```
+
+`defn-` DOES take a docstring; only `def-` is the odd one out.
+
 ### Lint warnings are often false positives
 
 `vendor/bin/phel lint` warns on:


### PR DESCRIPTION
## 📚 Description

Two small docs touch-ups closing out this batch of work.

## 🔖 Changes

- `docs/contributing.md`: new Phel gotcha - `def-` takes no docstring slot (unlike `def`/`defn-`); a docstring silently becomes the value and the real value is dropped, surfacing as a runtime type error lint won't catch. Placed next to the destructure + recur-shadow gotchas it resembles. (This one bit the #119 `bfs-steps` change.)
- `CHANGELOG.md`: tightened the `## [Unreleased]` entries (walls / settings / chainsaw / rng) to concise user-facing lines. Docs/refactor PRs stay out per the file's own rule (only feat/fix/perf are user-facing).