### PR TITLE
fix(controls): settings cursor moves once per arrow tap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 - Start-menu settings (`s`) now apply and persist; music/sfx/minimap/difficulty edits were silently dropped.
 - Chainsaw (slot 4) is now obtainable: it drops on L4 and `--armory` includes it (was unreachable dead content).
 - Powerup spawn odds and map placement margins now match their documented values (`rng/int!` was off-by-one inclusive).
+- Settings cursor no longer jumps two rows per arrow tap. On kitty-protocol terminals a tap sends a press and a release event; both were counted as navigation. Release events are now ignored (held-key ramp still works via repeat events).
 
 ## [0.7.0] - 2026-06-01
 

--- a/src/glue/controls.phel
+++ b/src/glue/controls.phel
@@ -353,15 +353,21 @@
         (= 1 (php/preg_match kitty-re keys)))))
 
 (defn- arrow-count
-  "How many times an arrow with final byte `letter` (A=up B=down C=right
-   D=left) appears in `keys`. Matches every encoding a terminal may
-   send: CSI (`\\e[A`), modified / kitty-enhanced CSI (`\\e[1;2A`,
-   `\\e[1;m:eD`), AND the SS3 application-cursor form (`\\eOA`) that many
-   terminals + tmux emit in the alternate screen. Counting (not a bool)
-   lets a held key's OS-repeat burst ramp a slider."
+  "How many PRESS / REPEAT arrows with final byte `letter` (A=up B=down
+   C=right D=left) appear in `keys`. Matches every encoding a terminal
+   may send: CSI (`\\e[A`), modified / kitty-enhanced CSI (`\\e[1;2A`,
+   `\\e[1;1:2A`), AND the SS3 application-cursor form (`\\eOA`) that many
+   terminals + tmux emit in the alternate screen.
+
+   Excludes kitty RELEASE events (`:3`). With report-event-types on
+   (`\\e[>3u` in init-input!) a single tap sends a press AND a release;
+   counting both moved the settings cursor twice per keypress. The
+   optional `(?::[12])?` accepts press (`:1` / none) and repeat (`:2`,
+   so a held key still ramps) but not release. Counting (not a bool)
+   lets a held key's repeat burst ramp a slider."
   [keys letter]
   (let [m (php/array)]
-    (php/preg_match_all (str "/\\x1b(?:\\[[\\d;:]*|O)" letter "/") keys m)))
+    (php/preg_match_all (str "/\\x1b(?:\\[[\\d;]*(?::[12])?|O)" letter "/") keys m)))
 
 (defn nav-deltas
   "Net menu-navigation intent in `keys` for the settings page, as

--- a/tests/glue/controls-test.phel
+++ b/tests/glue/controls-test.phel
@@ -325,6 +325,20 @@
   (is (= {:cursor -1 :value 0} (nav-deltas "\e[1;2A")) "shift+up")
   (is (= {:cursor -1 :value 0} (nav-deltas "\e[1;1:1A")) "kitty up press"))
 
+(deftest test-nav-deltas-excludes-kitty-release-events
+  ;; Regression (menu double-move): with report-event-types on
+  ;; (\e[>3u in init-input!), a single arrow tap sends a PRESS and a
+  ;; RELEASE (:3). Counting both moved the settings cursor twice per
+  ;; keypress. Release events must NOT count.
+  (is (= {:cursor 0 :value 0} (nav-deltas "\e[1;1:3B")) "release alone = no move")
+  (is (= {:cursor 1 :value 0} (nav-deltas "\e[B\e[1;1:3B")) "bare press + release = one move")
+  (is (= {:cursor 1 :value 0} (nav-deltas "\e[1;1:1B\e[1;1:3B")) "press + release = one move"))
+
+(deftest test-nav-deltas-counts-kitty-repeat-for-ramp
+  ;; A held arrow on kitty sends press then repeat (:2) events; both
+  ;; count so the slider still ramps. Only release (:3) is dropped.
+  (is (= {:cursor 3 :value 0} (nav-deltas "\e[1;1:1B\e[1;1:2B\e[1;1:2B"))))
+
 (deftest test-nav-deltas-wasd-fallback
   ;; WASD navigates too, so the page works even when arrows aren't
   ;; recognised by the terminal.


### PR DESCRIPTION
## 📚 Description

In the settings page (pause screen and start-menu options), a single up/down arrow tap moved the cursor **two rows**.

Cause: `init-input!` enables the kitty keyboard protocol with report-event-types (`\e[>3u`), so a single tap emits a **press** AND a **release** event (e.g. `\e[B` then `\e[1;1:3B`). `arrow-count`'s regex `/\x1b(?:\[[\d;:]*|O)<letter>/` allowed `:3` in the param class, so it counted the release as a second navigation step.

## 🔖 Changes

- `controls.phel`: `arrow-count` now matches press (`:1` / none) and repeat (`:2`) events but excludes release (`:3`), via `(?::[12])?` - same press-only convention `key-pressed?` already uses for CSI-u keys. Held-key ramp still works (repeats counted).
- Tests: release alone = no move; tap (press+release) = one move; held (press+repeats) still ramps.
- CHANGELOG Fixed entry.

Fixes both settings entry points. WASD nav unaffected (unmodified letters stay plain text under `\e[>3u`); movement keys don't use `nav-deltas`. Full suite green (1592).