### PR TITLE
feat(render): weapon-aware reload reminder (#128)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 
 ### Changed
 
+- `press R to RELOAD` reminder is now weapon-aware (#128): it arms on the remaining-mag fraction instead of an absolute count, and is suppressed for single-round mags (the BFG no longer nags on its 1/1 magazine).
 - Plainer, deeper wall shading: flat shaded stone (no brick speckle), gamma distance falloff for brighter mids, stronger corner contrast.
 
 ### Fixed

--- a/docs/combat.md
+++ b/docs/combat.md
@@ -33,6 +33,8 @@ Per-weapon overrides in `weapons.phel`: mag-size, fire-cooldown, reload-duration
 
 Empty trigger pulls → `empty-trigger-pull`: arm `:empty-click-secs` (0.8s), play `:click` sfx. Render paints `CLICK · press R to reload` or `OUT OF AMMO`.
 
+The periodic `press R to RELOAD` nag is gated by the pure `reload-reminder-visible?` (`io/render.phel`). It arms on the remaining-mag **fraction** (`<= reload-reminder-frac`, 0.3) rather than an absolute count, so a 10-round pistol and a 4-round shotgun both nag at "nearly empty". Single-round mags (BFG, chainsaw: `mag-size <= 1`) reload every shot by design, so the nag is suppressed entirely. It is also suppressed while reloading, when the reserve is dry, during the dry-fire CLICK, and on viewports under 9 rows.
+
 Fresh run starts with 30 reserve (3 mags); cap 50. Pickups refill (see [`level-system.md`](level-system.md)).
 
 ## Kill loot

--- a/src/io/render.phel
+++ b/src/io/render.phel
@@ -1540,36 +1540,66 @@
         (buf-push parts (str "\e[1;" col "H" label))))
     parts))
 
+(def reload-reminder-frac
+  "Mag fraction at or below which the periodic reload nag arms. Relative
+   to the weapon's mag-size so a 10-round pistol and a 4-round shotgun
+   both nag at 'nearly empty' rather than a shared absolute count."
+  0.3)
+
+(defn- reload-reminder-interval
+  "Seconds between reminder blinks, scaled by urgency: an empty mag
+   pulses fastest, a merely-low mag slower. Driven by the remaining-mag
+   fraction so the cadence is weapon-size agnostic."
+  [^int mag ^float frac]
+  (cond
+    (php/<= mag 0)    1.0
+    (php/<= frac 0.1) 3.0
+    :else             5.0))
+
+(defn reload-reminder-visible?
+  {:doc "True when the periodic 'press R to RELOAD' nag should be on
+         screen this frame, given ammo state + the game clock. Pure so
+         the threshold + cadence rules are unit-testable independent of
+         the ANSI paint.
+
+         Armed only when the mag fraction is at or below
+         `reload-reminder-frac` AND there is reserve to draw from.
+         Suppressed: while reloading (`reload-cd` > 0), during the
+         dry-fire CLICK (so prompts don't stack), and on tiny viewports
+         (`vh` < 9). Single-round mags (BFG, chainsaw: mag-size <= 1)
+         reload every shot by design, so the nag is pure noise and is
+         skipped entirely."
+   :see-also ["reload-reminder-interval" "paint-reload-reminder"]
+   :example "(reload-reminder-visible? 2 10 30 0.0 0.0 0.0 30) ; => true"}
+  [^int mag ^int mag-size ^int reserve ^float reload-cd ^float click-secs ^float game-time ^int vh]
+  (and (php/> mag-size 1)
+       (php/> reserve 0)
+       (php/<= reload-cd 0.0)
+       (php/<= click-secs 0.0)
+       (php/>= vh 9)
+       (let [frac (php// mag mag-size)]
+         (and (php/<= frac reload-reminder-frac)
+              (php/< (php/fmod game-time (reload-reminder-interval mag frac)) 0.5)))))
+
 (defn- paint-reload-reminder
-  "Periodic 'press R to RELOAD' nag above the pistol when the player
-   is sitting on a near-empty mag with reserve to spare. Cadence
-   scales with urgency: visible 0.5s every 5s at mag=2, every 3s at
-   mag=1, every 1s at mag=0. Suppressed while reloading (cooldown
-   active), when the reserve is dry (a reload would no-op), and
-   while the dry-fire CLICK is on screen so the two prompts don't
-   stack."
+  "Periodic 'press R to RELOAD' nag above the gun when the player is
+   sitting on a near-empty mag with reserve to spare. Visibility +
+   cadence are decided by the pure `reload-reminder-visible?`; this fn
+   only positions and paints the chip."
   [parts stats vw vh]
-  (let [mag     (or (get stats :mag) 0)
-        reserve (or (get stats :ammo-reserve) 0)
-        cd      (or (get stats :reload-cooldown) 0.0)
-        click   (or (get stats :empty-click-secs) 0.0)
-        gt      (or (get stats :game-time) 0.0)]
-    (when (and (php/> reserve 0)
-               (php/<= cd 0.0)
-               (php/<= click 0.0)
-               (php/<= mag 2)
-               (php/>= vh 9))
-      (let [interval (cond (php/<= mag 0) 1.0
-                           (php/<= mag 1) 3.0
-                           :else          5.0)
-            phase    (php/fmod gt interval)]
-        (when (php/< phase 0.5)
-          (let [text  " press R to RELOAD "
-                label (str "\e[40;38;5;226;1m" text "\e[0m")
-                col   (php/max 1 (php/- (php/intdiv vw 2)
-                                        (php/intdiv (php/strlen text) 2)))
-                row   (php/max 3 (php/- vh 8))]
-            (buf-push parts (str "\e[" row ";" col "H" label)))))))
+  (let [mag      (or (get stats :mag) 0)
+        mag-size (or (get stats :mag-size) 10)
+        reserve  (or (get stats :ammo-reserve) 0)
+        cd       (or (get stats :reload-cooldown) 0.0)
+        click    (or (get stats :empty-click-secs) 0.0)
+        gt       (or (get stats :game-time) 0.0)]
+    (when (reload-reminder-visible? mag mag-size reserve cd click gt vh)
+      (let [text  " press R to RELOAD "
+            label (str "\e[40;38;5;226;1m" text "\e[0m")
+            col   (php/max 1 (php/- (php/intdiv vw 2)
+                                    (php/intdiv (php/strlen text) 2)))
+            row   (php/max 3 (php/- vh 8))]
+        (buf-push parts (str "\e[" row ";" col "H" label)))))
   parts)
 
 (defn- paint-save-flash

--- a/src/io/render.phel
+++ b/src/io/render.phel
@@ -1547,12 +1547,12 @@
   0.3)
 
 (defn- reload-reminder-interval
-  "Seconds between reminder blinks, scaled by urgency: an empty mag
-   pulses fastest, a merely-low mag slower. Driven by the remaining-mag
-   fraction so the cadence is weapon-size agnostic."
-  [^int mag ^float frac]
+  "Seconds between reminder blinks, scaled by urgency from the
+   remaining-mag fraction: an empty mag (frac 0) pulses fastest, a
+   merely-low mag slower. Weapon-size agnostic."
+  [^float frac]
   (cond
-    (php/<= mag 0)    1.0
+    (php/<= frac 0.0) 1.0
     (php/<= frac 0.1) 3.0
     :else             5.0))
 
@@ -1579,7 +1579,7 @@
        (php/>= vh 9)
        (let [frac (php// mag mag-size)]
          (and (php/<= frac reload-reminder-frac)
-              (php/< (php/fmod game-time (reload-reminder-interval mag frac)) 0.5)))))
+              (php/< (php/fmod game-time (reload-reminder-interval frac)) 0.5)))))
 
 (defn- paint-reload-reminder
   "Periodic 'press R to RELOAD' nag above the gun when the player is

--- a/tests/io/render-test.phel
+++ b/tests/io/render-test.phel
@@ -1,6 +1,51 @@
 (ns phel-doom-tests.io.render-test
   (:require phel.test :refer [deftest is])
-  (:require phel-doom.io.render :refer [direction-char project-enemy enemy-front-visible-at?]))
+  (:require phel-doom.io.render :refer [direction-char project-enemy enemy-front-visible-at? reload-reminder-visible?]))
+
+;; ---------------------------------------------------------------------
+;; reload-reminder-visible? (#128): the periodic "press R to RELOAD" nag
+;; must scale to the active weapon's mag-size instead of an absolute
+;; mag<=2 threshold. Single-round mags (BFG mag-size 1) reload every
+;; shot by design, so the nag is pure noise and must be suppressed.
+;; ---------------------------------------------------------------------
+
+(deftest test-reload-reminder-suppressed-for-single-round-mag
+  ;; BFG: mag-size 1. Empty mag, reserve to spare, clock on a visible
+  ;; phase -- still must not nag.
+  (is (= false (reload-reminder-visible? 0 1 5 0.0 0.0 0.0 30))
+      "single-round mag (BFG) never shows the periodic reminder"))
+
+(deftest test-reload-reminder-shows-on-low-mag-fraction
+  ;; Pistol mag-size 10, 2 rounds left (20% <= 30% threshold), reserve
+  ;; spare, not reloading, clock inside the 0.5s visible window.
+  (is (= true (reload-reminder-visible? 2 10 30 0.0 0.0 0.0 30))
+      "pistol at low mag fraction shows the reminder"))
+
+(deftest test-reload-reminder-hidden-on-full-mag
+  (is (= false (reload-reminder-visible? 9 10 30 0.0 0.0 0.0 30))
+      "near-full mag (90%) does not nag"))
+
+(deftest test-reload-reminder-suppressed-while-reloading
+  (is (= false (reload-reminder-visible? 0 10 30 1.0 0.0 0.0 30))
+      "active reload cooldown suppresses the nag"))
+
+(deftest test-reload-reminder-suppressed-when-reserve-dry
+  (is (= false (reload-reminder-visible? 1 10 0 0.0 0.0 0.0 30))
+      "no reserve -> a reload would no-op -> no nag"))
+
+(deftest test-reload-reminder-suppressed-during-empty-click
+  (is (= false (reload-reminder-visible? 0 10 30 0.0 0.5 0.0 30))
+      "dry-fire CLICK on screen suppresses the nag so prompts don't stack"))
+
+(deftest test-reload-reminder-blinks-off-outside-visible-window
+  ;; Empty pistol -> 1s interval. At game-time 0.6 the phase is past the
+  ;; 0.5s on-window, so the nag blinks off.
+  (is (= false (reload-reminder-visible? 0 10 30 0.0 0.0 0.6 30))
+      "reminder blinks off in the second half of its cadence interval"))
+
+(deftest test-reload-reminder-needs-min-viewport-height
+  (is (= false (reload-reminder-visible? 0 10 30 0.0 0.0 0.0 8))
+      "tiny viewport (<9 rows) suppresses the reminder"))
 
 (deftest test-direction-char-cardinal
   (is (= "→" (direction-char 0.0)))

--- a/tests/io/render-test.phel
+++ b/tests/io/render-test.phel
@@ -21,6 +21,12 @@
   (is (= true (reload-reminder-visible? 2 10 30 0.0 0.0 0.0 30))
       "pistol at low mag fraction shows the reminder"))
 
+(deftest test-reload-reminder-arms-at-exact-threshold
+  ;; mag=3, mag-size=10 -> frac exactly 0.3 == reload-reminder-frac.
+  ;; The `<=` compare must arm here (locks boundary intent).
+  (is (= true (reload-reminder-visible? 3 10 30 0.0 0.0 0.0 30))
+      "exactly 30% mag fraction arms the reminder (<= threshold)"))
+
 (deftest test-reload-reminder-hidden-on-full-mag
   (is (= false (reload-reminder-visible? 9 10 30 0.0 0.0 0.0 30))
       "near-full mag (90%) does not nag"))


### PR DESCRIPTION
Closes #128

## Problem
The `press R to RELOAD` nag (`paint-reload-reminder`) used an absolute `mag <= 2` threshold tuned for the pistol (mag-size 10). For single-round mags it never stops: the **BFG** (`mag-size 1`) has mag always 0 or 1, so `mag <= 2` is permanently true and it nags constantly, even though reloading every shot is the weapon's normal rhythm.

## Fix
Extract the show + cadence decision into a pure, exported `reload-reminder-visible?`:
- arms on the remaining-mag **fraction** (`<= reload-reminder-frac`, 0.3) instead of an absolute count, so pistol/shotgun/chaingun all nag at "nearly empty";
- **suppresses single-round mags** (`mag-size <= 1` -> BFG, chainsaw) entirely;
- keeps the existing guards (reserve > 0, not reloading, no CLICK, vh >= 9) and the urgency-scaled blink cadence.

The painter keeps only positioning + ANSI emit (IO boundary: decision is pure + tested).

## Testing
- 8 new unit tests in `tests/io/render-test.phel` (BFG suppressed, low-mag shows, full-mag hidden, mid-reload/dry-reserve/CLICK/tiny-viewport suppressed, cadence blink-off).
- `composer ci` green (1600 tests).
- `docs/combat.md` updated.