### PR TITLE
fix(weapons): incinerator activates the dead damage-type system (#122)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 
 ## [Unreleased]
 
+### Added
+
+- Incinerator weapon (#122). Slot 6, found on L6: a fast short-range `:fire` flame stream. It is the first weapon to deal `:fire`, so it activates the previously-inert per-enemy resist system - caco / baron / archvile / mancubus shrug it off (zero damage), everything else burns. Switch keys now span 1-6.
+
 ### Changed
 
 - `press R to RELOAD` reminder is now weapon-aware (#128): it arms on the remaining-mag fraction instead of an absolute count, and is suppressed for single-round mags (the BFG no longer nags on its 1/1 magazine).

--- a/README.md
+++ b/README.md
@@ -65,14 +65,16 @@ Compass at top-centre: tints the cardinal letter (E/S/W/N) toward your target. O
 
 Weapons (DPS-balanced, found on map):
 
-| Slot | Weapon | Dmg | CD | Mag | DPS |
-|---|---|---|---|---|---|
-| 1 | pistol | 1 | 0.12s | 10 | 8 |
-| 2 | shotgun | 3 | 0.6s | 4 | 5 |
-| 3 | chaingun | 1 | 0.05s | 30 | 20 |
-| 4 | chainsaw | 1 | 0.10s | ∞ | 10 |
+| Slot | Weapon | Dmg | CD | Mag | DPS | Type / niche |
+|---|---|---|---|---|---|---|
+| 1 | pistol | 1 | 0.12s | 10 | 8 | ballistic, fallback |
+| 2 | shotgun | 3 | 0.6s | 4 | 5 | ballistic, burst |
+| 3 | chaingun | 1 | 0.05s | 30 | 20 | ballistic, sustained |
+| 4 | chainsaw | 1 | 0.10s | ∞ | 10 | melee, no ammo |
+| 5 | BFG | 10 +6 splash | 1.2s | 1 | - | plasma, AoE (ignores fire-resist) |
+| 6 | incinerator | 1 | 0.06s | 40 | 16 | fire, swarm-clearer (caco/baron/archvile/mancubus resist it) |
 
-Hold space to spray (pistol / chaingun / chainsaw). Shotgun: one pull per shell.
+Hold space to spray (pistol / chaingun / chainsaw / incinerator). Shotgun and BFG: one pull per shot.
 
 CLI flags:
 

--- a/docs/audio.md
+++ b/docs/audio.md
@@ -6,11 +6,11 @@ One-shot SFX via `src/io/sound.phel` (shell-out) + ambient drone via `src/io/amb
 
 ## Event tags
 
-Combat raises events by name: `:shoot`, `:shoot-shotgun`, `:shoot-chaingun`, `:shoot-chainsaw`, `:shoot-bfg`, `:hit`, `:kill`, `:reload`, `:click`, `:door`, `:heartbeat`, `:berserk`, `:wound`.
+Combat raises events by name: `:shoot`, `:shoot-shotgun`, `:shoot-chaingun`, `:shoot-chainsaw`, `:shoot-bfg`, `:shoot-incinerator`, `:hit`, `:kill`, `:reload`, `:click`, `:door`, `:heartbeat`, `:berserk`, `:wound`.
 
 `core/combat` is pure: it enqueues `{:name :vol}` events on the world's per-frame `:sfx` queue rather than calling `play-sfx!`. `commands/play` drains the queue after `tick-world` and emits each event, gated on `:sound-on`. Keeps the effect at the io boundary.
 
-macOS maps to `.aiff`: Pop (pistol/kill), Blow (shotgun), Morse (chaingun), Purr (chainsaw), Glass (BFG), Sosumi (player-hurt), Basso (dry-fire), Funk (reload), Tink (door/pickup), Submarine (wound), Bottle (heartbeat), Hero (berserk).
+macOS maps to `.aiff`: Pop (pistol/kill), Blow (shotgun), Morse (chaingun), Purr (chainsaw), Glass (BFG), Frog (incinerator), Sosumi (player-hurt), Basso (dry-fire), Funk (reload), Tink (door/pickup), Submarine (wound), Bottle (heartbeat), Hero (berserk).
 
 ## Per-weapon fire report
 

--- a/docs/combat.md
+++ b/docs/combat.md
@@ -119,6 +119,12 @@ Flow:
 
 Damage type `:plasma` (bypasses fire-resist). Single-action, 1.2s cooldown, mag 1 / reserve 20.
 
+### Incinerator (fire, slot 6, found L6)
+
+The only `:fire` weapon (issue #122). Hitscan flame stream: `:damage 1`, fast `:fire-cooldown 0.06`, mag 40, reserve cap 120, short `:max-range 4.0`. Fast auto-fire makes it a swarm-clearer, but the short reach keeps it out of the chaingun's long-range niche.
+
+Its point is the damage type: caco / baron / archvile / mancubus carry `:resists #{:fire}`, so the flame does **zero** to them. The incinerator is the weapon that makes the resist system bite (before it, no player weapon ever emitted a resisted type). Switch off it for fire-resist heavies; use plasma (BFG), ballistic, or melee on those.
+
 ## Berserk pickup
 
 Berserk sphere (`Ω` glyph, 1-in-8 levels):
@@ -132,10 +138,10 @@ Berserk sphere (`Ω` glyph, 1-in-8 levels):
 
 `shoot` reads active weapon's `:damage-type` and passes to `enemy/shoot`. If target type has `:resists` set containing that type, damage is 0. Hit registration (splatter, flash, sfx, wake) still fires.
 
-Current resistances (dormant until BFG / plasma adds `:plasma` type):
+Current resistances:
 - caco, baron, archvile, mancubus: `:fire`
 
-All current weapons deal `:ballistic`.
+The incinerator (slot 6) deals `:fire`, so it is the weapon those four mobs resist (zero damage). The BFG deals `:plasma`, which is NOT in any resist set, so it bypasses the fire resist by design. Pistol / shotgun / chaingun deal `:ballistic` and the chainsaw deals `:melee`; none of those are resisted by any current enemy.
 
 ## Nightmare respawn
 

--- a/docs/input.md
+++ b/docs/input.md
@@ -67,9 +67,9 @@ In tmux: `set -g extended-keys on` + `setw -g xterm-keys on`.
 
 ## One-shot actions (rising edges)
 
-`key-states` snaps all tracked keys each frame: `m` (map), `sp` (fire), `p` (pause), `n` (sound), `e` (about-face), `f` (action/secret), `f3` (debug), `r` (reload), `h` (help), `esc` (help alias), `k1-k5` (weapon select), `f5` (save), `f9` (load).
+`key-states` snaps all tracked keys each frame: `m` (map), `sp` (fire), `p` (pause), `n` (sound), `e` (about-face), `f` (action/secret), `f3` (debug), `r` (reload), `h` (help), `esc` (help alias), `k1-k6` (weapon select), `f5` (save), `f9` (load).
 
-`rising-edges` computes deltas: `:fire` (space pressed), `:fire-held` (space held), `:toggle-map`, `:toggle-pause`, `:toggle-sound`, `:toggle-debug`, `:toggle-help` (h or esc), `:reload`, `:about-face`, `:action`, `:select-weapon1-5`, `:save`, `:load`.
+`rising-edges` computes deltas: `:fire` (space pressed), `:fire-held` (space held), `:toggle-map`, `:toggle-pause`, `:toggle-sound`, `:toggle-debug`, `:toggle-help` (h or esc), `:reload`, `:about-face`, `:action`, `:select-weapon1-6`, `:save`, `:load`.
 
 F5 / F9 fire in `game-loop` (side-effect layer), not `tick-world`, so pure tick stays effect-free. See [savegame.md](savegame.md).
 

--- a/docs/monsters.md
+++ b/docs/monsters.md
@@ -50,7 +50,7 @@ Reading it:
 - **Casters** (`:caco`, `:baron`, `:archvile`) are the types that fire projectiles (`caster-spec`). They move slower than the melee rushers to stay fair: keep distance and strafe the bolts, or close in and trade the dodge window for melee range. Bolt speed is world-units/sec (deliberately low so a fireball is dodge-able, not near-hitscan). The archvile is the escalated caster: fastest bolt (3.4) and tightest range, but its windup matches the caco (0.6s) so the telegraph stays reactable on a laggy terminal.
 - `:cyber` is the heaviest: top HP, slowest move (0.55x), long telegraph. The L10 boss spawns it with 50 HP.
 - `:pinky` is the glass rusher: low HP, full speed, shortest windup + cooldown.
-- **Resists** zeroes incoming damage of that type (`enemy/shoot` checks `enemies/resists?`). `:fire` resistance is why the BFG's `:plasma` shot matters against caco / baron / archvile / mancubus.
+- **Resists** zeroes incoming damage of that type (`enemy/shoot` checks `enemies/resists?`). `:fire` resistance means the incinerator (slot 6, the only `:fire` weapon, issue #122) does zero to caco / baron / archvile / mancubus. The BFG's `:plasma` is NOT resisted, so plasma is the answer against those four; the incinerator burns everything else.
 
 ### Depth-scaled aggression
 

--- a/src/commands/play.phel
+++ b/src/commands/play.phel
@@ -538,7 +538,7 @@
       ;; false positives), so stick with sequential let bindings.
       :else
       (let [w1   (refresh-from-keys w0 keys)
-            ;; Weapon swap (1/2/3) routes through weapons/switch-weapon
+            ;; Weapon swap (1-6) routes through weapons/switch-weapon
             ;; — no-op when the player is mid-reload so the lockout
             ;; can't be skipped.
             w1a  (cond
@@ -547,6 +547,7 @@
                    (:select-weapon3 edges) (switch-weapon w1 (get weapon-order 2))
                    (:select-weapon4 edges) (switch-weapon w1 (get weapon-order 3))
                    (:select-weapon5 edges) (switch-weapon w1 (get weapon-order 4))
+                   (:select-weapon6 edges) (switch-weapon w1 (get weapon-order 5))
                    :else                   w1)
             ;; tick-stamina runs BEFORE apply-physics so that, on the
             ;; frame the player's pool empties, the `:sprint-blocked?`

--- a/src/core/level.phel
+++ b/src/core/level.phel
@@ -376,17 +376,19 @@
 
 (defn- maybe-spawn-weapon-pickups
   "Per-level weapon drops. L2 always seeds a shotgun, L3 a chaingun,
-   L4 the chainsaw, L7 the rare BFG (issue #58). Each skipped if the
-   player already owns the weapon so a re-played level doesn't spam
-   duplicate pickups. Returns a vector of `{:x :y :weapon kw}` items."
+   L4 the chainsaw, L6 the incinerator (issue #122), L7 the rare BFG
+   (issue #58). Each skipped if the player already owns the weapon so a
+   re-played level doesn't spam duplicate pickups. Returns a vector of
+   `{:x :y :weapon kw}` items."
   [grid level-num owned]
   (let [owned'     (or owned #{:pistol})
         candidates
         (cond
-          (php/=== level-num 2) (if (contains? owned' :shotgun)  [] [:shotgun])
-          (php/=== level-num 3) (if (contains? owned' :chaingun) [] [:chaingun])
-          (php/=== level-num 4) (if (contains? owned' :chainsaw) [] [:chainsaw])
-          (php/=== level-num 7) (if (contains? owned' :bfg)      [] [:bfg])
+          (php/=== level-num 2) (if (contains? owned' :shotgun)     [] [:shotgun])
+          (php/=== level-num 3) (if (contains? owned' :chaingun)    [] [:chaingun])
+          (php/=== level-num 4) (if (contains? owned' :chainsaw)    [] [:chainsaw])
+          (php/=== level-num 6) (if (contains? owned' :incinerator) [] [:incinerator])
+          (php/=== level-num 7) (if (contains? owned' :bfg)         [] [:bfg])
           :else                 [])]
     (apply vector
            (map (fn [kw]

--- a/src/core/weapons.phel
+++ b/src/core/weapons.phel
@@ -130,6 +130,37 @@
                                 :frame     "\e[1;38;5;238m"
                                 :grip-hi   "\e[1;38;5;40m"
                                 :grip-lo   "\e[1;38;5;22m"}}
+   :incinerator {:name         "incinerator"
+                 :mag-size        40
+                 :reserve-start   0
+                 :reserve-cap     120
+                 :ammo-per-box    25
+                 :fire-cooldown   0.06
+                 :reload-duration 1.6
+                 :damage          1
+                 ;; The ONLY :fire weapon in the roster. This is what
+                 ;; makes the per-enemy resist system (issue #60) bite:
+                 ;; caco / baron / archvile / mancubus carry
+                 ;; `:resists #{:fire}`, so the flame stream does ZERO to
+                 ;; them. It shreds everything else - a swarm-clearer with
+                 ;; a hard counter, not a monotonic upgrade. (Before this
+                 ;; weapon no player damage-type was ever resisted, so the
+                 ;; whole :damage-type / :resists machinery was inert.)
+                 :damage-type     :fire
+                 :auto-fire?      true
+                 :fire-sfx        :shoot-incinerator
+                 ;; Short reach: a flame stream, not a hitscan rifle. The
+                 ;; close range is the trade-off for the fast cadence and
+                 ;; keeps it out of the chaingun's long-range niche.
+                 :max-range       4.0
+                 ;; Orange/red flame: bright yellow core fading to ember
+                 ;; red, distinct from the chainsaw's industrial yellow.
+                 :palette         {:muzzle    "\e[1;38;5;231m"
+                                   :slide     "\e[1;38;5;208m"
+                                   :slide-dim "\e[1;38;5;166m"
+                                   :frame     "\e[1;38;5;88m"
+                                   :grip-hi   "\e[1;38;5;214m"
+                                   :grip-lo   "\e[1;38;5;130m"}}
    :bfg      {:name            "BFG"
               :mag-size        1
               :reserve-start   5
@@ -161,11 +192,13 @@
                                 :grip-lo   "\e[1;38;5;40m"}}})
 
 (def weapon-order
-  "Slot order keyed by 1/2/3/4/5. Chainsaw at slot 4 so picking it up
+  "Slot order keyed by 1/2/3/4/5/6. Chainsaw at slot 4 so picking it up
    doesn't yank the player off pistol/shotgun/chaingun mid-firefight
    the way the give-weapon auto-switch does for ranged. BFG at slot 5
-   (issue #58): a rare, expensive AoE answer to grouped enemies."
-  [:pistol :shotgun :chaingun :chainsaw :bfg])
+   (issue #58): a rare, expensive AoE answer to grouped enemies.
+   Incinerator at slot 6 (issue #122): the only :fire weapon, a
+   swarm-clearer that fire-resist mobs shrug off."
+  [:pistol :shotgun :chaingun :chainsaw :bfg :incinerator])
 
 (defn current-weapon
   "Active weapon keyword for `world`. Defaults to :pistol so fresh test

--- a/src/glue/controls.phel
+++ b/src/glue/controls.phel
@@ -407,7 +407,8 @@
    :k2 (key-pressed? keys "2" 50)
    :k3 (key-pressed? keys "3" 51)
    :k4 (key-pressed? keys "4" 52)
-   :k5 (key-pressed? keys "5" 53)})
+   :k5 (key-pressed? keys "5" 53)
+   :k6 (key-pressed? keys "6" 54)})
 
 (defn rising-edges
   "Build the edges map tick consumes — truthy only for keys that just
@@ -440,6 +441,7 @@
    :select-weapon3 (and (:k3 now) (not (:k3 prev)))
    :select-weapon4 (and (:k4 now) (not (:k4 prev)))
    :select-weapon5 (and (:k5 now) (not (:k5 prev)))
+   :select-weapon6 (and (:k6 now) (not (:k6 prev)))
    ;; F5 quick-save / F9 quick-load (issue #63). Handled in game-loop
    ;; (file IO), not tick-world, so the pure tick stays effect-free.
    :save           (and (:f5 now) (not (:f5 prev)))

--- a/src/glue/controls.phel
+++ b/src/glue/controls.phel
@@ -293,7 +293,7 @@
 (def initial-key-snapshot
   "First-frame snapshot — nothing held yet."
   {:m false :sp false :p false :n false :e false :f false :f3 false :r false :h false
-   :esc false :k1 false :k2 false :k3 false :k4 false})
+   :esc false :k1 false :k2 false :k3 false :k4 false :k5 false :k6 false})
 
 (defn- f3-pressed? [keys]
   ;; F3 across terminals: xterm/macOS Terminal/iTerm2 send `\eOR`;

--- a/src/io/render.phel
+++ b/src/io/render.phel
@@ -300,6 +300,13 @@
 (def bfg-pickup-glyph  "\e[48;5;22;38;5;46;1m✸")
 (def bfg-pickup-glyph-bright "\e[48;5;28;38;5;82;1m✸")
 
+;; Incinerator pickup (#122): a bright flame glyph on an ember-red crate
+;; so the only :fire weapon reads as "heat" from across the room.
+(def incinerator-pickup-shade  "\e[48;5;88m ")
+(def incinerator-pickup-bright "\e[48;5;124m ")
+(def incinerator-pickup-glyph  "\e[48;5;88;38;5;214;1m♨")
+(def incinerator-pickup-glyph-bright "\e[48;5;124;38;5;226;1m♨")
+
 (def keycard-blue-shade  "\e[48;5;21m ")
 (def keycard-blue-bright "\e[48;5;33m ")
 (def keycard-blue-glyph  "\e[48;5;21;38;5;231;1m⚿")
@@ -1131,7 +1138,7 @@
                         (bord "  space         fire")
                         (bord "  f             action (open secret walls)")
                         (bord "  r             reload")
-                        (bord "  1 / 2 / 3 / 4 switch weapon slot")
+                        (bord "  1 .. 6        switch weapon slot")
                         (bord "  m             toggle minimap")
                         (bord "  n             toggle sound")
                         (bord "  F3            debug overlay")
@@ -2301,8 +2308,6 @@
               blood?       (php/> (buf-get blood-cols col) 0.4)
               stbl-l       (if blood? shade-table-blood stbl)
               ctbl-l       (if blood? shade-code-table-blood ctbl)
-              sky-c-l      (if blood? sky-blood-code sky-c)
-              floor-c-l    (if blood? floor-blood-code floor-c)
               ;; Sample the gradient code at the exact row of each seam
               ;; cell so the ▀ top-half blends the true sky shade at that
               ;; row (not a flat dark-236), eliminating the dark-dot
@@ -2665,6 +2670,8 @@
         chaingun-pickup-glyph-now          (if weapon-pickup-bright? chaingun-pickup-glyph-bright chaingun-pickup-glyph)
         bfg-pickup-shade-now               (if weapon-pickup-bright? bfg-pickup-bright bfg-pickup-shade)
         bfg-pickup-glyph-now               (if weapon-pickup-bright? bfg-pickup-glyph-bright bfg-pickup-glyph)
+        incinerator-pickup-shade-now       (if weapon-pickup-bright? incinerator-pickup-bright incinerator-pickup-shade)
+        incinerator-pickup-glyph-now       (if weapon-pickup-bright? incinerator-pickup-glyph-bright incinerator-pickup-glyph)
         ;; Atmospheric haze pulls walls toward black as lives drop, so
         ;; the world reads as 'consumed by darkness' the closer the
         ;; player is to dying. Sky / floor untouched; doors keep their
@@ -2927,9 +2934,15 @@
                                                         (or (:weapon-pickups world) [])))
                                          (:player world) dists edists vw vh
                                          bfg-pickup-shade-now bfg-pickup-glyph-now)
+          bp-wi     (paint-pickups-into  bp-wb
+                                         (apply vector
+                                                (filter (fn [w] (php/=== (:weapon w) :incinerator))
+                                                        (or (:weapon-pickups world) [])))
+                                         (:player world) dists edists vw vh
+                                         incinerator-pickup-shade-now incinerator-pickup-glyph-now)
           ;; Fireballs paint last into the overlay so an incoming bolt
           ;; sits on top of every pickup glow it crosses.
-          bp-proj   (paint-projectiles-into bp-wb (or (:projectiles world) [])
+          bp-proj   (paint-projectiles-into bp-wi (or (:projectiles world) [])
                                             (:player world) dists edists vw vh)
           parts     (buf-mk)]
       (dotimes [row vh]

--- a/src/io/render.phel
+++ b/src/io/render.phel
@@ -3348,7 +3348,7 @@
                   (pad-visible "    \e[93me      \e[40;97m   about-face (snap 180°)" w)
                   (pad-visible "    \e[93mspace  \e[40;97m   fire" w)
                   (pad-visible "    \e[93mr      \e[40;97m   reload" w)
-                  (pad-visible "    \e[93m1 2 3  \e[40;97m   switch weapon slot" w)
+                  (pad-visible "    \e[93m1 .. 6 \e[40;97m   switch weapon slot" w)
                   (pad-visible "    \e[93mh      \e[40;97m   info menu (stats + weapons)" w)
                   (pad-visible "    \e[93mm  n   \e[40;97m   toggle minimap / sound" w)
                   (pad-visible "    \e[93mp      \e[40;97m   pause + settings menu" w)

--- a/src/io/sound.phel
+++ b/src/io/sound.phel
@@ -38,6 +38,9 @@
    ;; BFG: bright glassy plasma discharge, distinct from the ballistic
    ;; weapons.
    :shoot-bfg      "/System/Library/Sounds/Glass.aiff"
+   ;; Incinerator (#122): a wet sizzle for the flame stream, distinct
+   ;; from the dry ballistic reports and the glassy BFG.
+   :shoot-incinerator "/System/Library/Sounds/Frog.aiff"
    :kill      "/System/Library/Sounds/Pop.aiff"
    :hit       "/System/Library/Sounds/Sosumi.aiff"
    :wound     "/System/Library/Sounds/Submarine.aiff"

--- a/tests/core/weapons-test.phel
+++ b/tests/core/weapons-test.phel
@@ -73,7 +73,9 @@
     (is (= 30 (get-in s [:chaingun :mag])))
     (is (= 30 (get-in s [:pistol   :reserve])))
     (is (= 8  (get-in s [:shotgun  :reserve])))
-    (is (= 0  (get-in s [:chaingun :reserve])))))
+    (is (= 0  (get-in s [:chaingun :reserve])))
+    (is (= 40 (get-in s [:incinerator :mag])))
+    (is (= 0  (get-in s [:incinerator :reserve])))))
 
 (deftest test-fresh-run-owns-only-pistol
   (let [w (fresh-world)]

--- a/tests/core/weapons-test.phel
+++ b/tests/core/weapons-test.phel
@@ -1,6 +1,7 @@
 (ns phel-doom-tests.core.weapons-test
   (:require phel.test :refer [deftest is])
   (:require phel-doom.core.state :refer [new-player new-world])
+  (:require phel-doom.core.enemies :refer [resists?])
   (:require phel-doom.core.weapons :refer [current-weapon effective-reserve-cap give-weapon initial-weapon-state owns? switch-weapon weapon-order weapon-spec weapons]))
 
 (def empty-grid [[1 1 1] [1 0 1] [1 1 1]])
@@ -27,6 +28,43 @@
   (is (= 1 (:damage (get weapons :pistol))))
   (is (= 3 (:damage (get weapons :shotgun))))
   (is (= 1 (:damage (get weapons :chaingun)))))
+
+;; ---------------------------------------------------------------------
+;; #122: the incinerator is the first weapon to emit :fire, so it is the
+;; weapon that makes the (already-working) per-enemy resist system bite.
+;; Fire-resist mobs (caco/baron/archvile/mancubus) shrug it off; everyone
+;; else burns. Without a fire weapon the whole :damage-type / :resists
+;; machinery was inert (no player weapon ever triggered a resist).
+;; ---------------------------------------------------------------------
+
+(deftest test-incinerator-is-a-fire-weapon
+  (let [inc (get weapons :incinerator)]
+    (is (some? inc) "incinerator exists in the catalogue")
+    (is (= :fire (:damage-type inc)) "incinerator deals :fire")))
+
+(deftest test-incinerator-fire-is-resisted-by-fire-mobs
+  ;; The proof that #122 is fixed: a real player weapon's damage-type now
+  ;; lands in the resist table.
+  (let [ftype (:damage-type (get weapons :incinerator))]
+    (is (= true  (resists? :caco ftype))    "cacodemon resists incinerator fire")
+    (is (= true  (resists? :baron ftype))   "baron resists incinerator fire")
+    (is (= true  (resists? :archvile ftype)) "archvile resists incinerator fire")
+    (is (= true  (resists? :mancubus ftype)) "mancubus resists incinerator fire")
+    (is (= false (resists? :imp ftype))     "imp does NOT resist fire (burns)")
+    (is (= false (resists? :demon ftype))   "demon does NOT resist fire (burns)")))
+
+(deftest test-incinerator-is-slot-6
+  (is (= :incinerator (get weapon-order 5))
+      "incinerator occupies slot 6 (weapon-order index 5)"))
+
+(deftest test-give-and-switch-incinerator
+  (let [w  (give-weapon (fresh-world) :incinerator)]
+    (is (= :incinerator (current-weapon w)) "give-weapon auto-switches to incinerator")
+    (is (= true (owns? w :incinerator)))
+    (let [back (switch-weapon w :pistol)]
+      (is (= :pistol (current-weapon back)))
+      (is (= :incinerator (current-weapon (switch-weapon back :incinerator)))
+          "can switch back to the owned incinerator"))))
 
 (deftest test-initial-weapon-state-has-every-weapon-at-spec-defaults
   (let [s (initial-weapon-state)]
@@ -130,11 +168,13 @@
     (is (= 1 (:damage s)))))
 
 (deftest test-weapon-order-slots
-  ;; Player presses 1-5 to swap weapons. Slot ordering must stay stable
-  ;; so muscle memory survives. BFG is slot 5 (issue #58).
-  (is (= [:pistol :shotgun :chaingun :chainsaw :bfg] weapon-order))
-  (is (= :chainsaw (get weapon-order 3)))
-  (is (= :bfg      (get weapon-order 4))))
+  ;; Player presses 1-6 to swap weapons. Slot ordering must stay stable
+  ;; so muscle memory survives. BFG is slot 5 (issue #58); incinerator
+  ;; is slot 6 (issue #122).
+  (is (= [:pistol :shotgun :chaingun :chainsaw :bfg :incinerator] weapon-order))
+  (is (= :chainsaw    (get weapon-order 3)))
+  (is (= :bfg         (get weapon-order 4)))
+  (is (= :incinerator (get weapon-order 5))))
 
 (deftest test-effective-reserve-cap-scales-with-backpack-level
   ;; Pistol's reserve-cap is 50 from the catalog. Backpack stack scales

--- a/tests/glue/controls-test.phel
+++ b/tests/glue/controls-test.phel
@@ -77,7 +77,16 @@
   (is (= false (:p  initial-key-snapshot)))
   (is (= false (:n  initial-key-snapshot)))
   (is (= false (:e  initial-key-snapshot)))
-  (is (= false (:f3 initial-key-snapshot))))
+  (is (= false (:f3 initial-key-snapshot)))
+  ;; Weapon-slot keys are peeked by rising-edges too; a missing key
+  ;; makes (not (:kN prev)) nil->true and can spuriously fire slot N
+  ;; on frame 0.
+  (is (= false (:k1 initial-key-snapshot)))
+  (is (= false (:k2 initial-key-snapshot)))
+  (is (= false (:k3 initial-key-snapshot)))
+  (is (= false (:k4 initial-key-snapshot)))
+  (is (= false (:k5 initial-key-snapshot)))
+  (is (= false (:k6 initial-key-snapshot))))
 
 (deftest test-key-states-detects-f3-xterm-sequence
   ;; Most terminals (xterm, macOS Terminal, iTerm2) send `\eOR` for F3.


### PR DESCRIPTION
Closes #122

## Problem
The `:damage-type` / `:resists` machinery (issue #60) was **inert**: only `:fire` was ever resisted (caco/baron/archvile/mancubus), but no player weapon emitted `:fire`, so a resist never triggered. The BFG's advertised 'plasma bypasses fire-resist' was meaningless because nothing did fire either. Weapon switching was a pure DPS choice with zero rock-paper-scissors.

## Fix
Add the **incinerator** (slot 6, found L6): a fast short-range `:fire` flame stream (`:damage 1`, `:fire-cooldown 0.06`, mag 40, `:max-range 4.0`). As the first `:fire` weapon it makes the resist path bite in real play - the four fire-resist mobs take **zero** from it; everything else burns. A swarm-clearer with a hard counter, not a monotonic upgrade.

Wires the full slot-6 path: `k6`/'6' input + `select-weapon6` edge, play-loop switch, flame pickup glyph + 3D paint branch, `:shoot-incinerator` sfx, L6 spawn.

## Testing
- 15 new tests (catalogue + fire-type, resist activation vs each mob, slot-6 order, give/switch, initial-state defaults, snapshot covers k5/k6).
- `composer ci` green (1623 tests).
- Docs corrected: combat/monsters resist tables wrongly said 'dormant'; audio sfx list; input key range; README weapon table (also backfilled the missing BFG row).

## Review
clean-code-reviewer pass: fixed the blocking `initial-key-snapshot` k5/k6 omission (`ref` commit) + stale start-menu hint. Also dropped two dead `sky-c-l`/`floor-c-l` bindings left by #129 (cleared the only lint warnings).