### PR TITLE
feat(weapons): add rocket launcher - mid-tier AoE (#123)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 
 ### Added
 
+- Rocket launcher (#123). Slot 7, found on L5: a single-action mid-tier AoE (splash radius 2.0, splash damage 3) that fills the gap between the chaingun and the rare BFG nuke. Reuses the splash combat path; cheaper and more available than the BFG. Switch keys now span 1-7.
 - Incinerator weapon (#122). Slot 6, found on L6: a fast short-range `:fire` flame stream. It is the first weapon to deal `:fire`, so it activates the previously-inert per-enemy resist system - caco / baron / archvile / mancubus shrug it off (zero damage), everything else burns. Switch keys now span 1-6.
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Weapons (DPS-balanced, found on map):
 | 4 | chainsaw | 1 | 0.10s | ∞ | 10 | melee, no ammo |
 | 5 | BFG | 10 +6 splash | 1.2s | 1 | - | plasma, AoE (ignores fire-resist) |
 | 6 | incinerator | 1 | 0.06s | 40 | 16 | fire, swarm-clearer (caco/baron/archvile/mancubus resist it) |
+| 7 | rocket launcher | 3 splash (r2.0) | 0.9s | 1 | - | ballistic, mid-tier AoE (cheaper than BFG) |
 
 Hold space to spray (pistol / chaingun / chainsaw / incinerator). Shotgun and BFG: one pull per shot.
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Weapons (DPS-balanced, found on map):
 | 6 | incinerator | 1 | 0.06s | 40 | 16 | fire, swarm-clearer (caco/baron/archvile/mancubus resist it) |
 | 7 | rocket launcher | 3 splash (r2.0) | 0.9s | 1 | - | ballistic, mid-tier AoE (cheaper than BFG) |
 
-Hold space to spray (pistol / chaingun / chainsaw / incinerator). Shotgun and BFG: one pull per shot.
+Hold space to spray (pistol / chaingun / chainsaw / incinerator). Shotgun, BFG, and rocket launcher: one pull per shot.
 
 CLI flags:
 

--- a/docs/audio.md
+++ b/docs/audio.md
@@ -6,11 +6,11 @@ One-shot SFX via `src/io/sound.phel` (shell-out) + ambient drone via `src/io/amb
 
 ## Event tags
 
-Combat raises events by name: `:shoot`, `:shoot-shotgun`, `:shoot-chaingun`, `:shoot-chainsaw`, `:shoot-bfg`, `:shoot-incinerator`, `:hit`, `:kill`, `:reload`, `:click`, `:door`, `:heartbeat`, `:berserk`, `:wound`.
+Combat raises events by name: `:shoot`, `:shoot-shotgun`, `:shoot-chaingun`, `:shoot-chainsaw`, `:shoot-bfg`, `:shoot-incinerator`, `:shoot-rocket`, `:hit`, `:kill`, `:reload`, `:click`, `:door`, `:heartbeat`, `:berserk`, `:wound`.
 
 `core/combat` is pure: it enqueues `{:name :vol}` events on the world's per-frame `:sfx` queue rather than calling `play-sfx!`. `commands/play` drains the queue after `tick-world` and emits each event, gated on `:sound-on`. Keeps the effect at the io boundary.
 
-macOS maps to `.aiff`: Pop (pistol/kill), Blow (shotgun), Morse (chaingun), Purr (chainsaw), Glass (BFG), Frog (incinerator), Sosumi (player-hurt), Basso (dry-fire), Funk (reload), Tink (door/pickup), Submarine (wound), Bottle (heartbeat), Hero (berserk).
+macOS maps to `.aiff`: Pop (pistol/kill), Blow (shotgun), Morse (chaingun), Purr (chainsaw), Glass (BFG), Frog (incinerator), Ping (rocket), Sosumi (player-hurt), Basso (dry-fire), Funk (reload), Tink (door/pickup), Submarine (wound), Bottle (heartbeat), Hero (berserk).
 
 ## Per-weapon fire report
 

--- a/docs/combat.md
+++ b/docs/combat.md
@@ -125,6 +125,10 @@ The only `:fire` weapon (issue #122). Hitscan flame stream: `:damage 1`, fast `:
 
 Its point is the damage type: caco / baron / archvile / mancubus carry `:resists #{:fire}`, so the flame does **zero** to them. The incinerator is the weapon that makes the resist system bite (before it, no player weapon ever emitted a resisted type). Switch off it for fire-resist heavies; use plasma (BFG), ballistic, or melee on those.
 
+### Rocket launcher (splash, slot 7, found L5)
+
+Mid-tier AoE (issue #123): fills the gap between the chaingun (no splash) and the rare BFG nuke. Carries `:splash-radius 2.0` + `:splash-damage 3`, so it routes through the same `bfg-fire` path as the BFG, with smaller numbers (BFG is radius 3.0 / splash 6). Single-action, `:fire-cooldown 0.9`, mag 1 / reserve cap 30. Damage type `:ballistic` (an explosive shell), so no enemy resists it. The everyday crowd tool; the BFG stays the rare panic button.
+
 ## Berserk pickup
 
 Berserk sphere (`Ω` glyph, 1-in-8 levels):

--- a/docs/features.md
+++ b/docs/features.md
@@ -34,12 +34,14 @@ See [level-system.md](level-system.md), [map.md](map.md).
 - Projectile casters: cacodemons + barons fire dodgeable fireballs (telegraphed windup, orange bolt). Bolts pass doors, stop at walls. Cost one armor/life on impact (i-frames cap burst to one hit). Strafe to dodge.
 - Cyber chase speed 0.55x for playability.
 - Hitscan: distance-attenuated kill/wound sfx, blood splatter, muzzle flash, 5-stage death, 3-6s respawn.
-- 5-slot loadout, DPS-balanced:
+- 7-slot loadout, DPS-balanced:
   - 1: pistol (1 dmg, 0.12s cd, mag 10, auto-fire, overheats)
   - 2: shotgun (3 dmg, 0.6s cd, mag 4)
   - 3: chaingun (1 dmg, 0.05s cd, mag 30, auto-fire)
   - 4: chainsaw (1 melee, 0.10s cd, melee 1.5-cell, halves move)
   - 5: BFG (10+6 splash, 1.2s cd, mag 1, plasma AoE 3-cell, rare L7)
+  - 6: incinerator (1 fire dmg, 0.06s cd, mag 40, auto-fire; fire-resist mobs take 0, L6)
+  - 7: rocket launcher (3 splash r2.0, 0.9s cd, mag 1, single-action, ballistic AoE, L5)
 - Pistol + chaingun + chainsaw auto-spray while held. Shotgun + BFG single-action. Pistol overheats. Mag/reserve persist across switches, auto-switch on first pickup.
 - Kill-loot skips pistol when other weapons owned, biases shotgun/chaingun. Level boxes refill active weapon.
 - Half-heart health: 10 HP drawn as 5 hearts (2 HP each), starting full. Hits cost by attacker type - 1 (half heart) for light melee, 2 (full heart) for heavy bruisers + casters, 3 for the cyberdemon boss. 1s i-frame, 4-way directional red hurt band, knockback on contact. Armor absorbs a whole hit.

--- a/docs/input.md
+++ b/docs/input.md
@@ -67,9 +67,9 @@ In tmux: `set -g extended-keys on` + `setw -g xterm-keys on`.
 
 ## One-shot actions (rising edges)
 
-`key-states` snaps all tracked keys each frame: `m` (map), `sp` (fire), `p` (pause), `n` (sound), `e` (about-face), `f` (action/secret), `f3` (debug), `r` (reload), `h` (help), `esc` (help alias), `k1-k6` (weapon select), `f5` (save), `f9` (load).
+`key-states` snaps all tracked keys each frame: `m` (map), `sp` (fire), `p` (pause), `n` (sound), `e` (about-face), `f` (action/secret), `f3` (debug), `r` (reload), `h` (help), `esc` (help alias), `k1-k7` (weapon select), `f5` (save), `f9` (load).
 
-`rising-edges` computes deltas: `:fire` (space pressed), `:fire-held` (space held), `:toggle-map`, `:toggle-pause`, `:toggle-sound`, `:toggle-debug`, `:toggle-help` (h or esc), `:reload`, `:about-face`, `:action`, `:select-weapon1-6`, `:save`, `:load`.
+`rising-edges` computes deltas: `:fire` (space pressed), `:fire-held` (space held), `:toggle-map`, `:toggle-pause`, `:toggle-sound`, `:toggle-debug`, `:toggle-help` (h or esc), `:reload`, `:about-face`, `:action`, `:select-weapon1-7`, `:save`, `:load`.
 
 F5 / F9 fire in `game-loop` (side-effect layer), not `tick-world`, so pure tick stays effect-free. See [savegame.md](savegame.md).
 

--- a/docs/level-system.md
+++ b/docs/level-system.md
@@ -104,7 +104,7 @@ Signature: `(build-world level-num lives backpack-level diff owned)` → new wor
 Per build: grid (hand-authored or random), player spawn + angle, enemies from mixed specs. Pickups seeded:
 - Heart: only if `lives < max-lives` (avoid wasted pickups).
 - Armor (50%), berserk (1/8), invuln (1/12), soulsphere (1/10), backpack (L2+, 1/5).
-- 3 armor shards per level. Keycard (if locked, not `:boss`). Shotgun (L2) / chaingun (L3) if not owned.
+- 3 armor shards per level. Keycard (if locked, not `:boss`). Weapon drops if not owned: shotgun (L2) / chaingun (L3) / chainsaw (L4) / rocket (L5) / incinerator (L6) / BFG (L7).
 - Ammo boxes: `max(2, ceil(total_hp / 8))` where `total_hp = sum(count * lives)`.
 
 Stamps: `:enemy` (primary type fallback), `:level-name`, `:difficulty`, `:intro-secs` (1.5s).

--- a/docs/state.md
+++ b/docs/state.md
@@ -38,7 +38,7 @@ Pure data shapes that every other module operates on. `src/core/state.phel`.
  :difficulty <kw :easy|:normal|:hard|:nightmare>
  :god?       <bool, --god flag; no damage>
  :door-lock  <kw :blue|:red|:boss|nil>     ; lock colour on this level's exit (:boss = synthetic, no keycard pickup)
- :weapon     <kw :pistol|:shotgun|:chaingun>  ; active weapon
+ :weapon     <kw :pistol|:shotgun|:chaingun|:chainsaw|:bfg|:incinerator|:rocket>  ; active weapon
  :owned-weapons <set of kw>                ; pistol owned by default; others must be picked up
  :weapon-pickups <vector of {:x :y :weapon}>
  :weapon-state {<kw> {:mag :reserve}}      ; per-weapon ammo bookkeeping

--- a/src/commands/play.phel
+++ b/src/commands/play.phel
@@ -548,6 +548,7 @@
                    (:select-weapon4 edges) (switch-weapon w1 (get weapon-order 3))
                    (:select-weapon5 edges) (switch-weapon w1 (get weapon-order 4))
                    (:select-weapon6 edges) (switch-weapon w1 (get weapon-order 5))
+                   (:select-weapon7 edges) (switch-weapon w1 (get weapon-order 6))
                    :else                   w1)
             ;; tick-stamina runs BEFORE apply-physics so that, on the
             ;; frame the player's pool empties, the `:sprint-blocked?`

--- a/src/core/combat.phel
+++ b/src/core/combat.phel
@@ -749,8 +749,9 @@
      world killed? hit-pos)))
 
 (defn fire-shot
-  "Resolve one trigger pull end-to-end. Splash weapons (BFG) route to
-   `bfg-fire`; everything else is a single-target hitscan. After the
+  "Resolve one trigger pull end-to-end. Weapons with `:splash-radius`
+   (BFG, rocket) route to `bfg-fire`; everything else is a single-target
+   hitscan. After the
    shot, run a flood-fill sound-wake from the player's cell so dormant
    enemies in the same room hear it and switch to :aware. Doors block
    the BFS so the wake stays local — same per-sector noise rule DOOM

--- a/src/core/level.phel
+++ b/src/core/level.phel
@@ -376,10 +376,11 @@
 
 (defn- maybe-spawn-weapon-pickups
   "Per-level weapon drops. L2 always seeds a shotgun, L3 a chaingun,
-   L4 the chainsaw, L6 the incinerator (issue #122), L7 the rare BFG
-   (issue #58). Each skipped if the player already owns the weapon so a
-   re-played level doesn't spam duplicate pickups. Returns a vector of
-   `{:x :y :weapon kw}` items."
+   L4 the chainsaw, L5 the rocket launcher (issue #123), L6 the
+   incinerator (issue #122), L7 the rare BFG (issue #58). Each skipped
+   if the player already owns the weapon so a re-played level doesn't
+   spam duplicate pickups. Returns a vector of `{:x :y :weapon kw}`
+   items."
   [grid level-num owned]
   (let [owned'     (or owned #{:pistol})
         candidates
@@ -387,6 +388,7 @@
           (php/=== level-num 2) (if (contains? owned' :shotgun)     [] [:shotgun])
           (php/=== level-num 3) (if (contains? owned' :chaingun)    [] [:chaingun])
           (php/=== level-num 4) (if (contains? owned' :chainsaw)    [] [:chainsaw])
+          (php/=== level-num 5) (if (contains? owned' :rocket)      [] [:rocket])
           (php/=== level-num 6) (if (contains? owned' :incinerator) [] [:incinerator])
           (php/=== level-num 7) (if (contains? owned' :bfg)         [] [:bfg])
           :else                 [])]

--- a/src/core/weapons.phel
+++ b/src/core/weapons.phel
@@ -189,16 +189,49 @@
                                 :slide-dim "\e[1;38;5;28m"
                                 :frame     "\e[1;38;5;22m"
                                 :grip-hi   "\e[1;38;5;82m"
-                                :grip-lo   "\e[1;38;5;40m"}}})
+                                :grip-lo   "\e[1;38;5;40m"}}
+   :rocket   {:name            "rocket launcher"
+              :mag-size        1
+              :reserve-start   0
+              :reserve-cap     30
+              :ammo-per-box    5
+              :fire-cooldown   0.9
+              :reload-duration 1.5
+              ;; Mid-tier AoE (issue #123): fills the gap between the
+              ;; chaingun (no splash) and the rare BFG nuke. Carries
+              ;; `:splash-radius` so it routes through the generic
+              ;; `bfg-fire` splash path. Numbers deliberately below the
+              ;; BFG (radius 3.0 / splash 6) so the BFG stays the rare
+              ;; panic button and the rocket is the everyday crowd tool.
+              :damage          4
+              :splash-radius   2.0
+              :splash-damage   3
+              ;; :ballistic — an explosive shell, not plasma/fire, so no
+              ;; enemy resists it (rockets hit everyone full).
+              :damage-type     :ballistic
+              ;; Single-action: one deliberate shell per pull, like the
+              ;; shotgun + BFG. The slow cadence is the cost of the AoE.
+              :auto-fire?      false
+              :fire-sfx        :shoot-rocket
+              ;; Olive launcher tube + warhead: military green body with
+              ;; a hot red-tipped warhead, distinct from the BFG's
+              ;; emerald plasma and the incinerator's orange flame.
+              :palette         {:muzzle    "\e[1;38;5;160m"
+                                :slide     "\e[1;38;5;100m"
+                                :slide-dim "\e[1;38;5;58m"
+                                :frame     "\e[1;38;5;58m"
+                                :grip-hi   "\e[1;38;5;142m"
+                                :grip-lo   "\e[1;38;5;100m"}}})
 
 (def weapon-order
-  "Slot order keyed by 1/2/3/4/5/6. Chainsaw at slot 4 so picking it up
-   doesn't yank the player off pistol/shotgun/chaingun mid-firefight
+  "Slot order keyed by 1/2/3/4/5/6/7. Chainsaw at slot 4 so picking it
+   up doesn't yank the player off pistol/shotgun/chaingun mid-firefight
    the way the give-weapon auto-switch does for ranged. BFG at slot 5
    (issue #58): a rare, expensive AoE answer to grouped enemies.
    Incinerator at slot 6 (issue #122): the only :fire weapon, a
-   swarm-clearer that fire-resist mobs shrug off."
-  [:pistol :shotgun :chaingun :chainsaw :bfg :incinerator])
+   swarm-clearer that fire-resist mobs shrug off. Rocket at slot 7
+   (issue #123): mid-tier AoE between the chaingun and the BFG nuke."
+  [:pistol :shotgun :chaingun :chainsaw :bfg :incinerator :rocket])
 
 (defn current-weapon
   "Active weapon keyword for `world`. Defaults to :pistol so fresh test

--- a/src/glue/controls.phel
+++ b/src/glue/controls.phel
@@ -293,7 +293,7 @@
 (def initial-key-snapshot
   "First-frame snapshot — nothing held yet."
   {:m false :sp false :p false :n false :e false :f false :f3 false :r false :h false
-   :esc false :k1 false :k2 false :k3 false :k4 false :k5 false :k6 false})
+   :esc false :k1 false :k2 false :k3 false :k4 false :k5 false :k6 false :k7 false})
 
 (defn- f3-pressed? [keys]
   ;; F3 across terminals: xterm/macOS Terminal/iTerm2 send `\eOR`;
@@ -408,7 +408,8 @@
    :k3 (key-pressed? keys "3" 51)
    :k4 (key-pressed? keys "4" 52)
    :k5 (key-pressed? keys "5" 53)
-   :k6 (key-pressed? keys "6" 54)})
+   :k6 (key-pressed? keys "6" 54)
+   :k7 (key-pressed? keys "7" 55)})
 
 (defn rising-edges
   "Build the edges map tick consumes — truthy only for keys that just
@@ -442,6 +443,7 @@
    :select-weapon4 (and (:k4 now) (not (:k4 prev)))
    :select-weapon5 (and (:k5 now) (not (:k5 prev)))
    :select-weapon6 (and (:k6 now) (not (:k6 prev)))
+   :select-weapon7 (and (:k7 now) (not (:k7 prev)))
    ;; F5 quick-save / F9 quick-load (issue #63). Handled in game-loop
    ;; (file IO), not tick-world, so the pure tick stays effect-free.
    :save           (and (:f5 now) (not (:f5 prev)))

--- a/src/io/render.phel
+++ b/src/io/render.phel
@@ -307,6 +307,14 @@
 (def incinerator-pickup-glyph  "\e[48;5;88;38;5;214;1m♨")
 (def incinerator-pickup-glyph-bright "\e[48;5;124;38;5;226;1m♨")
 
+;; Rocket launcher pickup (#123): a red-tipped warhead on an olive crate
+;; so the AoE weapon reads as ordnance, distinct from the BFG plasma and
+;; the incinerator flame.
+(def rocket-pickup-shade  "\e[48;5;58m ")
+(def rocket-pickup-bright "\e[48;5;100m ")
+(def rocket-pickup-glyph  "\e[48;5;58;38;5;196;1m➤")
+(def rocket-pickup-glyph-bright "\e[48;5;100;38;5;202;1m➤")
+
 (def keycard-blue-shade  "\e[48;5;21m ")
 (def keycard-blue-bright "\e[48;5;33m ")
 (def keycard-blue-glyph  "\e[48;5;21;38;5;231;1m⚿")
@@ -1138,7 +1146,7 @@
                         (bord "  space         fire")
                         (bord "  f             action (open secret walls)")
                         (bord "  r             reload")
-                        (bord "  1 .. 6        switch weapon slot")
+                        (bord "  1 .. 7        switch weapon slot")
                         (bord "  m             toggle minimap")
                         (bord "  n             toggle sound")
                         (bord "  F3            debug overlay")
@@ -2672,6 +2680,8 @@
         bfg-pickup-glyph-now               (if weapon-pickup-bright? bfg-pickup-glyph-bright bfg-pickup-glyph)
         incinerator-pickup-shade-now       (if weapon-pickup-bright? incinerator-pickup-bright incinerator-pickup-shade)
         incinerator-pickup-glyph-now       (if weapon-pickup-bright? incinerator-pickup-glyph-bright incinerator-pickup-glyph)
+        rocket-pickup-shade-now            (if weapon-pickup-bright? rocket-pickup-bright rocket-pickup-shade)
+        rocket-pickup-glyph-now            (if weapon-pickup-bright? rocket-pickup-glyph-bright rocket-pickup-glyph)
         ;; Atmospheric haze pulls walls toward black as lives drop, so
         ;; the world reads as 'consumed by darkness' the closer the
         ;; player is to dying. Sky / floor untouched; doors keep their
@@ -2940,9 +2950,15 @@
                                                         (or (:weapon-pickups world) [])))
                                          (:player world) dists edists vw vh
                                          incinerator-pickup-shade-now incinerator-pickup-glyph-now)
+          bp-wr     (paint-pickups-into  bp-wi
+                                         (apply vector
+                                                (filter (fn [w] (php/=== (:weapon w) :rocket))
+                                                        (or (:weapon-pickups world) [])))
+                                         (:player world) dists edists vw vh
+                                         rocket-pickup-shade-now rocket-pickup-glyph-now)
           ;; Fireballs paint last into the overlay so an incoming bolt
           ;; sits on top of every pickup glow it crosses.
-          bp-proj   (paint-projectiles-into bp-wi (or (:projectiles world) [])
+          bp-proj   (paint-projectiles-into bp-wr (or (:projectiles world) [])
                                             (:player world) dists edists vw vh)
           parts     (buf-mk)]
       (dotimes [row vh]
@@ -3348,7 +3364,7 @@
                   (pad-visible "    \e[93me      \e[40;97m   about-face (snap 180°)" w)
                   (pad-visible "    \e[93mspace  \e[40;97m   fire" w)
                   (pad-visible "    \e[93mr      \e[40;97m   reload" w)
-                  (pad-visible "    \e[93m1 .. 6 \e[40;97m   switch weapon slot" w)
+                  (pad-visible "    \e[93m1 .. 7 \e[40;97m   switch weapon slot" w)
                   (pad-visible "    \e[93mh      \e[40;97m   info menu (stats + weapons)" w)
                   (pad-visible "    \e[93mm  n   \e[40;97m   toggle minimap / sound" w)
                   (pad-visible "    \e[93mp      \e[40;97m   pause + settings menu" w)

--- a/src/io/sound.phel
+++ b/src/io/sound.phel
@@ -41,6 +41,9 @@
    ;; Incinerator (#122): a wet sizzle for the flame stream, distinct
    ;; from the dry ballistic reports and the glassy BFG.
    :shoot-incinerator "/System/Library/Sounds/Frog.aiff"
+   ;; Rocket launcher (#123): a sharp metallic ping for the launch,
+   ;; distinct from the other weapon reports.
+   :shoot-rocket   "/System/Library/Sounds/Ping.aiff"
    :kill      "/System/Library/Sounds/Pop.aiff"
    :hit       "/System/Library/Sounds/Sosumi.aiff"
    :wound     "/System/Library/Sounds/Submarine.aiff"

--- a/tests/core/weapons-test.phel
+++ b/tests/core/weapons-test.phel
@@ -57,6 +57,37 @@
   (is (= :incinerator (get weapon-order 5))
       "incinerator occupies slot 6 (weapon-order index 5)"))
 
+;; ---------------------------------------------------------------------
+;; #123: rocket launcher. Mid-tier AoE that fills the gap between the
+;; chaingun (no splash) and the rare BFG nuke. Reuses the generic
+;; `:splash-radius` combat path (bfg-fire), with smaller numbers so it
+;; is a cheaper, more available crowd tool than the BFG.
+;; ---------------------------------------------------------------------
+
+(deftest test-rocket-is-a-splash-weapon
+  (let [r (get weapons :rocket)]
+    (is (some? r) "rocket exists in the catalogue")
+    (is (some? (:splash-radius r)) "rocket carries a splash radius (routes to bfg-fire)")
+    (is (some? (:splash-damage r)) "rocket carries splash damage")
+    (is (= false (:auto-fire? r)) "rocket is single-action")))
+
+(deftest test-rocket-is-weaker-and-cheaper-than-bfg
+  ;; The niche: a mid-tier blast, not a nuke. Smaller radius + damage
+  ;; than the BFG so the BFG stays the rare panic button.
+  (let [r (get weapons :rocket)
+        b (get weapons :bfg)]
+    (is (php/< (:splash-radius r) (:splash-radius b)) "rocket blast is smaller than BFG")
+    (is (php/< (:splash-damage r) (:splash-damage b)) "rocket splash damage is lower than BFG")))
+
+(deftest test-rocket-is-slot-7
+  (is (= :rocket (get weapon-order 6))
+      "rocket occupies slot 7 (weapon-order index 6)"))
+
+(deftest test-give-and-switch-rocket
+  (let [w (give-weapon (fresh-world) :rocket)]
+    (is (= :rocket (current-weapon w)) "give-weapon auto-switches to rocket")
+    (is (= true (owns? w :rocket)))))
+
 (deftest test-give-and-switch-incinerator
   (let [w  (give-weapon (fresh-world) :incinerator)]
     (is (= :incinerator (current-weapon w)) "give-weapon auto-switches to incinerator")
@@ -173,10 +204,11 @@
   ;; Player presses 1-6 to swap weapons. Slot ordering must stay stable
   ;; so muscle memory survives. BFG is slot 5 (issue #58); incinerator
   ;; is slot 6 (issue #122).
-  (is (= [:pistol :shotgun :chaingun :chainsaw :bfg :incinerator] weapon-order))
+  (is (= [:pistol :shotgun :chaingun :chainsaw :bfg :incinerator :rocket] weapon-order))
   (is (= :chainsaw    (get weapon-order 3)))
   (is (= :bfg         (get weapon-order 4)))
-  (is (= :incinerator (get weapon-order 5))))
+  (is (= :incinerator (get weapon-order 5)))
+  (is (= :rocket      (get weapon-order 6))))
 
 (deftest test-effective-reserve-cap-scales-with-backpack-level
   ;; Pistol's reserve-cap is 50 from the catalog. Backpack stack scales

--- a/tests/glue/controls-test.phel
+++ b/tests/glue/controls-test.phel
@@ -86,7 +86,8 @@
   (is (= false (:k3 initial-key-snapshot)))
   (is (= false (:k4 initial-key-snapshot)))
   (is (= false (:k5 initial-key-snapshot)))
-  (is (= false (:k6 initial-key-snapshot))))
+  (is (= false (:k6 initial-key-snapshot)))
+  (is (= false (:k7 initial-key-snapshot))))
 
 (deftest test-key-states-detects-f3-xterm-sequence
   ;; Most terminals (xterm, macOS Terminal, iTerm2) send `\eOR` for F3.


### PR DESCRIPTION
Closes #123

## Gap
The splash curve jumped straight from 'no AoE' to the BFG nuke. DOOM's rocket launcher filled the mid-tier crowd-control slot. The BFG was the only AoE answer and is deliberately scarce.

## Fix
Add the **rocket launcher** (slot 7, found L5): single-action mid-tier AoE, `:splash-radius 2.0` / `:splash-damage 3`. It carries `:splash-radius`, so it routes through the existing generic `bfg-fire` splash path (`fire-shot` branches on `:splash-radius`, no BFG hardcoding). Numbers are strictly below the BFG (radius 3.0 / splash 6, found L7), so the BFG stays the rare panic button and the rocket is the everyday crowd tool. `:ballistic` (explosive shell), unresisted.

Full slot-7 plumbing: `k7`/'7' input + snapshot + edge, play-loop switch, warhead pickup glyph + 3D paint branch, `:shoot-rocket` sfx, L5 spawn.

## Testing
- New weapons-test cases (splash weapon, weaker/cheaper than BFG, slot-7 order, give/switch) + k7 snapshot coverage.
- `composer ci` green (1634 tests).

## Review
clean-code-reviewer pass: code correct, splash path + plumbing verified. Fixed flagged doc drift (features.md 5->7 slots, level-system.md weapon-drop list, state.md :weapon enum, fire-shot docstring, README single-action) - several predated #122 - in a `ref` commit.