### PR TITLE
docs: focus README on starting the game, move details to player guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 DOOM-lite raycaster in your terminal. Pure [Phel](https://phel-lang.org/) (Lisp on PHP). 256-color ANSI, 10 procgen levels, FPS combat, ~5ms frame. Full feature list: [docs/features.md](docs/features.md).
 
-## Quick start
+## Play
 
-Needs PHP >= 8.4, Composer, 256-color terminal.
+Needs PHP >= 8.4, Composer, and a 256-color terminal.
 
 ```bash
 git clone git@github.com:Chemaclass/phel-doom.git
@@ -17,9 +17,10 @@ make play
 
 Or `composer install && composer play`.
 
-### Docker
+<details>
+<summary>No local PHP? Run in Docker</summary>
 
-No PHP? Run in Docker: PHP 8.5 CLI + Composer + deps in an image. `docker` is the only prerequisite.
+PHP 8.5 CLI + Composer + deps in an image; `docker` is the only prerequisite.
 
 ```bash
 make docker-build      # build image
@@ -31,59 +32,21 @@ make docker-clean      # remove image
 
 Override tag: `DOCKER_IMG=mytag make docker-build`. Host PHP is the inner loop; Docker adds ~1s startup.
 
+</details>
+
 ## Controls
 
-| Key            | Action                       |
+| Key            | Action                  |
 |---|---|
-| `w` / `s` / ↑↓ | Forward / back               |
-| `a` / `d`      | Strafe left / right          |
-| `←` / `→`      | Turn left / right            |
-| `SHIFT` / `x`  | Sprint (1.6× speed)          |
-| `e`            | About-face (180°)            |
-| `space`        | Fire                         |
-| `r`            | Reload                       |
-| `1` / `2` / `3` | Switch weapon                |
-| `m` / `n`      | Minimap / sound toggle       |
-| `p`            | Pause + settings             |
-| `h` / `ESC`    | Info menu + pause            |
-| `F3`           | Debug overlay                |
-| `q`            | Quit                         |
+| `w` `a` `s` `d` / arrows | Move / turn    |
+| `SHIFT`        | Sprint                  |
+| `space` / `r`  | Fire / reload           |
+| `1`...`7`      | Switch weapon           |
+| `p` / `q`      | Pause / quit            |
 
-Walk into doors to advance. Pickups:
+Walk into doors to advance. Find weapons and pickups on the map.
 
-- **♥ heart**: `+1` life
-- **◆ armor**: absorbs one hit (cap 5)
-- **armor shard**: `+1` armor over 5, up to 10
-- **soulsphere**: `+1` life over cap, decays back
-- **ammo box**: `+N` to weapon reserve
-- **berserk**: 20s of `×2` damage
-- **invuln**: 10s immunity
-- **backpack**: increases reserve cap
-- **⚿ keycard**: unlocks L4 (blue) / L5 (red) exits; L10 boss-locked
-
-Compass at top-centre: tints the cardinal letter (E/S/W/N) toward your target. Orange = exit, blue/red = keycard needed.
-
-Weapons (DPS-balanced, found on map):
-
-| Slot | Weapon | Dmg | CD | Mag | DPS | Type / niche |
-|---|---|---|---|---|---|---|
-| 1 | pistol | 1 | 0.12s | 10 | 8 | ballistic, fallback |
-| 2 | shotgun | 3 | 0.6s | 4 | 5 | ballistic, burst |
-| 3 | chaingun | 1 | 0.05s | 30 | 20 | ballistic, sustained |
-| 4 | chainsaw | 1 | 0.10s | ∞ | 10 | melee, no ammo |
-| 5 | BFG | 10 +6 splash | 1.2s | 1 | - | plasma, AoE (ignores fire-resist) |
-| 6 | incinerator | 1 | 0.06s | 40 | 16 | fire, swarm-clearer (caco/baron/archvile/mancubus resist it) |
-| 7 | rocket launcher | 3 splash (r2.0) | 0.9s | 1 | - | ballistic, mid-tier AoE (cheaper than BFG) |
-
-Hold space to spray (pistol / chaingun / chainsaw / incinerator). Shotgun, BFG, and rocket launcher: one pull per shot.
-
-CLI flags:
-
-- `--difficulty=easy|normal|hard|nightmare` (`-d`) - scales enemy speed, HP, count
-- `--level=N` (`-l`) - start at level N
-- `--god` (`-g`), `--armory` (`-a`), `--full-map` (`-f`) - dev flags
-
-Terminal quirks (kitty, tmux): [docs/input.md](docs/input.md).
+Full controls, pickups, and weapons: [docs/gameplay.md](docs/gameplay.md).
 
 ## Internals
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,7 @@ Per-subsystem docs, each linked to source files and key functions.
 
 | Topic | File |
 |---|---|
+| Player guide (controls, pickups, weapons) | [gameplay.md](gameplay.md) |
 | Feature catalogue | [features.md](features.md) |
 | Module layout + rules | [architecture.md](architecture.md) |
 | Per-frame transitions | [game-loop.md](game-loop.md) |

--- a/docs/gameplay.md
+++ b/docs/gameplay.md
@@ -1,0 +1,68 @@
+# Player guide
+
+Full controls, pickups, weapons, and CLI flags. The README keeps a short
+version; this page is the complete reference.
+
+## Controls
+
+| Key            | Action                                  |
+|---|---|
+| `w` / `s` / ↑↓ | Forward / back                          |
+| `a` / `d`      | Strafe left / right                     |
+| `←` / `→`      | Turn left / right                       |
+| `SHIFT` / `x`  | Sprint (1.6x speed)                     |
+| `e`            | About-face (180 degrees)                |
+| `space`        | Fire (hold to spray auto-fire weapons)  |
+| `r`            | Reload                                   |
+| `f`            | Use: reveal secret / toggle switch      |
+| `1`...`7`      | Switch weapon                           |
+| `m`            | Minimap toggle                          |
+| `n`            | Sound toggle                            |
+| `p`            | Pause + settings                        |
+| `h` / `ESC`    | Info menu + pause                       |
+| `F3`           | Debug overlay                           |
+| `F5` / `F9`    | Save / load                             |
+| `q`            | Quit                                    |
+
+Walk into doors to advance.
+
+Compass at top-centre tints the cardinal letter (E/S/W/N) toward your
+target. Orange = exit, blue/red = keycard needed.
+
+Terminal quirks (kitty, tmux): [input.md](input.md).
+
+## Pickups
+
+- **heart**: `+1` life
+- **armor**: absorbs one hit (cap 5)
+- **armor shard**: `+1` armor over 5, up to 10
+- **soulsphere**: `+1` life over cap, decays back
+- **ammo box**: `+N` to weapon reserve
+- **berserk**: 20s of `x2` damage
+- **invuln**: 10s immunity
+- **backpack**: increases reserve cap
+- **keycard**: unlocks L4 (blue) / L5 (red) exits; L10 is boss-locked
+
+## Weapons
+
+DPS-balanced niches rather than monotonic upgrades; weapons are found on
+the map and selected with keys `1`...`7`.
+
+| Key | Weapon | Dmg | CD | Mag | DPS | Type / niche |
+|---|---|---|---|---|---|---|
+| 1 | pistol | 1 | 0.12s | 10 | 8 | ballistic, fallback (overheats if held) |
+| 2 | shotgun | 3 | 0.6s | 4 | 5 | ballistic, burst |
+| 3 | chaingun | 1 | 0.05s | 30 | 20 | ballistic, sustained |
+| 4 | chainsaw | 1 | 0.10s | inf | 10 | melee, no ammo |
+| 5 | BFG | 10 + 6 splash (r3.0) | 1.2s | 1 | - | plasma, AoE (ignores fire-resist) |
+| 6 | incinerator | 1 | 0.06s | 40 | 16 | fire, swarm-clearer (caco/baron/archvile/mancubus resist) |
+| 7 | rocket launcher | 4 + 3 splash (r2.0) | 0.9s | 1 | - | ballistic, mid-tier AoE (cheaper than BFG) |
+
+Hold `space` to spray auto-fire weapons (pistol / chaingun / chainsaw /
+incinerator). Shotgun, BFG, and rocket launcher fire one shot per pull.
+
+## CLI flags
+
+- `--difficulty=easy|normal|hard|nightmare` (`-d`) - scales enemy speed, HP, count
+- `--level=N` (`-l`) - start at level N
+- `--god` (`-g`), `--armory` (`-a`), `--full-map` (`-f`) - dev flags


### PR DESCRIPTION
## What

Trim the README to the essentials for **starting the game**, and move the heavy reference tables to a dedicated player guide.

- README flow is now: **Play** -> Docker (collapsed in `<details>` for devs without local PHP) -> a short 5-row controls table -> links to the full guide. 96 -> 58 lines.
- New **`docs/gameplay.md`** holds the full controls, pickups, weapons, and CLI flags. Linked from `docs/README.md`.

## Corrected stale data while moving it

Verified every table against source (`weapons.phel`, `controls.phel`):

- weapon switch is keys **`1`...`7`** (README showed `1/2/3`, but `:select-weapon1..7` exist).
- rocket launcher is **4 dmg + 3 splash (r2.0)** (README said "3 splash").
- added missing keys: **`f`** (use / reveal secret / toggle switch), **`F5`/`F9`** (save/load).
- pickups + DPS values confirmed accurate (berserk 20s x2, invuln 10s, armor shard cap 10).

## Decision

Kept a simpler controls snippet in the README and moved the detailed tables out, rather than dropping them. Players get a fast start; the full reference lives one click away.