### PR TITLE
feat(render): surface F5/F9 quick save/load in the info menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 
 ### Added
 
+- The H info menu now lists `F5` / `F9` quick save / load, so the save feature is discoverable in-game instead of only via the post-press HUD flash.
 - Rocket launcher (#123). Slot 7, found on L5: a single-action mid-tier AoE (splash radius 2.0, splash damage 3) that fills the gap between the chaingun and the rare BFG nuke. Reuses the splash combat path; cheaper and more available than the BFG. Switch keys now span 1-7.
 - Incinerator weapon (#122). Slot 6, found on L6: a fast short-range `:fire` flame stream. It is the first weapon to deal `:fire`, so it activates the previously-inert per-enemy resist system - caco / baron / archvile / mancubus shrug it off (zero damage), everything else burns. Switch keys now span 1-6.
 
@@ -21,6 +22,7 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 
 ### Fixed
 
+- WEAPONS table in the H info menu: long weapon names (`rocket launcher`, `incinerator`) no longer collide with the `dmg` column, 2-digit damage (the BFG) no longer shifts the ammo column, and unowned `--/--` rows line up with owned rows. The name column now sizes to the longest weapon name.
 - Wall-top/ceiling seam no longer shows scattered dark dots. The half-block edge cell painted its sky/floor half with a flat shade code instead of the actual gradient shade at that row; it now samples the gradient so the seam blends cleanly.
 - Start-menu settings (`s`) now apply and persist; music/sfx/minimap/difficulty edits were silently dropped.
 - Chainsaw (slot 4) is now obtainable: it drops on L4 and `--armory` includes it (was unreachable dead content).

--- a/src/io/render.phel
+++ b/src/io/render.phel
@@ -988,37 +988,51 @@
     (str text "\e[40;97m"
          (php/str_repeat " " (php/max 0 (php/- width visible-len))))))
 
+(def help-weapon-name-width
+  "Widest weapon `:name`, so the `dmg`/ammo columns line up in the
+   WEAPONS table regardless of how long a name is (e.g. the 15-char
+   `rocket launcher` or `incinerator`). Computed from the catalog so a
+   new weapon never silently collides the columns."
+  (reduce (fn [m kw]
+            (php/max m (php/strlen (or (:name (get weapons kw)) (php/strval kw)))))
+          0 weapon-order))
+
 (defn- help-weapon-row
   "Render one weapon entry as a full menu row including both `│`
    borders. Builds the visible string first (no SGR) so the trailing
    pad math is byte-accurate, then wraps the body in the per-weapon
    colour. Active weapon gets a yellow `>` marker; unowned weapons
    render dim with `--/--` ammo so the player sees the slot exists
-   but still has to find it on the map."
+   but still has to find it on the map. The name pads to
+   `help-weapon-name-width` and dmg pads to 2 cols so every column
+   aligns down the table."
   [kw spec active? owned? mag reserve cap row-w]
   (let [name     (or (:name spec) (php/strval kw))
         dmg      (or (:damage spec) 0)
         mag-sz   (or (:mag-size spec) 0)
         marker   (if active? "> " "  ")
-        name-pad (php/str_repeat " " (php/max 0 (php/- 10 (php/strlen name))))
+        name-pad (php/str_repeat " " (php/max 0 (php/- help-weapon-name-width (php/strlen name))))
+        dmg-str  (php/str_pad (php/strval dmg) 2 " ")
         ammo-txt (if owned?
                    (let [mag-frag (str mag "/" mag-sz)]
                      (str mag-frag
                           (php/str_repeat " " (php/max 0 (php/- 7 (php/strlen mag-frag))))
                           "[" reserve "/" cap "]"))
-                   "--/--   [--/--]")
-        body     (str " " marker name name-pad "dmg " dmg "  " ammo-txt)
+                   "--/--  [--/--]")
+        body     (str " " marker name name-pad " dmg " dmg-str "  " ammo-txt)
         body-pad (php/str_repeat " " (php/max 0 (php/- row-w (php/strlen body))))
         sgr      (cond active? "\e[1;93m" owned? "\e[97m" :else "\e[2;90m")]
     (str "│" sgr body "\e[40;97m" body-pad "│")))
 
-(defn- help-menu-string
-  "Build the H info overlay. Three sections — run state, player
-   status, weapons table — plus a short controls reminder. Pure:
-   caller pushes the resulting ANSI string into the parts array.
+(defn help-menu-rows
+  "Build the H info overlay as a vector of full-width bordered rows
+   (each `│...│`, or a `┌─┐`/`├─┤`/`└─┘` rule). Sections — run state,
+   player status, weapons table, compass hint, controls — are spliced
+   greedily to fit `vh`. Every interior row is padded to the same width
+   so the right border lines up; `help-menu-string` positions them.
 
-   Reads everything from `stats` so the overlay never reaches back
-   into `world` directly. `stats` carries the same keys frame-stats
+   Pure: reads everything from `stats` so the overlay never reaches
+   back into `world` directly. `stats` carries the same keys frame-stats
    stamps in commands/play.phel — see that fn for the full list."
   [vw vh stats]
   (let [;; Width-adaptive: clamp interior so the whole frame
@@ -1151,7 +1165,8 @@
                         (bord "  n             toggle sound")
                         (bord "  F3            debug overlay")
                         (bord "  p             pause + settings")
-                        (bord "  h / ESC      close this menu")
+                        (bord "  F5 / F9       quick save / load")
+                        (bord "  h / ESC       close this menu")
                         (bord "  q             quit")])
         closer-rows   (to-php-array [blnk (str "└" bar "┘")])
         ;; Greedy fit: always include core + closer, then add compass
@@ -1171,16 +1186,26 @@
                         (php/array_merge with-compass controls-rows)
                         with-compass)
         rows          (apply vector (php/array_merge with-ctrls closer-rows))]
-    (let [n    (count rows)
-          col0 (php/max 1 (php/- (php/+ (php/intdiv vw 2) 1)
-                                 (php/intdiv (php/+ w 2) 2)))
-          row0 (php/max 1 (php/intdiv (php/max 1 (php/- vh n)) 2))]
-      (loop [i 0 acc ""]
-        (if (php/>= i n)
-          acc
-          (recur (php/+ i 1)
-                 (str acc "\e[" (php/+ row0 i) ";" col0 "H\e[40;97m"
-                      (get rows i) "\e[0m")))))))
+    rows))
+
+(defn- help-menu-string
+  "Position the help/info menu rows (built by `help-menu-rows`) with
+   absolute cursor moves, centred in the `vw` x `vh` viewport. Pure:
+   caller pushes the resulting ANSI string into the parts array."
+  [vw vh stats]
+  (let [w    (php/max help-min-inner-width
+                      (php/min help-inner-width (php/- vw 2)))
+        rows (help-menu-rows vw vh stats)
+        n    (count rows)
+        col0 (php/max 1 (php/- (php/+ (php/intdiv vw 2) 1)
+                               (php/intdiv (php/+ w 2) 2)))
+        row0 (php/max 1 (php/intdiv (php/max 1 (php/- vh n)) 2))]
+    (loop [i 0 acc ""]
+      (if (php/>= i n)
+        acc
+        (recur (php/+ i 1)
+               (str acc "\e[" (php/+ row0 i) ";" col0 "H\e[40;97m"
+                    (get rows i) "\e[0m"))))))
 
 (def settings-inner-width
   "Interior character width of each settings-overlay row. Wide enough

--- a/tests/io/render-test.phel
+++ b/tests/io/render-test.phel
@@ -1,6 +1,6 @@
 (ns phel-doom-tests.io.render-test
   (:require phel.test :refer [deftest is])
-  (:require phel-doom.io.render :refer [direction-char project-enemy enemy-front-visible-at? reload-reminder-visible?]))
+  (:require phel-doom.io.render :refer [direction-char project-enemy enemy-front-visible-at? reload-reminder-visible? help-menu-rows]))
 
 ;; ---------------------------------------------------------------------
 ;; reload-reminder-visible? (#128): the periodic "press R to RELOAD" nag
@@ -133,3 +133,64 @@
         edists (php/array)]
     (is (= true (enemy-front-visible-at? 4.0 0 dists edists))
         "no nearer enemy -> shadow allowed")))
+
+;; ---------------------------------------------------------------------
+;; help-menu-rows borders: every interior row of the H info overlay is
+;; padded to the same width so the right `│` border lines up. A row built
+;; without help-pad (or a miscounted glyph) would render a ragged border.
+;; This guards every section: RUN, PLAYER, WEAPONS, COMPASS, CONTROLS
+;; (incl. the F5/F9 quick save/load line).
+;; ---------------------------------------------------------------------
+
+(defn- visible-width [s]
+  ;; Strip CSI SGR escapes, then count display columns (mb, not bytes):
+  ;; matches how render's help-pad measures interior width.
+  (php/mb_strlen (php/preg_replace "/\\x1b\\[[\\d;]*m/" "" s)))
+
+(defn- expected-frame-width [vw]
+  ;; Mirror help-menu-string: interior w clamped to [36, 44], plus the
+  ;; two side borders.
+  (php/+ 2 (php/max 36 (php/min 44 (php/- vw 2)))))
+
+(defn- all-rows-aligned? [vw vh stats]
+  (let [rows (help-menu-rows vw vh stats)
+        want (expected-frame-width vw)]
+    (every? (fn [r] (= want (visible-width r))) rows)))
+
+(deftest test-help-menu-borders-align-default-stats
+  ;; vh=60 is tall enough that the greedy fit keeps every section,
+  ;; including CONTROLS (the F5/F9 + h/ESC rows).
+  (is (all-rows-aligned? 80 60 {})
+      "all help-menu rows share one width with every section visible"))
+
+(deftest test-help-menu-borders-align-narrow
+  ;; vw=44 -> interior clamps to 42 (below the 44 default). The widest
+  ;; row (rocket launcher) still fits, so borders stay aligned. Terminals
+  ;; narrower than the weapon table are the documented clip zone.
+  (is (all-rows-aligned? 44 40 {})
+      "borders still align when the menu clamps below its default width"))
+
+(deftest test-help-menu-borders-align-with-buffs-and-keys
+  ;; Populate the coloured keys/buffs rows + an active non-pistol weapon
+  ;; so the SGR-stripping pad math is exercised on every dynamic row.
+  (is (all-rows-aligned? 80 40
+                         {:held-keys #{:blue :red}
+                          :berserk-secs 12.0
+                          :invuln-secs 4.0
+                          :backpack? true
+                          :owned-weapons #{:pistol :shotgun :chaingun}
+                          :weapon :shotgun})
+      "coloured keys/buffs + weapon rows stay border-aligned"))
+
+(deftest test-help-menu-borders-align-short-viewport
+  ;; Short vh drops CONTROLS then COMPASS; the surviving rows must still
+  ;; align (closer row is always appended).
+  (is (all-rows-aligned? 80 14 {})
+      "section-dropping on a short terminal keeps borders aligned"))
+
+(deftest test-help-menu-lists-save-load
+  ;; The save/load feature must be discoverable in the info menu, not
+  ;; only via the post-press HUD flash.
+  (let [rows (help-menu-rows 80 60 {})]
+    (is (some (fn [r] (php/!== false (php/strpos r "F5 / F9"))) rows)
+        "H info menu lists F5 / F9 quick save / load")))


### PR DESCRIPTION
## Why

Quick save (`F5`) / quick load (`F9`) already worked, but the in-game **H info menu listed every other key except these two**. Players could only stumble on the feature via the post-press "SAVED" HUD flash. Now the CONTROLS section lists it:

```
  p             pause + settings
  F5 / F9       quick save / load
  h / ESC       close this menu
  q             quit
```

## Also: WEAPONS table borders

While checking the menu borders, found the WEAPONS table was internally ragged at normal width (the outer box border was fine):

Before:
```
  incineratordmg 1  --/--   [--/--]
> rocket launcherdmg 4  0/1    [0/30]
```
After:
```
  incinerator     dmg 1   --/--  [--/--]
> rocket launcher dmg 4   0/1    [0/30]
```

- name column now sizes to the longest weapon name (no collision with `dmg`)
- damage pads to 2 cols so 2-digit damage (BFG `dmg 10`) doesn't shift the ammo column
- unowned `--/--` rows line up with owned rows

## Tests

Extracted `help-menu-rows` (pure, exported) from `help-menu-string` and added:
- border-alignment checks (every row shares one visible width) across full/clamped widths and tall/short viewports, covering RUN / PLAYER / WEAPONS / COMPASS / CONTROLS
- a presence test for the `F5 / F9` line

33 render tests pass; full `composer ci` (format + lint + test + build) green.

Docs: `docs/gameplay.md` already documents F5/F9.