### PR TITLE
feat(render): show run time as a clock, not raw seconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 
 ### Added
 
+- Run times render as a clock (`M:SS`, or `H:MM:SS` past an hour) instead of raw seconds (#131). Applies to the victory and death screens, the persisted best time, and the info-menu RUN time, via a unit-tested `format-duration` helper.
 - The H info menu now lists `F5` / `F9` quick save / load, so the save feature is discoverable in-game instead of only via the post-press HUD flash.
 - Rocket launcher (#123). Slot 7, found on L5: a single-action mid-tier AoE (splash radius 2.0, splash damage 3) that fills the gap between the chaingun and the rare BFG nuke. Reuses the splash combat path; cheaper and more available than the BFG. Switch keys now span 1-7.
 - Incinerator weapon (#122). Slot 6, found on L6: a fast short-range `:fire` flame stream. It is the first weapon to deal `:fire`, so it activates the previously-inert per-enemy resist system - caco / baron / archvile / mancubus shrug it off (zero damage), everything else burns. Switch keys now span 1-6.

--- a/src/core/format.phel
+++ b/src/core/format.phel
@@ -1,0 +1,17 @@
+(ns phel-doom.core.format)
+
+(defn format-duration
+  {:doc "Format a second count as a clock string. Under an hour renders
+         `M:SS` (minutes not zero-padded); an hour or more renders
+         `H:MM:SS` (minutes zero-padded). Seconds are always two digits.
+         Negative input clamps to zero; a float floors to whole seconds."
+   :see-also ["end-rows" "best-victory-cell"]
+   :example "(format-duration 3725) ; => \"1:02:05\""}
+  [secs]
+  (let [s   (php/max 0 (php/intval secs))
+        h   (php/intdiv s 3600)
+        m   (php/intdiv (php/- s (php/* h 3600)) 60)
+        sec (php/- s (php/+ (php/* h 3600) (php/* m 60)))]
+    (if (php/> h 0)
+      (php/sprintf "%d:%02d:%02d" h m sec)
+      (php/sprintf "%d:%02d" m sec))))

--- a/src/io/render.phel
+++ b/src/io/render.phel
@@ -4,7 +4,8 @@
   (:require phel-doom.core.perf    :refer [render-scale])
   (:require phel-doom.core.map     :refer [find-door-cell])
   (:require phel-doom.core.weapons :refer [weapon-order weapons])
-  (:require phel-doom.core.settings :refer [page-fields]))
+  (:require phel-doom.core.settings :refer [page-fields])
+  (:require phel-doom.core.format  :refer [format-duration]))
 
 ;; =====================================================================
 ;; § Hot-loop buffer macros
@@ -1124,7 +1125,7 @@
                          (sec "RUN")
                          (bord (str "  level:  " level-n "  " level-name))
                          (bord (str "  kills:  " kills "   streak x" streak))
-                         (bord (str "  time:   " (php/intval time-s) "s"))
+                         (bord (str "  time:   " (format-duration time-s)))
                          (bord (str "  diff:   " (php/ltrim (php/strval difficulty) ":")))
                          blnk
                          (sec "PLAYER")
@@ -3241,7 +3242,7 @@
            (php/min end-box-width-cap (php/- cols 4))))
 
 (defn- best-victory-cell [s]
-  (if (php/<= s 0) "--" (str s "s")))
+  (if (php/<= s 0) "--" (format-duration s)))
 
 (defn- best-rows
   "Tiny 3-line block summarising the persisted best scores."
@@ -3269,7 +3270,7 @@
             (if compact [:sep] [bl :sep bl])
             [(str "\e[97m" (end-row-text (str "  " did-what " L" level " " level-name) width) "\e[0m")
              (str "\e[97m" (end-row-text (str "  kills:   " kills)                width) "\e[0m")
-             (str "\e[97m" (end-row-text (str "  time:    " survived-s "s")       width) "\e[0m")]
+             (str "\e[97m" (end-row-text (str "  time:    " (format-duration survived-s)) width) "\e[0m")]
             (if compact
               [:sep]
               (concat [bl :sep bl] (best-rows scores width) [bl :sep bl]))

--- a/tests/core/format-test.phel
+++ b/tests/core/format-test.phel
@@ -1,0 +1,33 @@
+(ns phel-doom-tests.core.format-test
+  (:require phel.test :refer [deftest is])
+  (:require phel-doom.core.format :refer [format-duration]))
+
+;; ---------------------------------------------------------------------
+;; format-duration (#131): turn a second count into a readable clock.
+;; Under an hour -> M:SS (minutes not zero-padded); an hour or more ->
+;; H:MM:SS (minutes zero-padded). Seconds always two digits.
+;; ---------------------------------------------------------------------
+
+(deftest test-format-duration-zero
+  (is (= "0:00" (format-duration 0))))
+
+(deftest test-format-duration-seconds-only
+  (is (= "0:05" (format-duration 5))))
+
+(deftest test-format-duration-minutes
+  (is (= "1:05" (format-duration 65)))
+  (is (= "10:05" (format-duration 605))))
+
+(deftest test-format-duration-exact-minute
+  (is (= "2:00" (format-duration 120))))
+
+(deftest test-format-duration-hours-zero-pads-minutes
+  (is (= "1:02:05" (format-duration 3725)))
+  (is (= "1:00:00" (format-duration 3600))))
+
+(deftest test-format-duration-clamps-negative
+  (is (= "0:00" (format-duration -5))))
+
+(deftest test-format-duration-truncates-float
+  ;; survived-s is already an int, but be defensive: a float floors.
+  (is (= "1:05" (format-duration 65.9))))


### PR DESCRIPTION
Closes #131

## What

Run times rendered as raw seconds (`time: 3725s`), unreadable on long runs. Now they render as a clock:

- under an hour -> `M:SS` (e.g. `1:05`)
- an hour or more -> `H:MM:SS` (e.g. `1:02:05`)

Applied everywhere a run time shows: victory screen, death screen, persisted **best time**, and the info-menu **RUN** time.

## How

New pure `format-duration` in `src/core/format.phel` (per the io-boundary rule: formatting math stays out of `io/`). `render.phel` just calls it.

## Tests

`tests/core/format-test.phel`: `0 -> 0:00`, `65 -> 1:05`, `605 -> 10:05`, `3725 -> 1:02:05`, negative clamps, float floors. Full `composer ci` green (1648 tests).

Reviewer note: trivial pure helper, covered by unit tests; skipped the deep review pass.