### PR TITLE
feat(combat): give the pistol a piercing identity vs the chaingun

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 
 ### Changed
 
+- Pistol identity vs chaingun (#124): the pistol round now **pierces**, hitting every enemy in the line instead of stopping at the nearest. That is its edge over the strictly-higher-DPS chaingun (lined-up enemies take one hit each). Overheat was dropped from the pistol - jamming the forced fallback weapon is anti-fun; the generic `:overheats?` mechanic stays dormant for future weapons.
 - `press R to RELOAD` reminder is now weapon-aware (#128): it arms on the remaining-mag fraction instead of an absolute count, and is suppressed for single-round mags (the BFG no longer nags on its 1/1 magazine).
 - Plainer, deeper wall shading: flat shaded stone (no brick speckle), gamma distance falloff for brighter mids, stronger corner contrast.
 

--- a/docs/combat.md
+++ b/docs/combat.md
@@ -14,8 +14,8 @@ Hitscan + damage timing + i-frames. `src/core/combat.phel`. Pure: no side effect
 | `fire-anim-seconds` | 0.09 | Muzzle flash visibility |
 | `fx-ttl-seconds` | 0.7 | Blood splatter lifetime |
 | `flash-seconds` | 0.05 | White impact jolt |
-| `heat-per-shot` | 0.30 | Pistol overheat per shot (jam at 1.0) |
-| `jam-seconds` | 0.7 | Pistol jam lockout duration |
+| `heat-per-shot` | 0.30 | Overheat per shot (jam at 1.0); dormant - no weapon overheats |
+| `jam-seconds` | 0.7 | Jam lockout duration; dormant (see Pistol below) |
 | `mag-size` | 10 | Pistol default magazine capacity |
 | `max-reserve` | 50 | Pistol default reserve cap |
 | `reload-cooldown-seconds` | 1.2 | Pistol reload duration |
@@ -63,6 +63,8 @@ On miss: weapon report only.
 
 Killed enemy stays in vector with `:respawn-after` timer. See [monsters.md](monsters.md).
 
+Weapons flagged `:pierce?` (the pistol) take a different path: `pierce` (in `enemy.phel`) damages **every** enemy in the line instead of only the nearest, and `pierce-fire` aggregates the kills like the BFG splash path (blood + sfx on the nearest target, hit-stop sized by the meatiest kill, no per-enemy loot).
+
 ### Blood splatter
 
 `{:x :y :ttl fx-ttl-seconds}` pushed into `:fx`. Render paints RGB gradient (bright-pink → mid-red → dim-red).
@@ -95,6 +97,12 @@ On kill, stamp `:hit-stop-secs` based on enemy HP via `hit-stop-for`:
 While `:hit-stop-secs > 0`, `play/tick-world` skips entire gameplay step (physics / AI / projectiles / shooting / damage); render holds frozen frame. Only tough kills freeze, so rapid-fire stays fluid.
 
 ## Weapon specializations
+
+### Pistol (pierce, slot 1)
+
+The pistol's identity (issue #124) is the `:pierce?` flag: its round passes through and damages every enemy along the ray, not just the nearest. That is its edge over the strictly-higher-DPS chaingun (20 vs 8 DPS) - a row of lined-up enemies in a corridor takes one hit each, where the chaingun would have to chew through them one at a time. The chaingun keeps the single-target sustained-spray niche; neither dominates.
+
+**Overheat dropped.** The pistol used to be the only `:overheats?` weapon (jam at heat 1.0). Jamming the weapon the player is *forced* onto when out of ammo is anti-fun, so overheat was removed from the pistol. The chaingun's mag burn and the shotgun's slow cadence are brake enough for those, so no weapon overheats now. The generic `:overheats?` / heat / jam machinery stays in place (data-driven, dormant) for any future weapon that opts in; `heat-per-shot` and `jam-seconds` are unused until then.
 
 ### Chainsaw (melee, slot 4)
 

--- a/src/core/combat.phel
+++ b/src/core/combat.phel
@@ -1,7 +1,7 @@
 (ns phel-doom.core.combat
   (:require phel-doom.core.rng :as rng)
   (:require phel-doom.core.engine   :refer [cast-ray])
-  (:require phel-doom.core.enemy    :refer [push-back-enemy shoot beam-impact splash])
+  (:require phel-doom.core.enemy    :refer [push-back-enemy shoot beam-impact splash pierce])
   (:require phel-doom.core.enemy-ai :refer [attacks? noise-wake])
   (:require phel-doom.core.physics  :refer [try-move])
   (:require phel-doom.core.state    :refer [max-lives])
@@ -748,17 +748,66 @@
      (apply-heat (push-blood-fx (assoc juiced :fire-anim fire-anim-seconds) hit-pos))
      world killed? hit-pos)))
 
+(defn- pierce-fire
+  "Resolve a piercing shot (weapons flagged `:pierce?`, the pistol). The
+   round damages every enemy in the line instead of stopping at the
+   nearest, so a row of lined-up enemies takes one hit each — the
+   pistol's niche over the higher-DPS chaingun. Aggregates kills/streak
+   like `bfg-fire`; blood + sfx land on the nearest target. No per-enemy
+   loot (mirrors the splash path)."
+  [world]
+  (let [p                          (:player world)
+        spec                       (w-spec world)
+        base                       (or (:damage spec) 1)
+        dmg                        (if (berserk? world) (php/* base berserk-damage-mul) base)
+        dtype                      (:damage-type spec)
+        max-r                      (or (:max-range spec) shot-max-range)
+        wall-d                     (cast-wall-distance world)
+        [es' killed hit-pos tough] (pierce (:enemies world) (:x p) (:y p) (:angle p)
+                                           wall-d shot-hit-radius max-r dmg dtype)
+        woken                      (noise-wake es' (:grid world) (:x p) (:y p))
+        hit?                       (not (nil? hit-pos))
+        killed?                    (php/> killed 0)
+        chain?                     (pos? (or (:streak-secs world) 0.0))
+        boss-killed?               (and (= (:door-lock world) :boss)
+                                        (some (fn [e] (and (= (:type e) :cyber)
+                                                           (false? (:alive e))))
+                                              woken))
+        scored                     (assoc world
+                                          :enemies     woken
+                                          :kills       (php/+ (or (:kills world) 0) killed)
+                                          :streak      (if killed?
+                                                         (php/+ (if chain? (or (:streak world) 0) 0) killed)
+                                                         (or (:streak world) 0))
+                                          :streak-secs (if killed? streak-window-seconds
+                                                           (or (:streak-secs world) 0.0)))
+        unlocked                   (if boss-killed?
+                                     (assoc scored :held-keys (conj (or (:held-keys scored) #{}) :boss))
+                                     scored)
+        juiced                     (if killed?
+                                     (let [hs (hit-stop-for tough)]
+                                       (if (php/> hs 0.0)
+                                         (assoc unlocked :hit-stop-secs hs)
+                                         unlocked))
+                                     unlocked)
+        based                      (assoc juiced :fire-anim fire-anim-seconds)]
+    (enqueue-shot-sfx
+     (apply-heat (if hit? (push-blood-fx based hit-pos) based))
+     world killed? (or hit-pos {:x (:x p) :y (:y p)}))))
+
 (defn fire-shot
   "Resolve one trigger pull end-to-end. Weapons with `:splash-radius`
-   (BFG, rocket) route to `bfg-fire`; everything else is a single-target
-   hitscan. After the
-   shot, run a flood-fill sound-wake from the player's cell so dormant
-   enemies in the same room hear it and switch to :aware. Doors block
-   the BFS so the wake stays local — same per-sector noise rule DOOM
-   uses."
+   (BFG, rocket) route to `bfg-fire`; `:pierce?` weapons (pistol) route
+   to `pierce-fire`; everything else is a single-target hitscan. After
+   the shot, run a flood-fill sound-wake from the player's cell so
+   dormant enemies in the same room hear it and switch to :aware. Doors
+   block the BFS so the wake stays local — same per-sector noise rule
+   DOOM uses."
   [world]
-  (if (:splash-radius (w-spec world))
-    (bfg-fire world)
+  (cond
+    (:splash-radius (w-spec world)) (bfg-fire world)
+    (:pierce? (w-spec world))       (pierce-fire world)
+    :else
     (let [[enemies' hit? hit-pos idx] (resolve-shot world)
           p                           (:player world)
           woken                       (noise-wake enemies' (:grid world) (:x p) (:y p))

--- a/src/core/enemy.phel
+++ b/src/core/enemy.phel
@@ -258,6 +258,54 @@
                        (conj acc (assoc woke :hit-flash-secs hit-flash-seconds))
                        killed)))))))))
 
+(defn pierce
+  "Piercing hitscan: damage EVERY alive enemy along the ray, not just the
+   nearest like `shoot`. An enemy is struck when it is in front of the
+   player (`proj > 0`), nearer than both the wall and `max-range`, and
+   within `hit-radius` of the ray line. Returns
+   `[new-enemies killed-count hit-pos kill-toughness]`, where `hit-pos`
+   is the nearest struck enemy (for blood + sfx) or nil on a clean miss,
+   and `kill-toughness` is the largest `:max-lives` among enemies killed
+   this shot (0 if none) so the caller can size hit-stop per the meatiest
+   kill. Survivors wake (`:aware`) + take a hit-flash; no pain roll
+   (mirrors `splash`). Pure."
+  [enemies ^float px ^float py ^float angle ^float wall-dist ^float hit-radius ^float max-range ^int damage damage-type]
+  (let [cos-a (php/cos angle)
+        sin-a (php/sin angle)
+        cap   (php/min wall-dist max-range)
+        hr2   (php/* hit-radius hit-radius)]
+    (loop [i 0 acc [] killed 0 best-d cap hit-pos nil tough 0]
+      (if (php/>= i (count enemies))
+        [acc killed hit-pos tough]
+        (let [e     (get enemies i)
+              dx    (php/- (:x e) px)
+              dy    (php/- (:y e) py)
+              proj  (php/+ (php/* dx cos-a) (php/* dy sin-a))
+              perpx (php/- dx (php/* proj cos-a))
+              perpy (php/- dy (php/* proj sin-a))
+              in?   (and (:alive e)
+                         (php/> proj 0.0)
+                         (php/< proj cap)
+                         (php/<= (php/+ (php/* perpx perpx) (php/* perpy perpy)) hr2))]
+          (if (not in?)
+            (recur (php/+ i 1) (conj acc e) killed best-d hit-pos tough)
+            (let [eff     (if (resists? (:type e) damage-type) 0 damage)
+                  lives   (php/max 0 (php/- (or (:lives e) 1) eff))
+                  woke    (assoc e :state :aware :lives lives)
+                  closer? (php/< proj best-d)
+                  hp'     (if closer? {:x (:x e) :y (:y e)} hit-pos)
+                  bd'     (if closer? proj best-d)]
+              (if (php/<= lives 0)
+                (recur (php/+ i 1)
+                       (conj acc (assoc woke
+                                        :alive false
+                                        :respawn-after (respawn-delay-for e)))
+                       (php/+ killed 1) bd' hp'
+                       (php/max tough (or (:max-lives e) 1)))
+                (recur (php/+ i 1)
+                       (conj acc (assoc woke :hit-flash-secs hit-flash-seconds))
+                       killed bd' hp' tough)))))))))
+
 (defn push-back-enemy
   "Shove the enemy at `idx` along `(cos-a, sin-a)` by `dist` world
    units; on wall collision try a half then a quarter step before

--- a/src/core/weapons.phel
+++ b/src/core/weapons.phel
@@ -39,12 +39,14 @@
               :damage-type     :ballistic
               :auto-fire?      true
               :fire-sfx        :shoot
-              ;; Pistol is the only overheating weapon. Trade-off
-              ;; for its 0.12s cd + auto-fire: hold space too long
-              ;; and the slide jams for jam-seconds. Chaingun has
-              ;; its own constraint (mag burns at 20/s), shotgun
-              ;; has its 0.6s cd, so neither needs overheat.
-              :overheats?      true
+              ;; Pistol identity (#124): the round PIERCES, hitting every
+              ;; enemy in the line instead of stopping at the nearest.
+              ;; That is the pistol's edge over the strictly-higher-DPS
+              ;; chaingun (lined-up enemies in a corridor take one hit
+              ;; each). Overheat was removed: jamming the forced fallback
+              ;; weapon is anti-fun, and the chaingun's mag burn / the
+              ;; shotgun's slow cd are brake enough for the others.
+              :pierce?         true
               :palette         {:muzzle    "\e[1;38;5;250m"
                                 :slide     "\e[1;38;5;233m"
                                 :slide-dim "\e[1;38;5;232m"

--- a/tests/core/combat-test.phel
+++ b/tests/core/combat-test.phel
@@ -108,21 +108,19 @@
 ;; apply-heat: one shot's worth of state change.
 ;; ---------------------------------------------------------------------
 
-(deftest test-apply-heat-bumps-and-cools-cooldown
+(deftest test-apply-heat-arms-cooldown
+  ;; Default weapon is the pistol; each shot arms the fire-cooldown.
   (let [w (apply-heat {:heat 0.0 :jam-secs 0.0})]
-    ;; Some non-zero cooldown is armed.
-    (is (> (:fire-cooldown w) 0.0))
-    ;; Heat increased.
-    (is (> (:heat w) 0.0))
-    ;; Not yet jammed.
-    (is (= 0.0 (:jam-secs w)))))
+    (is (> (:fire-cooldown w) 0.0))))
 
-(deftest test-apply-heat-overheats-into-jam
-  ;; Push heat near 1.0 then fire once more; should trigger jam.
+(deftest test-pistol-no-longer-overheats
+  ;; #124 dropped overheat from the pistol: jamming the forced fallback
+  ;; weapon is anti-fun. Even fed near-max heat the pistol stays cool and
+  ;; never jams (it now behaves like the chaingun/shotgun). The generic
+  ;; :overheats? machinery stays for any future weapon that opts in.
   (let [w (apply-heat {:heat 0.99 :jam-secs 0.0})]
-    (is (> (:jam-secs w) 0.0))
-    ;; Heat resets to 0 so the player isn't punished twice.
-    (is (= 0.0 (:heat w)))))
+    (is (= 0.0 (:heat w)) "pistol never accumulates heat")
+    (is (= 0.0 (:jam-secs w)) "pistol never jams")))
 
 (deftest test-apply-heat-burns-one-round
   ;; Each fired shot drops the mag count by one (issue #5 phase 1).
@@ -149,13 +147,6 @@
     (is (= 0.0 (:heat w)))
     (is (= 0.0 (:jam-secs w)))
     (is (= 3   (:mag w)))))
-
-(deftest test-apply-heat-pistol-still-jams
-  ;; Pistol is the only weapon that overheats. Pushed to ~1.0 the
-  ;; jam timer arms and heat resets.
-  (let [w (apply-heat {:weapon :pistol :heat 0.99 :jam-secs 0.0 :mag 10})]
-    (is (php/> (:jam-secs w) 0.0))
-    (is (= 0.0 (:heat w)))))
 
 ;; ---------------------------------------------------------------------
 ;; reload: tops the mag back up, arms a brief cooldown.

--- a/tests/core/enemy-test.phel
+++ b/tests/core/enemy-test.phel
@@ -1,6 +1,6 @@
 (ns phel-doom-tests.core.enemy-test
   (:require phel.test :refer [deftest is])
-  (:require phel-doom.core.enemy :refer [default-wander-fraction new-enemy promote-wanderers push-back-enemy spawn-enemies spawn-enemies-mixed shoot splash beam-impact advance tick-scare rear-attacker? type-speed-mul]))
+  (:require phel-doom.core.enemy :refer [default-wander-fraction new-enemy promote-wanderers push-back-enemy spawn-enemies spawn-enemies-mixed shoot pierce splash beam-impact advance tick-scare rear-attacker? type-speed-mul]))
 
 (def open-grid
   "Bordered 10x10 open arena, no interior walls."
@@ -661,3 +661,53 @@
   ;; No enemy along the ray -> impact at the wall distance (capped).
   (let [[ix _] (beam-impact [] 1.0 5.0 0.0 6.0 0.5 12.0)]
     (is (< (php/abs (php/- ix 7.0)) 0.001) "impact at player + wall-dist")))
+
+;; ---------------------------------------------------------------------
+;; pierce (#124): the pistol round hits EVERY enemy in the line, not just
+;; the nearest like `shoot`. This is the pistol's identity vs the chaingun.
+;; ---------------------------------------------------------------------
+
+(deftest test-pierce-hits-all-enemies-in-line
+  ;; Player at (1.5,1.5) facing +x. Two 1-HP enemies lined up east at
+  ;; x=3.5 and x=5.5. One pierce shot kills BOTH.
+  (let [[es' killed hit-pos]
+        (pierce [(new-enemy 3.5 1.5) (new-enemy 5.5 1.5)]
+                1.5 1.5 0.0 12.0 0.5 12.0 1 :ballistic)]
+    (is (= 2 killed) "both lined-up enemies die to one piercing shot")
+    (is (= false (:alive (get es' 0))))
+    (is (= false (:alive (get es' 1))))
+    ;; Blood/sfx land on the NEAREST struck enemy.
+    (is (= 3.5 (:x hit-pos)))))
+
+(deftest test-pierce-contrasts-shoot-which-hits-only-nearest
+  ;; Same setup: `shoot` damages only the nearest; the far one is untouched.
+  (let [[es' _ _ idx]
+        (shoot [(new-enemy 3.5 1.5) (new-enemy 5.5 1.5)]
+               1.5 1.5 0.0 12.0 0.5 12.0 1 :ballistic)]
+    (is (= 0 idx) "shoot picks the nearest enemy")
+    (is (= false (:alive (get es' 0))) "nearest dies")
+    (is (= true (:alive (get es' 1))) "far enemy survives a non-piercing shot")))
+
+(deftest test-pierce-wounds-multi-life-enemies-in-line
+  ;; Two 2-HP enemies in line: one pierce wounds both to 1 HP, no kills.
+  (let [[es' killed _]
+        (pierce [(new-enemy 3.5 1.5 2) (new-enemy 5.5 1.5 2)]
+                1.5 1.5 0.0 12.0 0.5 12.0 1 :ballistic)]
+    (is (= 0 killed))
+    (is (= 1 (:lives (get es' 0))))
+    (is (= 1 (:lives (get es' 1))))))
+
+(deftest test-pierce-skips-off-line-enemy
+  ;; An enemy well off the ray (north) is not struck.
+  (let [[es' killed _]
+        (pierce [(new-enemy 3.5 1.5) (new-enemy 3.5 5.5)]
+                1.5 1.5 0.0 12.0 0.5 12.0 1 :ballistic)]
+    (is (= 1 killed) "only the in-line enemy is hit")
+    (is (= false (:alive (get es' 0))))
+    (is (= true (:alive (get es' 1))))))
+
+(deftest test-pierce-clean-miss-returns-nil-hit-pos
+  (let [[_ killed hit-pos]
+        (pierce [(new-enemy 3.5 5.5)] 1.5 1.5 0.0 12.0 0.5 12.0 1 :ballistic)]
+    (is (= 0 killed))
+    (is (= nil hit-pos))))

--- a/tests/core/weapons-test.phel
+++ b/tests/core/weapons-test.phel
@@ -263,3 +263,13 @@
     (is (= :plasma (:damage-type b)) "plasma bypasses fire-resist mobs")
     (is (= :shoot-bfg (:fire-sfx b)))
     (is (= false (:auto-fire? b)) "single-action heavy shot")))
+
+(deftest test-pistol-pierces-and-does-not-overheat
+  ;; #124: pistol identity is pierce (hits the whole line), not overheat.
+  (let [pistol (get weapons :pistol)]
+    (is (= true (:pierce? pistol)) "pistol round pierces")
+    (is (nil? (:overheats? pistol)) "pistol no longer overheats")))
+
+(deftest test-chaingun-is-single-target-no-pierce
+  ;; The chaingun keeps its single-target high-DPS niche: no pierce.
+  (is (nil? (:pierce? (get weapons :chaingun)))))


### PR DESCRIPTION
Closes #124

## Problem

Pistol and chaingun were both `:damage 1` `:ballistic`. The chaingun is 2.4x faster with a bigger mag, so the pistol was **strictly dominated** the moment the chaingun had ammo. The only brake was overheat on the pistol - and jamming the weapon the player is forced onto when out of ammo is anti-fun.

## Solution

**Pistol pierces.** Its round damages *every* enemy along the ray, not just the nearest. Lined-up enemies in a corridor take one hit each - a clear niche the chaingun (single-target, but 20 vs 8 DPS) can't fill. Neither weapon dominates: the chaingun still shreds single targets far faster.

- New `pierce` in `enemy.phel`, modelled on `splash`: returns `[enemies killed hit-pos kill-toughness]`. Hit-stop is sized by the toughest kill (so piercing a row of trash doesn't freeze, but finishing a tough mob still does).
- New `pierce-fire` in `combat.phel`, modelled on `bfg-fire` (aggregate kills/streak, blood + sfx on the nearest target, no per-enemy loot).
- `fire-shot` routes `:pierce?` weapons to it (alongside the existing `:splash-radius` -> `bfg-fire` branch).

**Overheat dropped** from the pistol. The generic `:overheats?` / heat / jam machinery stays in place (data-driven, dormant) for any future weapon; no weapon overheats now.

## Tests

- `enemy-test`: pierce hits all in line, contrasts `shoot` (nearest only), wounds multi-life, skips off-line, clean-miss nil hit-pos.
- `combat-test`: pistol no longer overheats/jams.
- `weapons-test`: pistol `:pierce?` true + no `:overheats?`; chaingun no pierce.
- Full `composer ci` green (1662 tests).

docs/combat.md: new Pistol spec section + overheat decision documented (acceptance).