### PR TITLE
feat(combat): shotgun fires a multi-target graze cone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 
 ### Changed
 
+- Shotgun is now a multi-target graze (#125): the nearest enemy in a cone takes the full damage and up to two others in the cone are grazed for reduced damage, turning the slow-cadence shotgun into a crowd weapon instead of a single big hit.
 - Pistol identity vs chaingun (#124): the pistol round now **pierces**, hitting every enemy in the line instead of stopping at the nearest. That is its edge over the strictly-higher-DPS chaingun (lined-up enemies take one hit each). Overheat was dropped from the pistol - jamming the forced fallback weapon is anti-fun; the generic `:overheats?` mechanic stays dormant for future weapons.
 - `press R to RELOAD` reminder is now weapon-aware (#128): it arms on the remaining-mag fraction instead of an absolute count, and is suppressed for single-round mags (the BFG no longer nags on its 1/1 magazine).
 - Plainer, deeper wall shading: flat shaded stone (no brick speckle), gamma distance falloff for brighter mids, stronger corner contrast.

--- a/docs/combat.md
+++ b/docs/combat.md
@@ -63,7 +63,7 @@ On miss: weapon report only.
 
 Killed enemy stays in vector with `:respawn-after` timer. See [monsters.md](monsters.md).
 
-Weapons flagged `:pierce?` (the pistol) take a different path: `pierce` (in `enemy.phel`) damages **every** enemy in the line instead of only the nearest, and `pierce-fire` aggregates the kills like the BFG splash path (blood + sfx on the nearest target, hit-stop sized by the meatiest kill, no per-enemy loot).
+Weapons flagged `:pierce?` (the pistol) or `:spread?` (the shotgun) take a different path: `pierce` (in `enemy.phel`) damages **every** enemy in the line, while `spread-shoot` damages a primary plus grazed neighbours in a cone. Both aggregate kills through the shared `finish-multikill` tail (blood + sfx on the nearest target, hit-stop sized by the meatiest kill, no per-enemy loot).
 
 ### Blood splatter
 
@@ -103,6 +103,10 @@ While `:hit-stop-secs > 0`, `play/tick-world` skips entire gameplay step (physic
 The pistol's identity (issue #124) is the `:pierce?` flag: its round passes through and damages every enemy along the ray, not just the nearest. That is its edge over the strictly-higher-DPS chaingun (20 vs 8 DPS) - a row of lined-up enemies in a corridor takes one hit each, where the chaingun would have to chew through them one at a time. The chaingun keeps the single-target sustained-spray niche; neither dominates.
 
 **Overheat dropped.** The pistol used to be the only `:overheats?` weapon (jam at heat 1.0). Jamming the weapon the player is *forced* onto when out of ammo is anti-fun, so overheat was removed from the pistol. The chaingun's mag burn and the shotgun's slow cadence are brake enough for those, so no weapon overheats now. The generic `:overheats?` / heat / jam machinery stays in place (data-driven, dormant) for any future weapon that opts in; `heat-per-shot` and `jam-seconds` are unused until then.
+
+### Shotgun (spread, slot 2)
+
+The shotgun's `:spread?` flag makes it a multi-target graze (issue #125). Instead of one big single-target hit, the nearest enemy inside a cone (`:spread-half-angle`, default `shotgun-spread-half-angle` ~17 degrees) takes the full `:damage` (3); up to `:spread-targets - 1` other enemies in the cone are grazed for the smaller `:graze-damage` (1). `spread-shoot` (in `enemy.phel`) finds the primary, then grazes others in index order up to the cap; `spread-fire` routes the result through the shared `finish-multikill` tail (blood + sfx on the primary, hit-stop sized by the meatiest kill, no per-enemy loot). This turns the slow-cadence shotgun into a crowd weapon distinct from the chaingun's single-target spray.
 
 ### Chainsaw (melee, slot 4)
 

--- a/src/core/combat.phel
+++ b/src/core/combat.phel
@@ -1,7 +1,7 @@
 (ns phel-doom.core.combat
   (:require phel-doom.core.rng :as rng)
   (:require phel-doom.core.engine   :refer [cast-ray])
-  (:require phel-doom.core.enemy    :refer [push-back-enemy shoot beam-impact splash pierce])
+  (:require phel-doom.core.enemy    :refer [push-back-enemy shoot beam-impact splash pierce spread-shoot])
   (:require phel-doom.core.enemy-ai :refer [attacks? noise-wake])
   (:require phel-doom.core.physics  :refer [try-move])
   (:require phel-doom.core.state    :refer [max-lives])
@@ -49,6 +49,12 @@
 (def shot-max-range
   "Maximum hitscan range in world units."
   12.0)
+
+(def shotgun-spread-half-angle
+  "Default half-angle (radians, ~17°) of the shotgun cone when a weapon
+   spec omits `:spread-half-angle`. Enemies within this angle of facing
+   can be grazed by a spread shot (#125)."
+  0.30)
 
 (def touch-damage-dist
   "If an alive enemy is closer than this in world units, the player
@@ -748,13 +754,51 @@
      (apply-heat (push-blood-fx (assoc juiced :fire-anim fire-anim-seconds) hit-pos))
      world killed? hit-pos)))
 
+(defn- finish-multikill
+  "Shared tail for the multi-target hitscans (`pierce-fire`,
+   `spread-fire`): given the enemies after damage was applied, the kill
+   count, the nearest hit-pos (or nil), and the toughest kill's HP,
+   aggregate kills + streak like `bfg-fire`, unlock the boss door if a
+   cyber died, size hit-stop per the meatiest kill, splat blood on the
+   primary, drain the mag, and queue sfx. No per-enemy loot (mirrors the
+   splash path)."
+  [world enemies-after killed hit-pos tough]
+  (let [p            (:player world)
+        woken        (noise-wake enemies-after (:grid world) (:x p) (:y p))
+        hit?         (not (nil? hit-pos))
+        killed?      (php/> killed 0)
+        chain?       (pos? (or (:streak-secs world) 0.0))
+        boss-killed? (and (= (:door-lock world) :boss)
+                          (some (fn [e] (and (= (:type e) :cyber)
+                                             (false? (:alive e))))
+                                woken))
+        scored       (assoc world
+                            :enemies     woken
+                            :kills       (php/+ (or (:kills world) 0) killed)
+                            :streak      (if killed?
+                                           (php/+ (if chain? (or (:streak world) 0) 0) killed)
+                                           (or (:streak world) 0))
+                            :streak-secs (if killed? streak-window-seconds
+                                             (or (:streak-secs world) 0.0)))
+        unlocked     (if boss-killed?
+                       (assoc scored :held-keys (conj (or (:held-keys scored) #{}) :boss))
+                       scored)
+        juiced       (if killed?
+                       (let [hs (hit-stop-for tough)]
+                         (if (php/> hs 0.0)
+                           (assoc unlocked :hit-stop-secs hs)
+                           unlocked))
+                       unlocked)
+        based        (assoc juiced :fire-anim fire-anim-seconds)]
+    (enqueue-shot-sfx
+     (apply-heat (if hit? (push-blood-fx based hit-pos) based))
+     world killed? (or hit-pos {:x (:x p) :y (:y p)}))))
+
 (defn- pierce-fire
   "Resolve a piercing shot (weapons flagged `:pierce?`, the pistol). The
    round damages every enemy in the line instead of stopping at the
    nearest, so a row of lined-up enemies takes one hit each — the
-   pistol's niche over the higher-DPS chaingun. Aggregates kills/streak
-   like `bfg-fire`; blood + sfx land on the nearest target. No per-enemy
-   loot (mirrors the splash path)."
+   pistol's niche over the higher-DPS chaingun."
   [world]
   (let [p                          (:player world)
         spec                       (w-spec world)
@@ -764,49 +808,43 @@
         max-r                      (or (:max-range spec) shot-max-range)
         wall-d                     (cast-wall-distance world)
         [es' killed hit-pos tough] (pierce (:enemies world) (:x p) (:y p) (:angle p)
-                                           wall-d shot-hit-radius max-r dmg dtype)
-        woken                      (noise-wake es' (:grid world) (:x p) (:y p))
-        hit?                       (not (nil? hit-pos))
-        killed?                    (php/> killed 0)
-        chain?                     (pos? (or (:streak-secs world) 0.0))
-        boss-killed?               (and (= (:door-lock world) :boss)
-                                        (some (fn [e] (and (= (:type e) :cyber)
-                                                           (false? (:alive e))))
-                                              woken))
-        scored                     (assoc world
-                                          :enemies     woken
-                                          :kills       (php/+ (or (:kills world) 0) killed)
-                                          :streak      (if killed?
-                                                         (php/+ (if chain? (or (:streak world) 0) 0) killed)
-                                                         (or (:streak world) 0))
-                                          :streak-secs (if killed? streak-window-seconds
-                                                           (or (:streak-secs world) 0.0)))
-        unlocked                   (if boss-killed?
-                                     (assoc scored :held-keys (conj (or (:held-keys scored) #{}) :boss))
-                                     scored)
-        juiced                     (if killed?
-                                     (let [hs (hit-stop-for tough)]
-                                       (if (php/> hs 0.0)
-                                         (assoc unlocked :hit-stop-secs hs)
-                                         unlocked))
-                                     unlocked)
-        based                      (assoc juiced :fire-anim fire-anim-seconds)]
-    (enqueue-shot-sfx
-     (apply-heat (if hit? (push-blood-fx based hit-pos) based))
-     world killed? (or hit-pos {:x (:x p) :y (:y p)}))))
+                                           wall-d shot-hit-radius max-r dmg dtype)]
+    (finish-multikill world es' killed hit-pos tough)))
+
+(defn- spread-fire
+  "Resolve a spread shot (weapons flagged `:spread?`, the shotgun). The
+   nearest enemy in the cone takes full damage; up to `:spread-targets`-1
+   others in the cone are grazed for the smaller `:graze-damage` — a
+   multi-target crowd hit that justifies the slow cadence (#125)."
+  [world]
+  (let [p                          (:player world)
+        spec                       (w-spec world)
+        base                       (or (:damage spec) 1)
+        prim                       (if (berserk? world) (php/* base berserk-damage-mul) base)
+        graze-base                 (or (:graze-damage spec) 1)
+        graze                      (if (berserk? world) (php/* graze-base berserk-damage-mul) graze-base)
+        targets                    (or (:spread-targets spec) 3)
+        half                       (or (:spread-half-angle spec) shotgun-spread-half-angle)
+        dtype                      (:damage-type spec)
+        max-r                      (or (:max-range spec) shot-max-range)
+        wall-d                     (cast-wall-distance world)
+        [es' killed hit-pos tough] (spread-shoot (:enemies world) (:x p) (:y p) (:angle p)
+                                                 wall-d half max-r prim graze targets dtype)]
+    (finish-multikill world es' killed hit-pos tough)))
 
 (defn fire-shot
   "Resolve one trigger pull end-to-end. Weapons with `:splash-radius`
-   (BFG, rocket) route to `bfg-fire`; `:pierce?` weapons (pistol) route
-   to `pierce-fire`; everything else is a single-target hitscan. After
-   the shot, run a flood-fill sound-wake from the player's cell so
-   dormant enemies in the same room hear it and switch to :aware. Doors
-   block the BFS so the wake stays local — same per-sector noise rule
-   DOOM uses."
+   (BFG, rocket) route to `bfg-fire`; `:pierce?` weapons (pistol) to
+   `pierce-fire`; `:spread?` weapons (shotgun) to `spread-fire`;
+   everything else is a single-target hitscan. After the shot, run a
+   flood-fill sound-wake from the player's cell so dormant enemies in the
+   same room hear it and switch to :aware. Doors block the BFS so the
+   wake stays local — same per-sector noise rule DOOM uses."
   [world]
   (cond
     (:splash-radius (w-spec world)) (bfg-fire world)
     (:pierce? (w-spec world))       (pierce-fire world)
+    (:spread? (w-spec world))       (spread-fire world)
     :else
     (let [[enemies' hit? hit-pos idx] (resolve-shot world)
           p                           (:player world)

--- a/src/core/enemy.phel
+++ b/src/core/enemy.phel
@@ -306,6 +306,76 @@
                        (conj acc (assoc woke :hit-flash-secs hit-flash-seconds))
                        killed bd' hp' tough)))))))))
 
+(defn- in-cone?
+  "True when the enemy offset `(dx, dy)` lies in front of the player
+   within `half-angle` of facing `(cos-a, sin-a)` and nearer than `cap`.
+   Uses the projection / distance ratio as cos(angle-to-target)."
+  [^float dx ^float dy ^float cos-a ^float sin-a ^float cos-half ^float cap]
+  (let [proj (php/+ (php/* dx cos-a) (php/* dy sin-a))
+        dist (php/sqrt (php/+ (php/* dx dx) (php/* dy dy)))]
+    (and (php/> proj 0.0)
+         (php/< proj cap)
+         (php/> dist 0.0)
+         (php/>= (php// proj dist) cos-half))))
+
+(defn spread-shoot
+  "Shotgun cone (#125): a multi-target graze. The PRIMARY (nearest alive
+   enemy inside the `half-angle` cone in front of the player) takes the
+   full `primary-dmg`; up to `max-targets - 1` other enemies in the cone
+   are grazed for the smaller `graze-dmg`. Distinct from the single big
+   hit of `shoot` - the shotgun becomes a crowd weapon. Returns
+   `[new-enemies killed-count hit-pos kill-toughness]` like `pierce`,
+   where `hit-pos` is the primary target (blood + sfx)."
+  [enemies ^float px ^float py ^float angle ^float wall-dist ^float half-angle ^float max-range ^int primary-dmg ^int graze-dmg ^int max-targets damage-type]
+  (let [cos-a    (php/cos angle)
+        sin-a    (php/sin angle)
+        cos-half (php/cos half-angle)
+        cap      (php/min wall-dist max-range)
+        primary  (loop [i 0 best -1 best-d cap]
+                   (if (php/>= i (count enemies))
+                     best
+                     (let [e (get enemies i)]
+                       (if (not (:alive e))
+                         (recur (php/+ i 1) best best-d)
+                         (let [dx   (php/- (:x e) px)
+                               dy   (php/- (:y e) py)
+                               proj (php/+ (php/* dx cos-a) (php/* dy sin-a))]
+                           (if (and (php/< proj best-d)
+                                    (in-cone? dx dy cos-a sin-a cos-half cap))
+                             (recur (php/+ i 1) i proj)
+                             (recur (php/+ i 1) best best-d)))))))]
+    (if (php/< primary 0)
+      [enemies 0 nil 0]
+      (loop [i 0 acc [] killed 0 tough 0 grazed 0 hit-pos nil]
+        (if (php/>= i (count enemies))
+          [acc killed hit-pos tough]
+          (let [e (get enemies i)]
+            (if (not (:alive e))
+              (recur (php/+ i 1) (conj acc e) killed tough grazed hit-pos)
+              (let [dx       (php/- (:x e) px)
+                    dy       (php/- (:y e) py)
+                    primary? (php/=== i primary)
+                    graze?   (and (not primary?)
+                                  (php/< grazed (php/- max-targets 1))
+                                  (in-cone? dx dy cos-a sin-a cos-half cap))
+                    dmg      (cond primary? primary-dmg graze? graze-dmg :else 0)]
+                (if (php/<= dmg 0)
+                  (recur (php/+ i 1) (conj acc e) killed tough grazed hit-pos)
+                  (let [eff     (if (resists? (:type e) damage-type) 0 dmg)
+                        lives   (php/max 0 (php/- (or (:lives e) 1) eff))
+                        woke    (assoc e :state :aware :lives lives)
+                        hp'     (if primary? {:x (:x e) :y (:y e)} hit-pos)
+                        grazed' (if graze? (php/+ grazed 1) grazed)]
+                    (if (php/<= lives 0)
+                      (recur (php/+ i 1)
+                             (conj acc (assoc woke
+                                              :alive false
+                                              :respawn-after (respawn-delay-for e)))
+                             (php/+ killed 1) (php/max tough (or (:max-lives e) 1)) grazed' hp')
+                      (recur (php/+ i 1)
+                             (conj acc (assoc woke :hit-flash-secs hit-flash-seconds))
+                             killed tough grazed' hp'))))))))))))
+
 (defn push-back-enemy
   "Shove the enemy at `idx` along `(cos-a, sin-a)` by `dist` world
    units; on wall collision try a half then a quarter step before

--- a/src/core/weapons.phel
+++ b/src/core/weapons.phel
@@ -63,6 +63,15 @@
               :damage          3
               :damage-type     :ballistic
               :fire-sfx        :shoot-shotgun
+              ;; Spread / multi-target graze (#125): the primary target
+              ;; takes the full :damage; up to (:spread-targets - 1) other
+              ;; enemies inside the cone are grazed for :graze-damage. Turns
+              ;; the slow-cadence shotgun into a crowd weapon instead of a
+              ;; one-big-hit single scan. Half-angle defaults to
+              ;; combat/shotgun-spread-half-angle when omitted.
+              :spread?         true
+              :graze-damage    1
+              :spread-targets  3
               ;; Shotgun is single-action: each space press = one
               ;; shell. Holding the trigger does NOT auto-fire — the
               ;; player has to re-pull for every shot. Matches DOOM2's

--- a/tests/core/enemy-test.phel
+++ b/tests/core/enemy-test.phel
@@ -1,6 +1,6 @@
 (ns phel-doom-tests.core.enemy-test
   (:require phel.test :refer [deftest is])
-  (:require phel-doom.core.enemy :refer [default-wander-fraction new-enemy promote-wanderers push-back-enemy spawn-enemies spawn-enemies-mixed shoot pierce splash beam-impact advance tick-scare rear-attacker? type-speed-mul]))
+  (:require phel-doom.core.enemy :refer [default-wander-fraction new-enemy promote-wanderers push-back-enemy spawn-enemies spawn-enemies-mixed shoot pierce spread-shoot splash beam-impact advance tick-scare rear-attacker? type-speed-mul]))
 
 (def open-grid
   "Bordered 10x10 open arena, no interior walls."
@@ -711,3 +711,47 @@
         (pierce [(new-enemy 3.5 5.5)] 1.5 1.5 0.0 12.0 0.5 12.0 1 :ballistic)]
     (is (= 0 killed))
     (is (= nil hit-pos))))
+
+;; ---------------------------------------------------------------------
+;; spread-shoot (#125): shotgun cone. Nearest enemy in the cone takes the
+;; full primary damage; up to (max-targets - 1) others graze for less.
+;; Player at (1.5,1.5) facing +x; half-angle 0.30 rad (~17deg).
+;; ---------------------------------------------------------------------
+
+(deftest test-spread-primary-full-graze-reduced
+  ;; idx0 dead ahead (primary, full 3 -> kills 3HP); idx1 slightly off but
+  ;; in-cone (graze 1 -> 3HP drops to 2); idx2 far off-cone (untouched).
+  (let [[es' killed hit-pos _]
+        (spread-shoot [(new-enemy 4.5 1.5 3) (new-enemy 4.5 2.2 3) (new-enemy 4.5 4.0 3)]
+                      1.5 1.5 0.0 12.0 0.30 12.0 3 1 3 :ballistic)]
+    (is (= 1 killed) "only the primary dies; grazes just chip")
+    (is (= false (:alive (get es' 0))) "primary killed by full damage")
+    (is (= 2 (:lives (get es' 1))) "in-cone neighbour grazed for 1")
+    (is (= 3 (:lives (get es' 2))) "off-cone enemy untouched")
+    (is (= 4.5 (:x hit-pos)))
+    (is (= 1.5 (:y hit-pos)) "blood/sfx land on the primary")))
+
+(deftest test-spread-caps-at-max-targets
+  ;; Four enemies in the cone, max-targets 3 -> primary + 2 grazes; the
+  ;; 4th in-cone enemy takes nothing.
+  (let [[es' killed _ _]
+        (spread-shoot [(new-enemy 4.5 1.5 3) (new-enemy 4.5 1.9 3)
+                       (new-enemy 4.5 1.2 3) (new-enemy 4.5 1.7 3)]
+                      1.5 1.5 0.0 12.0 0.30 12.0 3 1 3 :ballistic)]
+    (is (= 1 killed))
+    ;; Exactly two of the three neighbours were grazed (lives 2); one was
+    ;; left at full (lives 3) because the target cap was reached.
+    (let [neighbours [(get es' 1) (get es' 2) (get es' 3)]
+          grazed     (count (filter (fn [e] (= 2 (:lives e))) neighbours))
+          untouched  (count (filter (fn [e] (= 3 (:lives e))) neighbours))]
+      (is (= 2 grazed) "max-targets-1 = 2 grazes applied")
+      (is (= 1 untouched) "the extra in-cone enemy is spared by the cap"))))
+
+(deftest test-spread-clean-miss-returns-nil
+  ;; Only an off-cone enemy present -> no primary, nothing hit.
+  (let [[es' killed hit-pos _]
+        (spread-shoot [(new-enemy 4.5 4.0 3)]
+                      1.5 1.5 0.0 12.0 0.30 12.0 3 1 3 :ballistic)]
+    (is (= 0 killed))
+    (is (= nil hit-pos))
+    (is (= 3 (:lives (get es' 0))) "off-cone enemy untouched")))

--- a/tests/core/weapons-test.phel
+++ b/tests/core/weapons-test.phel
@@ -273,3 +273,11 @@
 (deftest test-chaingun-is-single-target-no-pierce
   ;; The chaingun keeps its single-target high-DPS niche: no pierce.
   (is (nil? (:pierce? (get weapons :chaingun)))))
+
+(deftest test-shotgun-has-spread-graze
+  ;; #125: shotgun is a multi-target graze cone.
+  (let [sg (get weapons :shotgun)]
+    (is (= true (:spread? sg)) "shotgun spreads")
+    (is (= 1 (:graze-damage sg)) "grazes for reduced damage")
+    (is (php/>= (:spread-targets sg) 2) "hits 2+ targets")
+    (is (php/< (:graze-damage sg) (:damage sg)) "graze < primary damage")))


### PR DESCRIPTION
Closes #125

## Problem

The shotgun was a single hitscan (`:damage 3`) with the **lowest** sustained DPS in the game (5, below the pistol's 8). Its only edge was one-shotting <=3HP enemies; vs 4-5HP tanks it needed two shots while the chaingun shredded them, so it felt weak.

## Solution

The shotgun now fires a **cone**: the nearest enemy in the cone takes the full `:damage` (3), and up to `:spread-targets - 1` (= 2) other enemies in the cone are grazed for the smaller `:graze-damage` (1). A real crowd weapon, distinct from the chaingun's single-target spray, justifying its slow cadence.

- `spread-shoot` (`enemy.phel`): finds the primary (nearest in the `:spread-half-angle` cone), then grazes others up to the cap. Returns `[enemies killed hit-pos kill-toughness]`.
- Extracted a shared `finish-multikill` tail from `pierce-fire` (aggregate kills/streak/boss-unlock/hit-stop/blood); `spread-fire` reuses it - no duplication.
- `fire-shot` routes `:spread?` weapons to `spread-fire`.
- Shotgun spec: `:spread?` / `:graze-damage 1` / `:spread-targets 3`.

## Tests

`enemy-test`: primary full + neighbour grazed + off-cone skipped; graze count capped at `max-targets - 1`; clean miss returns nil. `weapons-test`: shotgun spread config. Full `composer ci` green (1678 tests).

docs/combat.md: new Shotgun spec section.