### PR TITLE
feat(combat): make berserk melee-biased with a full heal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 
 ### Changed
 
+- Berserk is now melee-biased with a full heal (#127), matching DOOM. Pickup restores health to full, and the rage window boosts melee (the chainsaw) far more than guns (`x6` vs `x2`) instead of a flat all-weapon multiplier - the classic "go punch everything" identity.
 - Shotgun is now a multi-target graze (#125): the nearest enemy in a cone takes the full damage and up to two others in the cone are grazed for reduced damage, turning the slow-cadence shotgun into a crowd weapon instead of a single big hit.
 - Pistol identity vs chaingun (#124): the pistol round now **pierces**, hitting every enemy in the line instead of stopping at the nearest. That is its edge over the strictly-higher-DPS chaingun (lined-up enemies take one hit each). Overheat was dropped from the pistol - jamming the forced fallback weapon is anti-fun; the generic `:overheats?` mechanic stays dormant for future weapons.
 - `press R to RELOAD` reminder is now weapon-aware (#128): it arms on the remaining-mag fraction instead of an absolute count, and is suppressed for single-round mags (the BFG no longer nags on its 1/1 magazine).

--- a/docs/combat.md
+++ b/docs/combat.md
@@ -147,11 +147,11 @@ High-burst tank-killer (issue #126): DOOM II's SSG. Reuses the shotgun `:spread?
 
 ## Berserk pickup
 
-Berserk sphere (`Ω` glyph, 1-in-8 levels):
+Berserk sphere (`Ω` glyph, 1-in-8 levels). Melee-biased, DOOM-style (issue #127): it is a "go punch everything" surge plus a full heal, not a flat all-weapon buff.
 
 1. `pickup-berserks` removes sphere, plays `:berserk` sfx, calls `arm-berserk`.
-2. `arm-berserk` stamps `:berserk-secs` to 20s (refresh, not stack).
-3. `decay-timers` ticks down; `fire-shot` multiplies weapon damage by 2 while active.
+2. `arm-berserk` stamps `:berserk-secs` to 20s (refresh, not stack) AND full-heals the player to `max-lives` (never lowering an over-cap soulsphere count).
+3. `decay-timers` ticks down. While active, `berserk-mul-for` scales weapon damage by `damage-type`: `:melee` (the chainsaw) gets the big `berserk-melee-mul` (6), every ranged type gets the modest `berserk-damage-mul` (2). So berserk turns the chainsaw into a tank shredder while only mildly buffing guns.
 4. Render paints red pulsing border (suppressed by i-frames, which take priority).
 
 ## Damage resistance

--- a/docs/gameplay.md
+++ b/docs/gameplay.md
@@ -38,7 +38,7 @@ Terminal quirks (kitty, tmux): [input.md](input.md).
 - **armor shard**: `+1` armor over 5, up to 10
 - **soulsphere**: `+1` life over cap, decays back
 - **ammo box**: `+N` to weapon reserve
-- **berserk**: 20s of `x2` damage
+- **berserk**: full heal + 20s melee surge (chainsaw `x6`, guns `x2`)
 - **invuln**: 10s immunity
 - **backpack**: increases reserve cap
 - **keycard**: unlocks L4 (blue) / L5 (red) exits; L10 is boss-locked

--- a/src/core/combat.phel
+++ b/src/core/combat.phel
@@ -172,16 +172,36 @@
   20.0)
 
 (def berserk-damage-mul
-  "Damage multiplier applied to every shot while berserk-secs > 0."
+  "Berserk damage multiplier for RANGED weapons (the default). Berserk is
+   melee-biased (#127): ranged guns get this modest boost, melee gets the
+   much larger `berserk-melee-mul`."
   2)
 
+(def berserk-melee-mul
+  "Berserk damage multiplier for `:melee` weapons (the chainsaw). Far
+   bigger than the ranged boost so berserk's identity is the DOOM 'go
+   punch everything' melee surge, not a flat all-weapon buff (#127). At
+   chainsaw damage 1 this is 6 per hit on a 0.10s cadence = a tank
+   shredder for the rage window."
+  6)
+
+(defn berserk-mul-for
+  "Berserk damage multiplier for `damage-type`: the big melee boost for
+   `:melee`, the modest ranged boost otherwise (#127)."
+  [damage-type]
+  (if (= damage-type :melee) berserk-melee-mul berserk-damage-mul))
+
 (defn arm-berserk
-  "Pure helper: stamp the full `berserk-seconds` rage window on the
-   world, replacing the current timer (a refresh, not a stack). Used
-   by `pickup-berserks` after the pickup is consumed; isolated here so
-   the timer logic can be unit-tested without the IO sfx call."
+  "Pure helper: stamp the full `berserk-seconds` rage window on the world
+   (a refresh, not a stack) AND full-heal the player to `max-lives` - the
+   DOOM berserk pack restores health on pickup (#127). Never lowers an
+   over-cap life count (e.g. from a soulsphere). Used by `pickup-berserks`
+   after the pickup is consumed; isolated here so the timer + heal logic
+   can be unit-tested without the IO sfx call."
   [world]
-  (assoc world :berserk-secs berserk-seconds))
+  (assoc world
+         :berserk-secs berserk-seconds
+         :lives (php/max (or (:lives world) 0) max-lives)))
 
 (defn berserk?
   "True while the player's berserk timer is still ticking down."
@@ -454,8 +474,8 @@
   (let [p         (:player world)
         spec      (w-spec world)
         base-dmg  (or (:damage spec) 1)
-        dmg       (if (berserk? world) (php/* base-dmg berserk-damage-mul) base-dmg)
         dmg-type  (:damage-type spec)
+        dmg       (if (berserk? world) (php/* base-dmg (berserk-mul-for dmg-type)) base-dmg)
         max-range (or (:max-range spec) shot-max-range)]
     (shoot (:enemies world) (:x p) (:y p) (:angle p)
            (cast-wall-distance world)
@@ -720,8 +740,8 @@
         spec         (w-spec world)
         radius       (:splash-radius spec)
         base         (or (:splash-damage spec) 1)
-        dmg          (if (berserk? world) (php/* base berserk-damage-mul) base)
         dtype        (:damage-type spec)
+        dmg          (if (berserk? world) (php/* base (berserk-mul-for dtype)) base)
         max-r        (or (:max-range spec) shot-max-range)
         wall-d       (cast-wall-distance world)
         [ix iy]      (beam-impact (:enemies world) (:x p) (:y p) (:angle p)
@@ -803,8 +823,8 @@
   (let [p                          (:player world)
         spec                       (w-spec world)
         base                       (or (:damage spec) 1)
-        dmg                        (if (berserk? world) (php/* base berserk-damage-mul) base)
         dtype                      (:damage-type spec)
+        dmg                        (if (berserk? world) (php/* base (berserk-mul-for dtype)) base)
         max-r                      (or (:max-range spec) shot-max-range)
         wall-d                     (cast-wall-distance world)
         [es' killed hit-pos tough] (pierce (:enemies world) (:x p) (:y p) (:angle p)
@@ -820,12 +840,13 @@
   (let [p                          (:player world)
         spec                       (w-spec world)
         base                       (or (:damage spec) 1)
-        prim                       (if (berserk? world) (php/* base berserk-damage-mul) base)
+        dtype                      (:damage-type spec)
+        mul                        (if (berserk? world) (berserk-mul-for dtype) 1)
+        prim                       (php/* base mul)
         graze-base                 (or (:graze-damage spec) 1)
-        graze                      (if (berserk? world) (php/* graze-base berserk-damage-mul) graze-base)
+        graze                      (php/* graze-base mul)
         targets                    (or (:spread-targets spec) 3)
         half                       (or (:spread-half-angle spec) shotgun-spread-half-angle)
-        dtype                      (:damage-type spec)
         max-r                      (or (:max-range spec) shot-max-range)
         wall-d                     (cast-wall-distance world)
         [es' killed hit-pos tough] (spread-shoot (:enemies world) (:x p) (:y p) (:angle p)

--- a/tests/core/combat-test.phel
+++ b/tests/core/combat-test.phel
@@ -1,8 +1,8 @@
 (ns phel-doom-tests.core.combat-test
   (:require phel.test :refer [deftest is])
-  (:require phel-doom.core.state :refer [new-world new-player])
+  (:require phel-doom.core.state :refer [new-world new-player max-lives])
   (:require phel-doom.core.combat
-            :refer [arm-berserk armory-reserve closest-attacker attacker-side berserk? berserk-damage-mul berserk-seconds can-fire? apply-heat damage-step empty-click-seconds enemy-hit-damage hit-damage-for hit-player-at hit-stop-for hit-stop-tough-seconds hit-stop-boss-seconds invuln? invuln-seconds knockback mag-size pick-loot-weapon reload reloading? roll-loot-kind tick-armory tick-shooting]))
+            :refer [arm-berserk armory-reserve closest-attacker attacker-side berserk? berserk-damage-mul berserk-melee-mul berserk-mul-for berserk-seconds can-fire? apply-heat damage-step empty-click-seconds enemy-hit-damage hit-damage-for hit-player-at hit-stop-for hit-stop-tough-seconds hit-stop-boss-seconds invuln? invuln-seconds knockback mag-size pick-loot-weapon reload reloading? roll-loot-kind tick-armory tick-shooting]))
 
 ;; ---------------------------------------------------------------------
 ;; closest-attacker: selection rule.
@@ -409,6 +409,38 @@
   ;; Acceptance criterion from issue #57: melee damage AT LEAST
   ;; doubles. Pin the constant so a future buff/nerf is intentional.
   (is (php/>= berserk-damage-mul 2)))
+
+;; ---------------------------------------------------------------------
+;; #127: berserk is melee-biased (the DOOM 'go punch everything' pack)
+;; plus a full heal on pickup, not a flat all-weapon multiplier.
+;; ---------------------------------------------------------------------
+
+(deftest test-berserk-mul-melee-beats-ranged
+  ;; Melee gets a much bigger boost than ranged - the identity shift.
+  (is (php/> (berserk-mul-for :melee) (berserk-mul-for :ballistic))
+      "melee berserk boost exceeds ranged")
+  (is (= berserk-melee-mul (berserk-mul-for :melee)))
+  (is (= berserk-damage-mul (berserk-mul-for :ballistic)))
+  (is (= berserk-damage-mul (berserk-mul-for :plasma))
+      "non-melee types all use the ranged multiplier"))
+
+(deftest test-berserk-melee-mul-is-a-real-surge
+  ;; Chainsaw (damage 1) under berserk should hit for the big melee
+  ;; multiplier, turning it into a tank shredder.
+  (is (php/>= berserk-melee-mul 4) "melee surge is substantial")
+  (is (php/> berserk-melee-mul berserk-damage-mul)))
+
+(deftest test-arm-berserk-full-heals-to-max
+  ;; Pickup restores health to the cap (#127).
+  (let [w (arm-berserk {:lives 2})]
+    (is (= max-lives (:lives w)) "berserk pickup full-heals to max-lives")
+    (is (= berserk-seconds (:berserk-secs w)) "and arms the rage window")))
+
+(deftest test-arm-berserk-never-lowers-overcap-lives
+  ;; A soulsphere can push lives over the cap; the berserk heal must not
+  ;; claw that back.
+  (let [w (arm-berserk {:lives (php/+ max-lives 3)})]
+    (is (= (php/+ max-lives 3) (:lives w)))))
 
 ;; ---------------------------------------------------------------------
 ;; Chainsaw (issue #59): no-ammo, melee range, slow movement while firing.


### PR DESCRIPTION
Closes #127

## Problem

`berserk-damage-mul` was a **flat global** multiplier (x2 on every weapon). In DOOM the berserk pack is **melee-specific** (a massive fist boost) and grants a **full heal** - a distinct "go punch everything" identity, not a generic damage buff.

## Solution

- **Melee-biased multiplier.** New `berserk-mul-for damage-type`: `:melee` (the chainsaw) gets the big `berserk-melee-mul` (6); every ranged type keeps the modest `berserk-damage-mul` (2). Under berserk the chainsaw (damage 1, 0.10s cadence) hits for 6 = a tank shredder, while guns only mildly improve. All four fire paths (single hitscan, BFG, pierce, spread) route through it.
- **Full heal on pickup.** `arm-berserk` now restores `:lives` to `max-lives`, never lowering an over-cap soulsphere count.

## Tests

`combat-test`: melee multiplier exceeds ranged; `berserk-mul-for` values per type; full-heal to max; over-cap heal is a no-op. Full `composer ci` green (1697 tests).

docs/combat.md + gameplay.md updated.

## Acceptance

- [x] Berserk meaningfully changes melee playstyle, not just a flat number
- [x] Tests cover melee vs ranged under berserk
- [x] docs/combat.md notes the behaviour