### PR TITLE
feat(render): give each weapon its own sprite silhouette

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 
 ### Changed
 
+- Each weapon now has its own gun-sprite silhouette, not just a recolour: the chainsaw shows a toothed blade over an engine (no barrel), the BFG a bulky cannon with a glowing aperture, the incinerator a thin nozzle over a fat fuel tank, the rocket a straight round tube, and the super shotgun a stubby twin-bore. Previously every weapon past the chaingun reused the pistol shape.
 - Berserk is melee-biased with a full heal (#127): pickup restores full health, and the rage window boosts melee (chainsaw `x6`) far more than guns (`x2`) - the DOOM "go punch everything" identity, not a flat all-weapon multiplier.
 - Shotgun fires a cone graze (#125): the nearest enemy takes full damage and up to two others in the cone are grazed - a crowd weapon, not one big hit.
 - Pistol pierces (#124): its round hits every enemy in the line, its edge over the higher-DPS chaingun. Overheat dropped (jamming the forced fallback weapon is anti-fun).

--- a/src/io/render.phel
+++ b/src/io/render.phel
@@ -2251,11 +2251,14 @@
           frame     (:frame     palette)
           grip-hi   (:grip-hi   palette)
           grip-lo   (:grip-lo   palette)]
-      ;; Gradient indices are 0-based for vh rows; cursor positions
-      ;; are 1-based. Per-weapon silhouette dispatches on :weapon —
-      ;; pistol stays narrow + single barrel, shotgun widens with a
-      ;; double-barrel muzzle + heavy stock, chaingun adds a multi-
-      ;; barrel cluster + wider housing.
+      ;; Gradient indices are 0-based for vh rows; cursor positions are
+      ;; 1-based. Per-weapon SILHOUETTE dispatches on :weapon so each
+      ;; weapon reads by SHAPE, not just colour: the pistol is a narrow
+      ;; single barrel; the shotgun a wide double-barrel; the chaingun a
+      ;; spaced rotary cluster; the super shotgun a stubby twin-bore; the
+      ;; chainsaw a toothed blade over an engine (no barrel); the BFG a
+      ;; bulky cannon with a glowing aperture; the incinerator a thin
+      ;; nozzle over a fat fuel tank; the rocket a straight round tube.
       (let [weapon (or (get stats :weapon) :pistol)
             rows
             (cond
@@ -2278,6 +2281,65 @@
                (paint-row (php/- vh 1) (php/- cc 3) (php/- vh 2) frame
                           (str "▐█" grip-hi "▓▓▓▓▓▓▓▓" frame "█▌"))
                (paint-row vh           (php/- cc 2) (php/- vh 1) grip-lo "▐▓▓▓▓▓▓▓▓▌"))
+
+              ;; Super shotgun: stubby twin-bore. A gap in the muzzle +
+              ;; barrels reads as the sawn-off double barrel.
+              (php/=== weapon :super-shotgun)
+              (str
+               (paint-row (php/- vh 5) (php/- cc 2) (php/- vh 6) muzzle    "▄▄▄ ▄▄▄")
+               (paint-row (php/- vh 4) (php/- cc 2) (php/- vh 5) slide     "▐██ ██▌")
+               (paint-row (php/- vh 3) (php/- cc 3) (php/- vh 4) slide     "▐█████████▌")
+               (paint-row (php/- vh 2) (php/- cc 3) (php/- vh 3) slide-dim "▐█████████▌")
+               (paint-row (php/- vh 1) (php/- cc 3) (php/- vh 2) frame
+                          (str "▐█" grip-hi "▓▓▓▓▓▓▓" frame "█▌"))
+               (paint-row vh           (php/- cc 2) (php/- vh 1) grip-lo "▐▓▓▓▓▓▓▓▌"))
+
+              ;; Chainsaw: no barrel. Toothed blade up top, light chain
+              ;; bar, then the engine block + handle.
+              (php/=== weapon :chainsaw)
+              (str
+               (paint-row (php/- vh 5) (php/- cc 3) (php/- vh 6) muzzle    "◣◢◣◢◣◢◣")
+               (paint-row (php/- vh 4) (php/- cc 3) (php/- vh 5) slide-dim "▐░░░░░░░▌")
+               (paint-row (php/- vh 3) (php/- cc 2) (php/- vh 4) slide     "▐██████▌")
+               (paint-row (php/- vh 2) (php/- cc 3) (php/- vh 3) slide     "▐████████▌")
+               (paint-row (php/- vh 1) (php/- cc 3) (php/- vh 2) frame
+                          (str "▐█" grip-hi "▓▓▓▓▓▓" frame "█▌"))
+               (paint-row vh           (php/- cc 2) (php/- vh 1) grip-lo "▐▓▓▓▓▓▓▌"))
+
+              ;; BFG: bulky cannon, wide glowing aperture + lit core.
+              (php/=== weapon :bfg)
+              (str
+               (paint-row (php/- vh 5) (php/- cc 4) (php/- vh 6) muzzle    "▟██████▙")
+               (paint-row (php/- vh 4) (php/- cc 4) (php/- vh 5) slide     "▐██████████▌")
+               (paint-row (php/- vh 3) (php/- cc 4) (php/- vh 4) slide
+                          (str "▐██" muzzle "▓▓▓▓" slide "██▌"))
+               (paint-row (php/- vh 2) (php/- cc 4) (php/- vh 3) slide-dim "▐██████████▌")
+               (paint-row (php/- vh 1) (php/- cc 3) (php/- vh 2) frame
+                          (str "▐█" grip-hi "▓▓▓▓▓▓▓" frame "█▌"))
+               (paint-row vh           (php/- cc 2) (php/- vh 1) grip-lo "▐▓▓▓▓▓▌"))
+
+              ;; Incinerator: thin nozzle over a fat round fuel tank.
+              (php/=== weapon :incinerator)
+              (str
+               (paint-row (php/- vh 5) cc           (php/- vh 6) muzzle    "╤═")
+               (paint-row (php/- vh 4) (php/- cc 1) (php/- vh 5) slide     "▐███▌")
+               (paint-row (php/- vh 3) (php/- cc 2) (php/- vh 4) slide     "▐██████▌")
+               (paint-row (php/- vh 2) (php/- cc 3) (php/- vh 3) slide-dim "▐████████▌")
+               (paint-row (php/- vh 1) (php/- cc 2) (php/- vh 2) frame
+                          (str "▐█" grip-hi "▓▓▓▓" frame "█▌"))
+               (paint-row vh           (php/- cc 2) (php/- vh 1) grip-lo "▐▓▓▓▓▌"))
+
+              ;; Rocket launcher: a straight uniform tube with a rounded
+              ;; bore, no taper.
+              (php/=== weapon :rocket)
+              (str
+               (paint-row (php/- vh 5) (php/- cc 2) (php/- vh 6) muzzle    "▗▄▄▄▄▖")
+               (paint-row (php/- vh 4) (php/- cc 2) (php/- vh 5) slide     "▐██████▌")
+               (paint-row (php/- vh 3) (php/- cc 2) (php/- vh 4) slide     "▐██████▌")
+               (paint-row (php/- vh 2) (php/- cc 2) (php/- vh 3) slide-dim "▐██████▌")
+               (paint-row (php/- vh 1) (php/- cc 2) (php/- vh 2) frame
+                          (str "▐█" grip-hi "▓▓▓▓" frame "█▌"))
+               (paint-row vh           (php/- cc 1) (php/- vh 1) grip-lo "▐▓▓▓▓▌"))
 
               :else
               (str


### PR DESCRIPTION
## Why

Weapons past the chaingun (chainsaw, BFG, incinerator, rocket, super shotgun) all fell through to the **pistol** sprite and differed only by palette colour. They should read by **shape**, not just hue.

## What

Per-weapon silhouette dispatch in `paint-weapon-sprite`:

- **chainsaw** - toothed blade `◣◢◣◢` over a light chain bar `░░░` and the engine block (no gun barrel)
- **BFG** - bulky cannon, wide glowing aperture `▟██████▙` + lit core
- **incinerator** - thin nozzle `╤═` over a fat round fuel tank
- **rocket launcher** - a straight, uniform tube with a rounded bore `▗▄▄▄▄▖`, no taper
- **super shotgun** - stubby twin-bore (`██ ██` gap reads as the sawn-off double barrel)

Pistol / shotgun / chaingun shapes are unchanged.

## Verification

Drove the game through a sized PTY (`--armory --god`), cycled weapons 4-8, and confirmed each weapon's distinctive glyphs render only when it's active (e.g. chainsaw frame):

```
◣◢◣◢◣◢◣
▐░░░░░░░▌
▐██████▌
▐████████▌
▐█▓▓▓▓▓▓█▌
▐▓▓▓▓▓▓▌
```

Full `composer ci` green (1697 tests; render shape is visual, covered by the play smoke).