### PR TITLE
feat(release): build and attach phel-doom.phar to GitHub releases

### DIFF
--- a/.agnostic-ai/AGNOSTIC_AI.md
+++ b/.agnostic-ai/AGNOSTIC_AI.md
@@ -29,6 +29,7 @@ Authoritative for their topic. Load skill before guessing. Match workflow first,
 - `/gh-issues` → walk all open issues sequentially (`.claude/skills/gh-issues/SKILL.md`)
 - `/fix` → auto-format + lint (`.claude/skills/fix/SKILL.md`)
 - `/changelog [entry]` → update `## Unreleased` (`.claude/skills/changelog/SKILL.md`)
+- `/changelog-simplify` → tighten + de-dup `## [Unreleased]`, commit + push (`.claude/skills/changelog-simplify/SKILL.md`)
 - `/phel-repl <expr>` → eval Phel expression (`.claude/skills/phel-repl/SKILL.md`)
 - `/perf-bench [scope]` → cast/render phase timing (`.claude/skills/perf-bench/SKILL.md`)
 - `/play` → launch game, smoke-test feature manually (`.claude/skills/play/SKILL.md`)

--- a/.agnostic-ai/skills/changelog-simplify/SKILL.md
+++ b/.agnostic-ai/skills/changelog-simplify/SKILL.md
@@ -1,0 +1,73 @@
+---
+description: Tighten and de-duplicate the CHANGELOG.md `## [Unreleased]` notes, then commit + push
+argument-hint: ""
+disable-model-invocation: true
+allowed-tools: "Read, Edit, Bash(git *)"
+target: claude
+---
+
+# Simplify Changelog
+
+Optimize the `## [Unreleased]` section of `CHANGELOG.md`: make it concise and
+scannable without losing any fact. Released sections (`## [X.Y.Z]`) are never
+touched.
+
+## Context
+
+!`git rev-parse --abbrev-ref HEAD`
+
+## Instructions
+
+1. Read `CHANGELOG.md`. Isolate the block from `## [Unreleased]` up to the next
+   `## [` heading. That block is the only thing you may rewrite.
+
+2. If the block has no bullets, report "Unreleased is already empty" and stop.
+   Do not commit.
+
+3. Rewrite each bullet tighter. Simplify wording only - never invent, never drop
+   information:
+   - Cut filler, hedging, and redundant clauses. Keep the *what* and the
+     *why-it-matters*.
+   - Preserve verbatim: issue/PR refs (`(#NNN)`), code in backticks, numbers,
+     slot/level facts, and any `**BREAKING**` marker.
+   - One bullet per user-facing change. Merge duplicates and bullets that
+     describe the same change.
+   - Match house style: descriptive lead phrase, then a colon or sentence with
+     the detail. ASCII hyphen ` - ` for asides, never the em-dash character.
+   - Drop anything not user-facing (pure `chore:` / CI / internal-only churn).
+
+4. Place each bullet under the right subsection and drop empty ones:
+   - `### Added` - new features
+   - `### Changed` - behavior changes, visible refactors
+   - `### Fixed` - bug fixes
+   - `### Removed` - removals
+   - `### Performance` - pure speed/size wins
+
+5. Order bullets within each section by user impact (biggest first).
+
+6. Write the simplified block back. Leave the released sections and the link
+   references at the bottom untouched.
+
+7. Guard: this skill commits + pushes `CHANGELOG.md` alone, so the working
+   tree must hold no other changes. Check first:
+
+   ```bash
+   git status --porcelain | grep -v '[[:space:]]CHANGELOG\.md$'
+   ```
+
+   If that prints anything, the tree has unrelated work (often the very feature
+   these notes describe, not yet committed). Do NOT commit or push. Leave
+   `CHANGELOG.md` edited, report what else is pending, and tell the user to land
+   those changes first (or commit the changelog alongside them).
+
+8. Only when the tree is otherwise clean, commit and push automatically - no
+   confirmation:
+
+   ```bash
+   git add CHANGELOG.md
+   git commit -m "docs(changelog): simplify unreleased notes"
+   git push
+   ```
+
+   This holds whether on `main` or a feature branch (the usual flow is `main`
+   right after a merged PR).

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ vendor/
 
 *.cache
 composer.lock
+
+# PHAR build artifact.
+build/out/
 .phel-repl-history
 gacela*.php
 phel-config-local.php

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,13 @@ All notable changes to phel-doom.
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Versioning: [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` until release cut. Run `./release.sh X.Y.Z` to roll the section into a new version.
+User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` until release cut. Run `./tools/release.sh X.Y.Z` to roll the section into a new version.
 
 ## [Unreleased]
+
+### Added
+
+- Distributable single-file `phel-doom.phar` (~2 MB): bundles the game with the Phel runtime into one executable. `./tools/release.sh` builds, smoke-tests, and attaches it to each GitHub release. Run with `php phel-doom.phar`.
 
 ## [0.8.0] - 2026-06-02
 

--- a/build/README.md
+++ b/build/README.md
@@ -1,0 +1,56 @@
+# build/
+
+Artifact production for phel-doom. Everything here turns the source tree into
+a shippable single-file executable: `phel-doom.phar`. Release orchestration
+lives in [`../tools/release.sh`](../tools/release.sh).
+
+## Files
+
+| File | Purpose |
+|---|---|
+| [`phar.sh`](phar.sh) | Build entry point. Compiles the game, then runs the packager. |
+| [`build-phar.php`](build-phar.php) | Bundles `out/` + `vendor/` into a GZ-compressed, SHA256-signed PHAR with a stub that runs `out/main.php`. |
+| `out/` | PHAR output (`out/phel-doom.phar`). Gitignored. |
+
+## How it works
+
+phel-doom is a Phel *application*, not the compiler. `phel build` emits the
+whole game plus the Phel stdlib it touches as ready-to-run PHP under `out/`.
+Nothing compiles at runtime (`phar.readonly` forbids it anyway), so packaging
+is two steps, orchestrated by `phar.sh`:
+
+1. `phel build --no-cache` -> compiled PHP under `out/`.
+2. `build-phar.php` bundles `out/` + `vendor/` (minus `.phel`/`.map` and any
+   `tests`/`docs` dirs), sets a stub that maps the PHAR and runs `out/main.php`,
+   then GZ-compresses and SHA256-signs.
+
+It is a ~90-line `Phar` build with no external tool, no network fetch, and no
+mutation of the working tree's `vendor/`. The whole vendor tree ships as-is; the
+single dev dependency (var-dumper, ~200 KB) rides along as harmless dead weight,
+because pruning it would mean regenerating a `--no-dev` autoloader (i.e.
+mutating `vendor/`). The stub's `out/main.php` does its own
+`require "../vendor/autoload.php"`, which resolves inside the PHAR. Levels are
+generated procedurally, so there are no external assets to bundle.
+
+The reported version comes from `:version` in `src/main.phel`, which
+`tools/release.sh` bumps as part of the release commit - the build stamps
+nothing.
+
+## Build
+
+```bash
+./build/phar.sh
+# -> build/out/phel-doom.phar
+```
+
+Run it:
+
+```bash
+php build/out/phel-doom.phar          # play
+php build/out/phel-doom.phar --version
+```
+
+## Not here
+
+- Release orchestration (version bump, CHANGELOG, tag, push, GitHub release +
+  PHAR attach) -> [`../tools/release.sh`](../tools/release.sh).

--- a/build/build-phar.php
+++ b/build/build-phar.php
@@ -1,0 +1,99 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+// Build a single-file, self-contained phel-doom PHAR.
+//
+// phel-doom is a Phel *application*: `phel build` emits the whole game plus the
+// Phel stdlib it touches as ready-to-run PHP under out/. Nothing compiles at
+// runtime, so the archive needs only two trees:
+//   out/     - compiled PHP entry point + game code + compiled stdlib
+//   vendor/  - the production Phel runtime the compiled code calls into
+//
+// The whole vendor/ tree is bundled as-is (minus tests/docs), so the working
+// tree is never mutated and the composer autoloader stays consistent. The one
+// dev dependency (var-dumper, ~200 KB) rides along as harmless dead weight;
+// pruning it would require regenerating a --no-dev autoloader, i.e. mutating
+// vendor/. The version comes from src/main.phel via `phel build`; nothing is
+// stamped here.
+//
+// Run with: php -d phar.readonly=0 build/build-phar.php [repo-root]
+
+$root = realpath($argv[1] ?? \dirname(__DIR__));
+$pharFile = $root . '/build/out/phel-doom.phar';
+
+if (\ini_get('phar.readonly') === '1') {
+    fwrite(STDERR, "Error: phar.readonly is on. Run with: php -d phar.readonly=0\n");
+    exit(1);
+}
+if (!is_file($root . '/out/main.php')) {
+    fwrite(STDERR, "Error: out/main.php missing — run `phel build` first.\n");
+    exit(1);
+}
+
+@mkdir(\dirname($pharFile), 0o755, true);
+@unlink($pharFile);
+
+// Directory basenames pruned anywhere (tests/docs ship in many vendor packages).
+$skipDirs = ['tests' => true, 'Tests' => true, 'test' => true, 'Test' => true,
+    'docs' => true, 'doc' => true, '.github' => true];
+
+$phar = new Phar($pharFile);
+$phar->startBuffering();
+
+$rootLen = \strlen($root) + 1;
+$files = 0;
+$sourceBytes = 0;
+
+$addTree = static function (string $dir) use ($root, $rootLen, $skipDirs, $phar, &$files, &$sourceBytes): void {
+    $filter = static function (SplFileInfo $cur) use ($skipDirs): bool {
+        if ($cur->isDir()) {
+            return !isset($skipDirs[$cur->getBasename()]);
+        }
+        // .phel sources and .map source maps are dead weight at runtime.
+        $ext = strtolower($cur->getExtension());
+        return $ext !== 'map' && $ext !== 'phel';
+    };
+
+    $it = new RecursiveIteratorIterator(
+        new RecursiveCallbackFilterIterator(
+            new RecursiveDirectoryIterator($dir, FilesystemIterator::SKIP_DOTS),
+            $filter,
+        ),
+    );
+
+    foreach ($it as $f) {
+        if (!$f->isFile()) {
+            continue;
+        }
+        $phar->addFile($f->getPathname(), substr($f->getPathname(), $rootLen));
+        ++$files;
+        $sourceBytes += (int) $f->getSize();
+    }
+};
+
+$addTree($root . '/out');
+$addTree($root . '/vendor');
+
+// Stub maps the PHAR and runs out/main.php, whose own require of
+// ../vendor/autoload.php resolves to phar://phel-doom.phar/vendor/autoload.php.
+$phar->setStub(
+    "#!/usr/bin/env php\n<?php\n"
+    . "Phar::mapPhar('phel-doom.phar');\n"
+    . "require 'phar://phel-doom.phar/out/main.php';\n"
+    . "__HALT_COMPILER();\n",
+);
+
+$phar->compressFiles(Phar::GZ);
+$phar->setSignatureAlgorithm(Phar::SHA256);
+$phar->stopBuffering();
+chmod($pharFile, 0o755);
+
+printf(
+    "PHAR: %d files, %.2f MB -> %.2f MB (%.0f%% smaller)\n",
+    $files,
+    $sourceBytes / 1048576,
+    filesize($pharFile) / 1048576,
+    (1 - filesize($pharFile) / $sourceBytes) * 100,
+);

--- a/build/phar.sh
+++ b/build/phar.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Build the phel-doom PHAR: a single-file, self-contained executable game.
+#
+# Two steps: compile the project to out/, then bundle out/ + the production
+# vendor tree into a signed, compressed PHAR (see build-phar.php). Dev deps are
+# pruned by reading composer.lock, so vendor/ is never mutated and there is
+# nothing to restore. The reported version comes from `:version` in
+# src/main.phel (bumped by tools/release.sh at release time).
+#
+# Usage: build/phar.sh
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+BUILD_SCRIPT="$SCRIPT_DIR/build-phar.php"
+PHAR_FILE="$SCRIPT_DIR/out/phel-doom.phar"
+
+error() { echo "Error: $*" >&2; exit 1; }
+
+echo "🔨  Compiling project..."
+(cd "$REPO_ROOT" && vendor/bin/phel build --no-cache) || error "phel build failed"
+
+echo "📦  Packaging PHAR..."
+php -d phar.readonly=0 "$BUILD_SCRIPT" "$REPO_ROOT" || error "PHAR build failed"
+[[ -x "$PHAR_FILE" ]] || error "PHAR was not created or is not executable: $PHAR_FILE"
+
+echo "📍  Final Location:   $PHAR_FILE"

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -1,22 +1,27 @@
 #!/usr/bin/env bash
 # Release script for phel-doom.
 #
-# Usage: ./release.sh [version] [--dry-run] [--force] [--name "Release name"]
+# Usage: ./tools/release.sh [version] [--dry-run] [--force] [--name "Release name"]
 #
 # Steps:
 #   1. Validate semver and preflight (clean tree, on main, gh CLI ready, tag free).
 #   2. Move CHANGELOG.md "## [Unreleased]" block into "## [X.Y.Z] - YYYY-MM-DD".
-#   3. Commit, tag vX.Y.Z, push branch and tag.
-#   4. Create GitHub release using the extracted changelog section as notes.
+#   3. Build a self-contained phel-doom.phar and smoke-test it.
+#   4. Commit, tag vX.Y.Z, push branch and tag.
+#   5. Create GitHub release using the extracted changelog as notes, attaching the PHAR.
 
 set -euo pipefail
 
 # ---------------------------------------------------------------------------
 # Config
 # ---------------------------------------------------------------------------
+# tools/ lives one level below the repo root.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-REPO_ROOT="$SCRIPT_DIR"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
 CHANGELOG_FILE="$REPO_ROOT/CHANGELOG.md"
+VERSION_FILE="$REPO_ROOT/src/main.phel"
+PHAR_SCRIPT="$REPO_ROOT/build/phar.sh"
+PHAR_OUTPUT="$REPO_ROOT/build/out/phel-doom.phar"
 MAIN_BRANCH="main"
 REMOTE="origin"
 DEFAULT_REPO_SLUG="Chemaclass/phel-doom"
@@ -27,6 +32,7 @@ DRY_RUN=0
 FORCE=0
 DRAFT=0
 SKIP_TESTS=0
+SKIP_PHAR=0
 REPO_SLUG=""
 
 # ---------------------------------------------------------------------------
@@ -79,6 +85,10 @@ rollback() {
         cp "$BACKUP_DIR/CHANGELOG.md" "$CHANGELOG_FILE"
         log_ok "Restored CHANGELOG.md"
     fi
+    if [[ -n "$BACKUP_DIR" && -f "$BACKUP_DIR/main.phel" ]]; then
+        cp "$BACKUP_DIR/main.phel" "$VERSION_FILE"
+        log_ok "Restored src/main.phel"
+    fi
     cleanup_backup
 }
 
@@ -107,13 +117,14 @@ Options:
   --dry-run           Print actions without changing files or pushing
   --force             Skip confirmation prompt
   --skip-tests        Skip composer ci gate (NOT recommended)
+  --skip-phar         Skip building + attaching the phel-doom.phar
   --draft             Create the GitHub release as a draft
   -h, --help          Show this help
 
 Examples:
-  ./release.sh                  # auto-bump minor from latest tag
-  ./release.sh 0.1.0
-  ./release.sh 0.2.0 --name "DDA raycaster" --dry-run
+  ./tools/release.sh                  # auto-bump minor from latest tag
+  ./tools/release.sh 0.1.0
+  ./tools/release.sh 0.2.0 --name "DDA raycaster" --dry-run
 EOF
 }
 
@@ -140,6 +151,7 @@ parse_args() {
             --dry-run)    DRY_RUN=1; shift ;;
             --force)      FORCE=1; shift ;;
             --skip-tests) SKIP_TESTS=1; shift ;;
+            --skip-phar)  SKIP_PHAR=1; shift ;;
             --draft)      DRAFT=1; shift ;;
             --name)       RELEASE_NAME="${2:-}"; shift 2 ;;
             -h|--help)    show_help; exit 0 ;;
@@ -336,7 +348,11 @@ confirm_release() {
     echo ""
     log "${BOLD}Release v$NEW_VERSION${NC}"
     [[ -n "$RELEASE_NAME" ]] && log "Name: $RELEASE_NAME"
-    log "Actions: update CHANGELOG.md, commit, tag v$NEW_VERSION, push, create GitHub release"
+    if [[ $SKIP_PHAR -eq 1 ]]; then
+        log "Actions: update CHANGELOG.md, commit, tag v$NEW_VERSION, push, create GitHub release"
+    else
+        log "Actions: update CHANGELOG.md, build+smoke-test PHAR, commit, tag v$NEW_VERSION, push, create GitHub release (with PHAR asset)"
+    fi
     echo ""
     read -rp "Proceed? [y/N] " response
     case "$response" in
@@ -348,8 +364,17 @@ confirm_release() {
 # ---------------------------------------------------------------------------
 # Git + GitHub
 # ---------------------------------------------------------------------------
+# Bump the `:version` literal in src/main.phel so the compiled game (and thus
+# the PHAR) reports the released version. This is the single source of truth;
+# the build does not stamp anything.
+bump_src_version() {
+    perl -0pi -e 's/(:version\s+)"[^"]*"/${1}"'"$NEW_VERSION"'"/' "$VERSION_FILE"
+    grep -q "\"$NEW_VERSION\"" "$VERSION_FILE" \
+        || { log_err "Failed to bump :version in src/main.phel"; return 1; }
+}
+
 git_commit_release() {
-    git -C "$REPO_ROOT" add "$CHANGELOG_FILE"
+    git -C "$REPO_ROOT" add "$CHANGELOG_FILE" "$VERSION_FILE"
     git -C "$REPO_ROOT" commit -m "chore(release): v$NEW_VERSION"
     COMMITTED=1
 }
@@ -368,6 +393,45 @@ git_push() {
     PUSHED=1
 }
 
+# Build the distributable single-file PHAR. The version was already bumped into
+# src/main.phel, so phar.sh just compiles + packages.
+build_phar() {
+    if [[ $SKIP_PHAR -eq 1 ]]; then
+        log_warn "Skipping PHAR build (--skip-phar)"
+        return 0
+    fi
+    [[ -x "$PHAR_SCRIPT" ]] || { log_err "PHAR build script not found: $PHAR_SCRIPT"; return 1; }
+    log "Building phel-doom.phar..."
+    "$PHAR_SCRIPT" >/dev/null \
+        || { log_err "PHAR build failed — run '$PHAR_SCRIPT' to see output"; return 1; }
+    [[ -f "$PHAR_OUTPUT" ]] || { log_err "PHAR not found at $PHAR_OUTPUT after build"; return 1; }
+    log_ok "Built $PHAR_OUTPUT"
+}
+
+# Smoke-test the freshly built PHAR: it must report the released version and
+# emit no PHP diagnostics on stderr. The game itself needs a TTY, so we only
+# exercise the non-interactive --version path here.
+smoke_test_phar() {
+    [[ $SKIP_PHAR -eq 1 ]] && return 0
+    local out err rc
+    out=$(mktemp); err=$(mktemp)
+    php "$PHAR_OUTPUT" --version >"$out" 2>"$err"; rc=$?
+    if [[ $rc -ne 0 ]]; then
+        log_err "PHAR smoke test failed (exit $rc)"; sed -n '1,20p' "$err" >&2
+        rm -f "$out" "$err"; return 1
+    fi
+    if grep -qE 'PHP (Warning|Fatal|Parse|Deprecated) ' "$err"; then
+        log_err "PHAR smoke test emitted PHP diagnostics:"; grep -E 'PHP ' "$err" | head -3 >&2
+        rm -f "$out" "$err"; return 1
+    fi
+    if ! grep -qE "phel-doom $NEW_VERSION" "$out"; then
+        log_err "PHAR --version did not report $NEW_VERSION:"; sed -n '1,5p' "$out" >&2
+        rm -f "$out" "$err"; return 1
+    fi
+    rm -f "$out" "$err"
+    log_ok "PHAR smoke test passed (phel-doom $NEW_VERSION)"
+}
+
 create_github_release() {
     local notes
     notes=$(extract_release_notes "$NEW_VERSION")
@@ -383,11 +447,16 @@ create_github_release() {
     local draft_flag=""
     [[ $DRAFT -eq 1 ]] && draft_flag="--draft"
 
+    # Attach the PHAR as a release asset when present (skipped via --skip-phar).
+    local asset=""
+    [[ $SKIP_PHAR -eq 0 && -f "$PHAR_OUTPUT" ]] && asset="$PHAR_OUTPUT"
+
     gh release create "v$NEW_VERSION" \
         --repo "$REPO_SLUG" \
         --title "$title" \
         --notes-file "$notes_file" \
-        $draft_flag
+        $draft_flag \
+        ${asset:+"$asset"}
 
     rm -f "$notes_file"
 }
@@ -412,22 +481,36 @@ main() {
 
     confirm_release
 
-    # Backup CHANGELOG so failures can roll back
+    # Backup mutated files so failures can roll back
     BACKUP_DIR=$(mktemp -d)
     cp "$CHANGELOG_FILE" "$BACKUP_DIR/CHANGELOG.md"
+    cp "$VERSION_FILE" "$BACKUP_DIR/main.phel"
 
     log "\n${BOLD}Updating CHANGELOG.md${NC}"
     update_changelog "$NEW_VERSION"
     log_ok "Moved Unreleased → [$NEW_VERSION]"
 
+    log "\n${BOLD}Bumping version${NC}"
+    bump_src_version
+    log_ok "Set src/main.phel :version to $NEW_VERSION"
+
     if [[ $DRY_RUN -eq 1 ]]; then
         log "\n${BOLD}Release notes preview${NC}"
         extract_release_notes "$NEW_VERSION"
-        log "\n[DRY-RUN] Would: git commit, tag v$NEW_VERSION, push, gh release create"
+        if [[ $SKIP_PHAR -eq 1 ]]; then
+            log "\n[DRY-RUN] Would: git commit, tag v$NEW_VERSION, push, gh release create (no PHAR)"
+        else
+            log "\n[DRY-RUN] Would: build phel-doom.phar (v$NEW_VERSION), smoke-test it,"
+            log "[DRY-RUN]       git commit, tag v$NEW_VERSION, push, gh release create + attach PHAR"
+        fi
         rollback
-        log_ok "Dry-run complete - CHANGELOG.md restored"
+        log_ok "Dry-run complete - CHANGELOG.md + src/main.phel restored"
         exit 0
     fi
+
+    log "\n${BOLD}Building PHAR${NC}"
+    build_phar
+    smoke_test_phar
 
     log "\n${BOLD}Committing${NC}"
     git_commit_release


### PR DESCRIPTION
## Summary

Package the game as a single-file `phel-doom.phar` and attach it to every GitHub release.

## How

- **`build/build-phar.php`** (~90 lines) bundles `out/` + `vendor/` (minus `.phel`/`.map`/tests/docs) → GZ + SHA256, stub runs `out/main.php`. No external tool, no network, no `vendor/` mutation. `build/phar.sh` just runs `phel build` then the packager.
- **`tools/release.sh`** (moved from root) bumps `:version` in `src/main.phel`, builds + smoke-tests the PHAR, and attaches it to the release. `--skip-phar` to opt out.
- **`/changelog-simplify`** skill: tighten + de-dup the `## [Unreleased]` notes (guards auto-push when the tree has unrelated changes).

## Verified

PHAR 2.30 MB (78% smaller than source); `--version`/`--help` boot; `vendor/` untouched; `composer test` → 1697 pass.

Run: `php phel-doom.phar`
