### PR TITLE
feat(menu): show version on welcome + credits, drop compass hint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 
 ## [Unreleased]
 
+### Added
+
+- Start-menu welcome box and credits screen show the current version, sourced from a single `src/core/version.phel` constant that `tools/release.sh` bumps (also feeds `--version`), so a release updates it everywhere at once.
+
+### Removed
+
+- Compass-hint section dropped from the start-menu welcome box (kept controls + how-to-play).
+
 ## [0.9.0] - 2026-06-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,9 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 
 - Start-menu welcome box and credits screen show the current version, sourced from a single `src/core/version.phel` constant that `tools/release.sh` bumps (also feeds `--version`), so a release updates it everywhere at once.
 
-### Removed
+### Changed
 
-- Compass-hint section dropped from the start-menu welcome box (kept controls + how-to-play).
+- Start-menu welcome box restructured: controls now in two columns, with how-to-play kept below and the compass-hint section dropped, so the box is shorter and fits more terminals.
 
 ## [0.9.0] - 2026-06-03
 

--- a/build/README.md
+++ b/build/README.md
@@ -32,9 +32,9 @@ mutating `vendor/`). The stub's `out/main.php` does its own
 `require "../vendor/autoload.php"`, which resolves inside the PHAR. Levels are
 generated procedurally, so there are no external assets to bundle.
 
-The reported version comes from `:version` in `src/main.phel`, which
-`tools/release.sh` bumps as part of the release commit - the build stamps
-nothing.
+The reported version comes from `src/core/version.phel` (the single source of
+truth, also shown in the start menu + credits), which `tools/release.sh` bumps
+as part of the release commit - the build stamps nothing.
 
 ## Build
 

--- a/src/commands/play.phel
+++ b/src/commands/play.phel
@@ -24,6 +24,7 @@
   (:require phel-doom.core.rng    :as rng)
   (:require phel-doom.core.level    :refer [build-world num-levels place-secret-reward])
   (:require phel-doom.core.perf     :refer [target-frame-us])
+  (:require phel-doom.core.version  :refer [version])
   (:require phel-doom.io.scores   :refer [update-scores!])
   (:require phel-doom.io.render   :refer [render! clear-screen
                                           read-perf-snapshot
@@ -1064,7 +1065,7 @@
 
 (defn- print-credits []
   (println)
-  (println "  \e[1mphel-doom\e[0m  by \e[1mChemaclass\e[0m  https://github.com/Chemaclass/phel-doom")
+  (println (str "  \e[1mphel-doom\e[0m \e[2mv" version "\e[0m  by \e[1mChemaclass\e[0m  https://github.com/Chemaclass/phel-doom"))
   (println "  written in \e[1mPhel Lang\e[0m  https://phel-lang.org/")
   (println))
 

--- a/src/core/version.phel
+++ b/src/core/version.phel
@@ -1,0 +1,8 @@
+(ns phel-doom.core.version)
+
+;; Single source of truth for the phel-doom version. Bumped by
+;; tools/release.sh at release time (alongside CHANGELOG), then surfaced in
+;; `--version`, the start-menu welcome box, and the credits screen. The flat
+;; `(def version "X.Y.Z")` shape (no docstring) keeps the bump a one-line,
+;; single-quote regex.
+(def version "0.9.0")

--- a/src/io/render.phel
+++ b/src/io/render.phel
@@ -3425,64 +3425,65 @@
   "Interior strings for the start-menu box. `:sep` markers between
    sections become `├─┤` divider rows in render-start-menu.
 
+   Controls are laid out in two columns to keep the box short.
+
    Adaptive to terminal height (`rows`):
-     >= 32  full menu (title + credit + controls + how-to-play + footer)
-     >= 24  drop the how-to-play section
-     < 24   ultra-compact (title + footer only; controls listed
-             behind a 'press ? for help' hint elsewhere).
+     >= 28  full menu (title + controls + how-to-play + footer)
+     >= 22  drop the how-to-play section
+     < 22   ultra-compact (title + footer only, with a resize hint).
 
    The total row count always fits inside `rows - 4` cells (box top
    border + bottom border + one cushion above + one below)."
   [rows]
   (let [w        start-menu-width
+        half     (php/intdiv w 2)
         blank    (pad-visible "" w)
+        ;; key+label cell: 2-space indent, yellow key in an 8-col field,
+        ;; then the label. ANSI is ignored by pad-visible's width count.
+        cell     (fn [key label]
+                   (str "  \e[93m" key "\e[40;97m"
+                        (php/str_repeat " " (php/max 1 (php/- 8 (php/mb_strwidth key))))
+                        label))
+        ;; one interior row holding two key/label cells side by side; each
+        ;; cell padded to half the interior so the columns line up.
+        row2     (fn [lkey llab rkey rlab]
+                   (str (pad-visible (cell lkey llab) half)
+                        (pad-visible (if (= rkey "") "" (cell rkey rlab)) half)))
         title    [blank
                   (pad-visible "      \e[1;93m✦  P H E L - D O O M  ✦\e[40;97m" w)
                   blank
-                  (pad-visible "         a DOOM-lite raycaster" w)
-                  (pad-visible "            written in \e[1mPhel\e[40;97m" w)]
-        credit   [blank
-                  (pad-visible "          \e[2;97m// crafted by \e[1;93mChemaclass\e[40;97m" w)
-                  (pad-visible (str "          \e[2;97m// v" version "\e[40;97m") w)
+                  (pad-visible (str "       \e[2;97m// crafted by \e[1;93mChemaclass\e[40;97m\e[2;97m  // v" version "\e[40;97m") w)
                   blank]
         controls [:sep blank
                   (pad-visible "  \e[1mCONTROLS\e[40;97m" w)
                   blank
-                  (pad-visible "    \e[93mw s ↑ ↓\e[40;97m   move forward / back" w)
-                  (pad-visible "    \e[93ma d    \e[40;97m   strafe left / right" w)
-                  (pad-visible "    \e[93m← →    \e[40;97m   turn left / right" w)
-                  (pad-visible "    \e[93me      \e[40;97m   about-face (snap 180°)" w)
-                  (pad-visible "    \e[93mspace  \e[40;97m   fire" w)
-                  (pad-visible "    \e[93mr      \e[40;97m   reload" w)
-                  (pad-visible "    \e[93m1 .. 8 \e[40;97m   switch weapon slot" w)
-                  (pad-visible "    \e[93mh      \e[40;97m   info menu (stats + weapons)" w)
-                  (pad-visible "    \e[93mm  n   \e[40;97m   toggle minimap / sound" w)
-                  (pad-visible "    \e[93mp      \e[40;97m   pause + settings menu" w)
-                  (pad-visible "    \e[93mF3 q   \e[40;97m   debug / quit" w)
+                  (row2 "w s ↑ ↓" "move"   "1 .. 8" "weapon slot")
+                  (row2 "a d"     "strafe" "h"      "info menu")
+                  (row2 "← →"     "turn"   "m n"    "map / sound")
+                  (row2 "e"       "180°"   "p"      "pause")
+                  (row2 "space"   "fire"   "F3 q"   "debug / quit")
+                  (row2 "r"       "reload" ""       "")
                   blank]
         howto    [:sep blank
                   (pad-visible "  \e[1mHOW TO PLAY\e[40;97m" w)
                   blank
-                  (pad-visible "    Shoot enemies. Walk into a door to" w)
-                  (pad-visible "    advance. Walk over a heart to refill" w)
-                  (pad-visible "    a life. Pick up armor to absorb a hit." w)
-                  (pad-visible "    Survive 5 levels." w)
+                  (pad-visible "  Shoot enemies. Walk into a door to advance." w)
+                  (pad-visible "  Heart refills a life. Armor soaks a hit." w)
+                  (pad-visible "  Survive 5 levels." w)
                   blank]
         footer   [:sep blank
-                  (pad-visible "      \e[93mENTER\e[40;97m  start game" w)
-                  (pad-visible "      \e[93ms\e[40;97m      settings" w)
-                  (pad-visible "      \e[93mq\e[40;97m      quit" w)
+                  (pad-visible "    \e[93mENTER\e[40;97m start   \e[93ms\e[40;97m settings   \e[93mq\e[40;97m quit" w)
                   blank]]
     (apply vector
            (cond
-             ;; Full menu: title + credit + controls + how-to-play + footer.
-             (php/>= rows 32) (concat title credit controls howto footer)
+             ;; Full menu: title + controls (2-col) + how-to-play + footer.
+             (php/>= rows 28) (concat title controls howto footer)
              ;; Medium: drop the how-to-play section.
-             (php/>= rows 24) (concat title credit controls footer)
+             (php/>= rows 22) (concat title controls footer)
              ;; Tight: title + footer only, with a hint that resizing
              ;; reveals the full menu.
              :else            (concat title
-                                      [blank
+                                      [:sep blank
                                        (pad-visible "       \e[2;97mresize terminal for full menu\e[40;97m" w)
                                        blank]
                                       footer)))))

--- a/src/io/render.phel
+++ b/src/io/render.phel
@@ -5,7 +5,8 @@
   (:require phel-doom.core.map     :refer [find-door-cell])
   (:require phel-doom.core.weapons :refer [weapon-order weapons])
   (:require phel-doom.core.settings :refer [page-fields])
-  (:require phel-doom.core.format  :refer [format-duration]))
+  (:require phel-doom.core.format  :refer [format-duration])
+  (:require phel-doom.core.version :refer [version]))
 
 ;; =====================================================================
 ;; § Hot-loop buffer macros
@@ -3442,6 +3443,7 @@
                   (pad-visible "            written in \e[1mPhel\e[40;97m" w)]
         credit   [blank
                   (pad-visible "          \e[2;97m// crafted by \e[1;93mChemaclass\e[40;97m" w)
+                  (pad-visible (str "          \e[2;97m// v" version "\e[40;97m") w)
                   blank]
         controls [:sep blank
                   (pad-visible "  \e[1mCONTROLS\e[40;97m" w)
@@ -3465,14 +3467,6 @@
                   (pad-visible "    advance. Walk over a heart to refill" w)
                   (pad-visible "    a life. Pick up armor to absorb a hit." w)
                   (pad-visible "    Survive 5 levels." w)
-                  blank
-                  (pad-visible "  \e[1mCOMPASS HINT\e[40;97m" w)
-                  blank
-                  (pad-visible "    Top-centre \e[93mE S W N\e[40;97m strip tints the" w)
-                  (pad-visible "    letter toward your next target:" w)
-                  (pad-visible "      \e[38;5;214;1morange\e[40;97m = exit door" w)
-                  (pad-visible "      \e[94;1mblue\e[40;97m / \e[91;1mred\e[40;97m = keycard (locked door)" w)
-                  (pad-visible "    Use it to navigate without the 2D map." w)
                   blank]
         footer   [:sep blank
                   (pad-visible "      \e[93mENTER\e[40;97m  start game" w)

--- a/src/main.phel
+++ b/src/main.phel
@@ -1,11 +1,12 @@
 (ns phel-doom.main
   (:require phel.cli :as cli)
+  (:require phel-doom.core.version :refer [version])
   (:require phel-doom.commands.play :refer [play-command]))
 
 (def app
   (cli/application
    {:name     "phel-doom"
-    :version  "0.9.0"
+    :version  version
     :default  "play"
     :commands [play-command]}))
 

--- a/tests/core/version-test.phel
+++ b/tests/core/version-test.phel
@@ -1,0 +1,15 @@
+(ns phel-doom-tests.core.version-test
+  (:require phel.test :refer [deftest is])
+  (:require phel.string :as str)
+  (:require phel-doom.core.version :refer [version]))
+
+;; version is the single source of truth surfaced in --version, the start
+;; menu, and the credits screen; tools/release.sh bumps it. Guard the shape
+;; so a bad bump (empty / non-semver) is caught by the test suite.
+
+(deftest version-is-non-empty-string
+  (is (string? version) "version is a string")
+  (is (not (= "" version)) "version is not empty"))
+
+(deftest version-is-semver
+  (is (php/preg_match "/^\\d+\\.\\d+\\.\\d+$/" version) "version is X.Y.Z"))

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(dirname "$SCRIPT_DIR")"
 CHANGELOG_FILE="$REPO_ROOT/CHANGELOG.md"
-VERSION_FILE="$REPO_ROOT/src/main.phel"
+VERSION_FILE="$REPO_ROOT/src/core/version.phel"
 PHAR_SCRIPT="$REPO_ROOT/build/phar.sh"
 PHAR_OUTPUT="$REPO_ROOT/build/out/phel-doom.phar"
 MAIN_BRANCH="main"
@@ -85,9 +85,9 @@ rollback() {
         cp "$BACKUP_DIR/CHANGELOG.md" "$CHANGELOG_FILE"
         log_ok "Restored CHANGELOG.md"
     fi
-    if [[ -n "$BACKUP_DIR" && -f "$BACKUP_DIR/main.phel" ]]; then
-        cp "$BACKUP_DIR/main.phel" "$VERSION_FILE"
-        log_ok "Restored src/main.phel"
+    if [[ -n "$BACKUP_DIR" && -f "$BACKUP_DIR/version.phel" ]]; then
+        cp "$BACKUP_DIR/version.phel" "$VERSION_FILE"
+        log_ok "Restored src/core/version.phel"
     fi
     cleanup_backup
 }
@@ -364,13 +364,13 @@ confirm_release() {
 # ---------------------------------------------------------------------------
 # Git + GitHub
 # ---------------------------------------------------------------------------
-# Bump the `:version` literal in src/main.phel so the compiled game (and thus
-# the PHAR) reports the released version. This is the single source of truth;
-# the build does not stamp anything.
+# Bump the version literal in src/core/version.phel so the compiled game (and
+# thus the PHAR), the start menu, and the credits all report the released
+# version. This is the single source of truth; the build does not stamp.
 bump_src_version() {
-    perl -0pi -e 's/(:version\s+)"[^"]*"/${1}"'"$NEW_VERSION"'"/' "$VERSION_FILE"
+    perl -0pi -e 's/(\(def version )"[^"]*"/${1}"'"$NEW_VERSION"'"/' "$VERSION_FILE"
     grep -q "\"$NEW_VERSION\"" "$VERSION_FILE" \
-        || { log_err "Failed to bump :version in src/main.phel"; return 1; }
+        || { log_err "Failed to bump version in src/core/version.phel"; return 1; }
 }
 
 git_commit_release() {
@@ -484,7 +484,7 @@ main() {
     # Backup mutated files so failures can roll back
     BACKUP_DIR=$(mktemp -d)
     cp "$CHANGELOG_FILE" "$BACKUP_DIR/CHANGELOG.md"
-    cp "$VERSION_FILE" "$BACKUP_DIR/main.phel"
+    cp "$VERSION_FILE" "$BACKUP_DIR/version.phel"
 
     log "\n${BOLD}Updating CHANGELOG.md${NC}"
     update_changelog "$NEW_VERSION"
@@ -492,7 +492,7 @@ main() {
 
     log "\n${BOLD}Bumping version${NC}"
     bump_src_version
-    log_ok "Set src/main.phel :version to $NEW_VERSION"
+    log_ok "Set version to $NEW_VERSION"
 
     if [[ $DRY_RUN -eq 1 ]]; then
         log "\n${BOLD}Release notes preview${NC}"
@@ -504,7 +504,7 @@ main() {
             log "[DRY-RUN]       git commit, tag v$NEW_VERSION, push, gh release create + attach PHAR"
         fi
         rollback
-        log_ok "Dry-run complete - CHANGELOG.md + src/main.phel restored"
+        log_ok "Dry-run complete - CHANGELOG.md + version.phel restored"
         exit 0
     fi
 


### PR DESCRIPTION
## Summary

Show the current version on the start-menu welcome box and credits, from a single source of truth, and restructure the welcome box into a tighter two-column layout.

## Changes

- **`src/core/version.phel`** - new single source of truth: `(def version "X.Y.Z")`. Feeds `--version` (`main.phel`), the start-menu byline, and `print-credits`, so a release updates all three at once.
- **`tools/release.sh`** - bumps this constant (was `src/main.phel :version`); backup/rollback updated.
- **Welcome box** - controls now in **two columns**, how-to-play kept below, compass-hint section dropped; version shown in the byline (`// crafted by Chemaclass  // v0.9.0`). Shorter box, fits more terminal heights. Adaptive thresholds: full >= 28 rows, drop how-to >= 22, tight below.
- Test `tests/core/version-test.phel` guards the version shape (semver).

## Verified

`--version` -> `phel-doom 0.9.0`; direct render eval shows the two-column controls + how-to + `// v0.9.0`; box fits at rows 20-32 with no overflow; game boots with 0 PHP errors; `composer test` -> 1700 pass.
