### PR TITLE
fix(release): bump the real version def, not a comment match

### DIFF
--- a/src/core/version.phel
+++ b/src/core/version.phel
@@ -3,6 +3,6 @@
 ;; Single source of truth for the phel-doom version. Bumped by
 ;; tools/release.sh at release time (alongside CHANGELOG), then surfaced in
 ;; `--version`, the start-menu welcome box, and the credits screen. The flat
-;; `(def version "X.Y.Z")` shape (no docstring) keeps the bump a one-line,
-;; single-quote regex.
+;; def below (no docstring) is kept on its own line so the release bump is a
+;; single line-anchored regex.
 (def version "0.9.0")

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -368,8 +368,10 @@ confirm_release() {
 # thus the PHAR), the start menu, and the credits all report the released
 # version. This is the single source of truth; the build does not stamp.
 bump_src_version() {
-    perl -0pi -e 's/(\(def version )"[^"]*"/${1}"'"$NEW_VERSION"'"/' "$VERSION_FILE"
-    grep -q "\"$NEW_VERSION\"" "$VERSION_FILE" \
+    # Line-anchored (^ + /m) so only the real `(def version ...)` form is
+    # rewritten, never a `(def version ...)` mention in a comment.
+    perl -0pi -e 's/^(\(def version )"[^"]*"/${1}"'"$NEW_VERSION"'"/m' "$VERSION_FILE"
+    grep -qE "^\(def version \"$NEW_VERSION\"\)" "$VERSION_FILE" \
         || { log_err "Failed to bump version in src/core/version.phel"; return 1; }
 }
 


### PR DESCRIPTION
## Summary

`tools/release.sh`'s version bump targeted the wrong line, so a release would have silently shipped a stale version.

## The bug

The bump regex was unanchored:

```
s/(\(def version )"[^"]*"/.../
```

`src/core/version.phel`'s comment contained an example `(def version "X.Y.Z")` *before* the real def. With no `/g` and no anchor, the non-global substitution rewrote that first (comment) match and left the actual `(def version "0.9.0")` untouched. The `grep -q` verify then passed anyway, because the new number now appeared in the comment - so the failure was silent.

## Fix

- Anchor the regex to line start (`^` + `/m`) so only the real def line matches.
- Tighten the verify to `grep -E "^\(def version \"X.Y.Z\"\)"` (the actual def, not the number anywhere).
- Drop the literal `(def version "X.Y.Z")` from the comment as belt-and-suspenders.

## Verified

Isolated bump on the real file now rewrites the def line (comment untouched) and the verify passes. Bug never shipped - the version-source change landed after v0.9.0 and no release has run since.
