### PR TITLE
feat(level): add yellow keycard + locked exit to L7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 
 ## [Unreleased]
 
+### Added
+
+- Level 7 now has a yellow-keyed locked exit and a yellow keycard pickup - the third keycard colour (classic DOOM blue/yellow/red).
+
 ### Changed
 
 - Internal maintainability pass (no gameplay change): the 3564-line `render.phel` is split into a thin public facade plus focused `render/{buffer,palette,frame-math,hud,paint,main}` namespaces; all in-tick sound effects (pickups, interactions, reload) now flow through the pure `:sfx` queue so `tick-world` is fully effect-free; render pulse cadences and the near-death haze ramp are named constants; and the docstring convention, engine cache rationale, and `enemy` / `enemy-ai` split are documented. Behaviour is identical.

--- a/docs/level-system.md
+++ b/docs/level-system.md
@@ -12,7 +12,7 @@
 | 4 | barons | random + blue lock | 5 barons |
 | 5 | cyberdemons | random + red lock | 7 cyberdemons |
 | 6 | spectres | random mix | 4 spectres + 2 imps |
-| 7 | revenants | random mix | 4 revenants + 2 demons |
+| 7 | revenants | random mix + yellow lock | 4 revenants + 2 demons |
 | 8 | archvile court | random mix | 2 archviles + 3 cacos + 2 mancubi |
 | 9 | the brood | random mix | 3 pinkies + 3 barons + 2 mancubi |
 | 10 | the final | hand-authored boss arena | 1 cyberdemon boss (50 HP) + 2 imps (max 1 alive) |
@@ -21,7 +21,7 @@
 
 L1-L5: single-type procgen. L6-L9: mixed-monster procgen. L10: hand-authored arena with secrets + switches.
 
-Non-locked procgen levels seed up to 2 secret passages (seen in [map.md](map.md)) that drop reward stashes on reveal. Locked levels (L4/L5) skip seeding to prevent bypassing the keycard door.
+Non-locked procgen levels seed up to 2 secret passages (seen in [map.md](map.md)) that drop reward stashes on reveal. Locked levels (L4/L5/L7) skip seeding to prevent bypassing the keycard door.
 
 ```phel
 (def levels
@@ -54,7 +54,7 @@ Optional:
 | Field | Meaning |
 |---|---|
 | `:enemy-lives` | Override the catalog's `:default-lives` (single-type entries only) |
-| `:door-lock`   | `:blue` / `:red` - adds a matching keycard pickup and locks the exit |
+| `:door-lock`   | `:blue` / `:red` / `:yellow` - adds a matching keycard pickup and locks the exit |
 | `:layout`      | Hand-authored ASCII grid (vector of strings) - bypasses `random-grid` |
 
 ### Mixed-monster rooms
@@ -76,7 +76,7 @@ When `:enemies` is a vector, each spec spawns its own count + HP and the enemy c
 |---|---|
 | `#` / `.` | wall / floor |
 | `@` | player spawn |
-| `D` / `B` / `R` / `X` | unlocked / blue / red / boss-locked door |
+| `D` / `B` / `R` / `Y` / `X` | unlocked / blue / red / yellow / boss-locked door |
 | `S` | secret wall (press F to reveal) |
 | `T` | switch (toggles target cells via `:switches` config) |
 

--- a/docs/map.md
+++ b/docs/map.md
@@ -14,13 +14,14 @@
 (def cell-secret    6)  ; hidden passage: looks + blocks like a wall until the player reveals it with F
 (def cell-switch-off 7) ; inactive switch: blocks like a wall, F-press flips to cell-switch-on + mutates target cells
 (def cell-switch-on  8) ; activated switch: same blocking + a second F-press reverts to cell-switch-off + targets
+(def cell-door-yellow 9) ; yellow-keyed door: blocks until player holds :yellow keycard
 ```
 
-Every cell is one of these ints. Constants exported so no module uses raw `0/1/2/3/4/5` literals. `(= cell-door (cell g x y))` reads as purpose.
+Every cell is one of these ints. Constants exported so no module uses raw `0/1/2/3/4/5/9` literals. `(= cell-door (cell g x y))` reads as purpose.
 
 `lock-colours` maps locked-door cell values to keycard keywords:
 ```phel
-{3 :blue   4 :red   5 :boss}
+{3 :blue   4 :red   5 :boss   9 :yellow}
 ```
 
 `:boss` is a synthetic "colour" - no physical keycard item ever spawns for it; the kw is granted automatically by `combat/maybe-unlock-boss-door` when the boss is killed on a `:door-lock :boss` level.

--- a/src/core/level.phel
+++ b/src/core/level.phel
@@ -1,7 +1,7 @@
 (ns phel-doom.core.level
   (:require phel-doom.core.rng :as rng)
   (:require phel-doom.core.state      :refer [max-backpacks max-lives new-player new-world with-enemies])
-  (:require phel-doom.core.map        :refer [cell-door cell-door-blue cell-door-red count-secrets parse-layout random-grid random-spawn seed-doors seed-secrets])
+  (:require phel-doom.core.map        :refer [cell-door cell-door-blue cell-door-red cell-door-yellow count-secrets parse-layout random-grid random-spawn seed-doors seed-secrets])
   (:require phel-doom.core.enemy      :refer [default-wander-fraction promote-wanderers spawn-enemies spawn-enemies-mixed])
   (:require phel-doom.core.enemy-ai   :refer [aggression-for])
   (:require phel-doom.core.enemies    :refer [enemy-types type-spec default-lives-for])
@@ -42,7 +42,7 @@
    Optional:
 
      :enemy-lives  override the catalog's :default-lives (single-type only)
-     :door-lock    :blue | :red — adds a keycard + locked exit
+     :door-lock    :blue | :red | :yellow — adds a keycard + locked exit
      :layout       vector of ASCII strings (see map/parse-layout) —
                    bypasses random-grid for hand-authored arenas
 
@@ -99,6 +99,7 @@
     :enemy   :revenant
     :chase   1.8
     :name    "revenants"
+    :door-lock :yellow
     :enemies [{:type :revenant :count 4}
               {:type :demon    :count 2}
               {:type :baron    :count 1}]}
@@ -345,9 +346,10 @@
   "Map a lock-colour kw to the matching locked-door cell value."
   [colour]
   (cond
-    (php/=== colour :blue) cell-door-blue
-    (php/=== colour :red)  cell-door-red
-    :else                  cell-door))
+    (php/=== colour :blue)   cell-door-blue
+    (php/=== colour :red)    cell-door-red
+    (php/=== colour :yellow) cell-door-yellow
+    :else                    cell-door))
 
 (defn- lock-the-door
   "Replace the FIRST cell-door in `grid` with the locked variant for

--- a/src/core/map.phel
+++ b/src/core/map.phel
@@ -37,6 +37,12 @@
    `passable?` / `held-keys` machinery."
   5)
 
+;; Value 9 sits AFTER the secret/switch cells (6-8) on purpose so the
+;; existing cell-* values are not renumbered when adding a 3rd keycard.
+(def cell-door-yellow
+  "Yellow-keyed door - see cell-door-blue."
+  9)
+
 (def cell-secret
   "Secret wall: looks and casts like a normal wall (raycaster treats
    it as solid, `wall?` returns true) but `passable?` returns false
@@ -70,7 +76,8 @@
    granted automatically by combat when the boss dies."
   {3 :blue
    4 :red
-   5 :boss})
+   5 :boss
+   9 :yellow})
 
 (def default-grid
   "16×16 starter map kept around for deterministic tests."
@@ -393,6 +400,7 @@
 ;; Char map:
 ;;   '#' wall            '.' floor
 ;;   'D' unlocked door   'B' blue-locked door   'R' red-locked door
+;;   'Y' yellow-locked door
 ;;   'X' boss-locked door (unlocks when boss is killed)
 ;;   '@' floor + records [x y] as the player spawn (cell centre)
 ;;
@@ -409,6 +417,7 @@
    "B" cell-door-blue
    "R" cell-door-red
    "X" cell-door-boss
+   "Y" cell-door-yellow
    "S" cell-secret
    "T" cell-switch-off})
 

--- a/src/io/render/hud.phel
+++ b/src/io/render/hud.phel
@@ -1,7 +1,7 @@
 ;; HUD + menu text: minimap, debug line, help menu, settings panel.
 (ns phel-doom.io.render.hud
   (:require phel-doom.io.render.buffer :refer [buf-mk buf-set buf-get buf-push])
-  (:require phel-doom.io.render.palette :refer [enemy-marker heart-marker ammo-marker berserk-marker invuln-marker soulsphere-marker armor-shard-marker backpack-marker keycard-blue-marker keycard-red-marker door-blue-marker door-red-marker shotgun-pickup-marker chaingun-pickup-marker boss-door-marker])
+  (:require phel-doom.io.render.palette :refer [enemy-marker heart-marker ammo-marker berserk-marker invuln-marker soulsphere-marker armor-shard-marker backpack-marker keycard-blue-marker keycard-red-marker keycard-yellow-marker door-blue-marker door-red-marker door-yellow-marker shotgun-pickup-marker chaingun-pickup-marker boss-door-marker])
   (:require phel-doom.io.render.frame-math :refer [direction-char layout])
   (:require phel-doom.core.weapons :refer [weapon-order weapons])
   (:require phel-doom.core.settings :refer [page-fields])
@@ -120,6 +120,8 @@
                                           (fn [k] (php/=== (:colour k) :blue)))
         krmap               (scaled-cells (:keycards world) step out-w
                                           (fn [k] (php/=== (:colour k) :red)))
+        kymap               (scaled-cells (:keycards world) step out-w
+                                          (fn [k] (php/=== (:colour k) :yellow)))
         wsmap               (scaled-cells (:weapon-pickups world) step out-w
                                           (fn [w] (php/=== (:weapon w) :shotgun)))
         wcmap               (scaled-cells (:weapon-pickups world) step out-w
@@ -137,10 +139,10 @@
                                         :else                                    (recur (php/+ dc 1))))) true
                                   :else (recur (php/+ dr 1)))))
         sample-cell         (fn [r0 c0]
-                              ;; Priority: wall (1) > any door (2/3/4/5) >
+                              ;; Priority: wall (1) > any door (2/3/4/5/9) >
                               ;; switch (7 / 8) > floor (0). Door + switch
                               ;; variants flow through so minimap-rows can
-                              ;; paint blue/red/boss + switch-on/off
+                              ;; paint blue/red/yellow/boss + switch-on/off
                               ;; markers distinct from each other.
                               (loop [dr 0 found 0]
                                 (if (php/>= dr step)
@@ -157,7 +159,8 @@
                                                          (php/=== cell 4)
                                                          (php/=== cell 5)
                                                          (php/=== cell 7)
-                                                         (php/=== cell 8)) (recur (php/+ dc 1) cell)
+                                                         (php/=== cell 8)
+                                                         (php/=== cell 9)) (recur (php/+ dc 1) cell)
                                                      :else            (recur (php/+ dc 1) acc)))))]
                                     (cond
                                       (php/=== v 1) 1
@@ -166,7 +169,8 @@
                                           (php/=== v 4)
                                           (php/=== v 5)
                                           (php/=== v 7)
-                                          (php/=== v 8)) (recur (php/+ dr 1) v)
+                                          (php/=== v 8)
+                                          (php/=== v 9)) (recur (php/+ dr 1) v)
                                       :else         (recur (php/+ dr 1) found))))))]
     (loop [row 0]
       (when (php/< row out-h)
@@ -185,6 +189,7 @@
                             (php/=== 2 cell)                              door-glyph
                             (php/=== 3 cell)                              door-blue-marker
                             (php/=== 4 cell)                              door-red-marker
+                            (php/=== 9 cell)                              door-yellow-marker
                             (php/=== 5 cell)                              boss-door-marker
                             (php/=== 7 cell)                              minimap-switch-off
                             (php/=== 8 cell)                              minimap-switch-on
@@ -198,6 +203,7 @@
                             (buf-get pmap (php/+ (php/* row out-w) col))  backpack-marker
                             (buf-get kbmap (php/+ (php/* row out-w) col)) keycard-blue-marker
                             (buf-get krmap (php/+ (php/* row out-w) col)) keycard-red-marker
+                            (buf-get kymap (php/+ (php/* row out-w) col)) keycard-yellow-marker
                             (buf-get wsmap (php/+ (php/* row out-w) col)) shotgun-pickup-marker
                             (buf-get wcmap (php/+ (php/* row out-w) col)) chaingun-pickup-marker
                             :else                                         minimap-floor)))
@@ -434,12 +440,19 @@
         ;; or bold from `\e[1;…m` — stays sticky and the closing `│`
         ;; border on the keys/buffs rows renders gray instead of the
         ;; menu's bright white.
-        keys-str      (cond
-                        (and (contains? held :blue) (contains? held :red))
-                        "\e[94;1mblue\e[22;40;97m  \e[91;1mred\e[22;40;97m"
-                        (contains? held :blue)                             "\e[94;1mblue\e[22;40;97m"
-                        (contains? held :red)                              "\e[91;1mred\e[22;40;97m"
-                        :else                                              "\e[2;90m(none)\e[22;40;97m")
+        ;; Enumerate every held keycard colour in a fixed order, each
+        ;; tagged with its own SGR, joined by two spaces. Blue-only,
+        ;; red-only, and blue+red keep their exact prior byte output;
+        ;; yellow slots in last. Falls back to dim `(none)` when the
+        ;; player holds no keys.
+        held-key-tags (apply vector
+                             (filter (fn [s] (not (php/=== s nil)))
+                                     [(when (contains? held :blue) "\e[94;1mblue\e[22;40;97m")
+                                      (when (contains? held :red) "\e[91;1mred\e[22;40;97m")
+                                      (when (contains? held :yellow) "\e[93;1myellow\e[22;40;97m")]))
+        keys-str      (if (php/=== (count held-key-tags) 0)
+                        "\e[2;90m(none)\e[22;40;97m"
+                        (php/implode "  " (to-php-array held-key-tags)))
         buffs-str     (let [chunks (apply vector
                                           (filter (fn [s] (not (php/=== s nil)))
                                                   [(when (php/> bsec 0.0)
@@ -489,7 +502,7 @@
                         (bord "  Top E S W N strip tints the letter")
                         (bord "  pointing at your next quest target:")
                         (bord "    \e[38;5;214;1morange\e[40;97m = exit door")
-                        (bord "    \e[94;1mblue\e[40;97m / \e[91;1mred\e[40;97m = keycard (locked door)")
+                        (bord "    \e[94;1mblue\e[40;97m / \e[91;1mred\e[40;97m / \e[93;1myellow\e[40;97m = keycard")
                         (bord "  Use it to navigate without the 2D map.")])
         controls-rows (to-php-array
                        [blnk

--- a/src/io/render/main.phel
+++ b/src/io/render/main.phel
@@ -2,7 +2,7 @@
 ;; perf snapshot, and the end / menu screens.
 (ns phel-doom.io.render.main
   (:require phel-doom.io.render.buffer :refer [buf-mk buf-set buf-get buf-push])
-  (:require phel-doom.io.render.palette :refer [sky floor enemy-head enemy-body door-shade boss-door-shade sky-code floor-code door-code boss-door-code sprite-shadow heart-shade heart-shade-bright heart-glyph heart-glyph-bright armor-shade armor-shade-bright armor-glyph armor-glyph-bright armor-shard-shade armor-shard-shade-bright armor-shard-glyph armor-shard-glyph-bright ammo-shade ammo-shade-bright ammo-glyph ammo-glyph-bright berserk-shade berserk-shade-bright berserk-glyph berserk-glyph-bright invuln-shade invuln-shade-bright invuln-glyph invuln-glyph-bright soulsphere-shade soulsphere-shade-bright soulsphere-glyph soulsphere-glyph-bright backpack-shade backpack-shade-bright backpack-glyph backpack-glyph-bright shotgun-pickup-shade shotgun-pickup-bright shotgun-pickup-glyph shotgun-pickup-glyph-bright chaingun-pickup-shade chaingun-pickup-bright chaingun-pickup-glyph chaingun-pickup-glyph-bright bfg-pickup-shade bfg-pickup-bright bfg-pickup-glyph bfg-pickup-glyph-bright incinerator-pickup-shade incinerator-pickup-bright incinerator-pickup-glyph incinerator-pickup-glyph-bright rocket-pickup-shade rocket-pickup-bright rocket-pickup-glyph rocket-pickup-glyph-bright keycard-blue-shade keycard-blue-bright keycard-blue-glyph keycard-blue-glyph-bright keycard-red-shade keycard-red-bright keycard-red-glyph keycard-red-glyph-bright char-aspect shade-table shade-code-table shade-table-blood shade-code-table-blood])
+  (:require phel-doom.io.render.palette :refer [sky floor enemy-head enemy-body door-shade boss-door-shade sky-code floor-code door-code boss-door-code sprite-shadow heart-shade heart-shade-bright heart-glyph heart-glyph-bright armor-shade armor-shade-bright armor-glyph armor-glyph-bright armor-shard-shade armor-shard-shade-bright armor-shard-glyph armor-shard-glyph-bright ammo-shade ammo-shade-bright ammo-glyph ammo-glyph-bright berserk-shade berserk-shade-bright berserk-glyph berserk-glyph-bright invuln-shade invuln-shade-bright invuln-glyph invuln-glyph-bright soulsphere-shade soulsphere-shade-bright soulsphere-glyph soulsphere-glyph-bright backpack-shade backpack-shade-bright backpack-glyph backpack-glyph-bright shotgun-pickup-shade shotgun-pickup-bright shotgun-pickup-glyph shotgun-pickup-glyph-bright chaingun-pickup-shade chaingun-pickup-bright chaingun-pickup-glyph chaingun-pickup-glyph-bright bfg-pickup-shade bfg-pickup-bright bfg-pickup-glyph bfg-pickup-glyph-bright incinerator-pickup-shade incinerator-pickup-bright incinerator-pickup-glyph incinerator-pickup-glyph-bright rocket-pickup-shade rocket-pickup-bright rocket-pickup-glyph rocket-pickup-glyph-bright keycard-blue-shade keycard-blue-bright keycard-blue-glyph keycard-blue-glyph-bright keycard-red-shade keycard-red-bright keycard-red-glyph keycard-red-glyph-bright keycard-yellow-shade keycard-yellow-bright keycard-yellow-glyph keycard-yellow-glyph-bright char-aspect shade-table shade-code-table shade-table-blood shade-code-table-blood])
   (:require phel-doom.io.render.frame-math :refer [enemy-shade-string enemy-textured-shade-string boss-col-paint aggro-distance enemy-aggro-head-string build-horizon-gradient build-themed-gradient build-horizon-gradient-codes build-themed-gradient-codes collect-enemy-projs layout pulse visuals-for-type enemy-front-visible-at?])
   (:require phel-doom.io.render.hud :refer [minimap-door minimap-door-pulse minimap-rows hud-debug-line hud-line-str help-menu-string settings-menu-string])
   (:require phel-doom.io.render.paint :refer [paint-face-overlay paint-wall-lights paint-crosshair paint-intro-splash paint-locked-bump paint-door-face paint-blood-drops paint-rear-warning paint-low-ammo paint-reload-reminder paint-save-flash paint-game-info paint-berserk-badge paint-invuln-badge paint-empty-click paint-flicker paint-heartbeat-vignette paint-hit-vignette paint-berserk-tint paint-heat-bar paint-kill-streak paint-compass paint-enemy-hp-flashes paint-hearts-hud paint-pistol-hud paint-blood-fx-into paint-pickups-into paint-projectiles-into build-blood-cols])
@@ -105,7 +105,7 @@
                 (buf-set bot-edge    col (str "\e[48;5;" flr-edge-c ";38;5;" boss-door-code-now "m▀"))
                 (buf-set top-shadow  col boss-door-shade-now)
                 (buf-set bot-shadow  col boss-door-shade-now))
-            (or (php/=== 2 h) (php/=== 3 h) (php/=== 4 h))
+            (or (php/=== 2 h) (php/=== 3 h) (php/=== 4 h) (php/=== 9 h))
             (do (buf-set normal      col door-shade-now)
                 (buf-set top-edge    col (str "\e[48;5;" door-code-now ";38;5;" sky-edge-c "m▀"))
                 (buf-set bot-edge    col (str "\e[48;5;" flr-edge-c ";38;5;" door-code-now "m▀"))
@@ -323,6 +323,8 @@
         keycard-blue-glyph-now             (if keycard-bright? keycard-blue-glyph-bright keycard-blue-glyph)
         keycard-red-shade-now              (if keycard-bright? keycard-red-bright keycard-red-shade)
         keycard-red-glyph-now              (if keycard-bright? keycard-red-glyph-bright keycard-red-glyph)
+        keycard-yellow-shade-now           (if keycard-bright? keycard-yellow-bright keycard-yellow-shade)
+        keycard-yellow-glyph-now           (if keycard-bright? keycard-yellow-glyph-bright keycard-yellow-glyph)
         weapon-pickup-bright?              (pulse t pulse-freq-weapon-pickup)
         shotgun-pickup-shade-now           (if weapon-pickup-bright? shotgun-pickup-bright shotgun-pickup-shade)
         shotgun-pickup-glyph-now           (if weapon-pickup-bright? shotgun-pickup-glyph-bright shotgun-pickup-glyph)
@@ -572,7 +574,13 @@
                                                         (or (:keycards world) [])))
                                          (:player world) dists edists vw vh
                                          keycard-red-shade-now keycard-red-glyph-now)
-          bp-ws     (paint-pickups-into  bp-kr
+          bp-ky     (paint-pickups-into  bp-kr
+                                         (apply vector
+                                                (filter (fn [k] (php/=== (:colour k) :yellow))
+                                                        (or (:keycards world) [])))
+                                         (:player world) dists edists vw vh
+                                         keycard-yellow-shade-now keycard-yellow-glyph-now)
+          bp-ws     (paint-pickups-into  bp-ky
                                          (apply vector
                                                 (filter (fn [w] (php/=== (:weapon w) :shotgun))
                                                         (or (:weapon-pickups world) [])))

--- a/src/io/render/paint.phel
+++ b/src/io/render/paint.phel
@@ -113,7 +113,7 @@
 
 (defn paint-intro-splash
   "Centred banner showing 'LEVEL N · NAME' while :intro-secs > 0.
-   On locked levels (L4 blue / L5 red) appends a 'FIND THE <COLOUR>
+   On locked levels (L4 blue / L5 red / L7 yellow) appends a 'FIND THE <COLOUR>
    KEY' subtitle so the player knows the door at the exit needs a
    keycard before they go hunting for it. Subtitle SGR matches the
    lock colour so the cue reads at a glance."
@@ -123,15 +123,17 @@
                         " · " (php/strtoupper (or (get stats :level-name) "")))
           lock     (get stats :door-lock)
           subtitle (cond
-                     (php/=== lock :blue) "FIND THE BLUE KEY"
-                     (php/=== lock :red)  "FIND THE RED KEY"
-                     (php/=== lock :boss) "KILL THE BOSS TO ESCAPE"
-                     :else                nil)
+                     (php/=== lock :blue)   "FIND THE BLUE KEY"
+                     (php/=== lock :red)    "FIND THE RED KEY"
+                     (php/=== lock :yellow) "FIND THE YELLOW KEY"
+                     (php/=== lock :boss)   "KILL THE BOSS TO ESCAPE"
+                     :else                  nil)
           sub-sgr  (cond
-                     (php/=== lock :blue) "\e[40;94;1m"
-                     (php/=== lock :red)  "\e[40;91;1m"
-                     (php/=== lock :boss) "\e[40;38;5;196;1m"
-                     :else                "\e[40;93;1m")
+                     (php/=== lock :blue)   "\e[40;94;1m"
+                     (php/=== lock :red)    "\e[40;91;1m"
+                     (php/=== lock :yellow) "\e[40;93;1m"
+                     (php/=== lock :boss)   "\e[40;38;5;196;1m"
+                     :else                  "\e[40;93;1m")
           ;; Box width sized to the longer of title / subtitle so
           ;; both lines fit symmetrically with the same 4-col pad.
           inner    (php/max (php/mb_strlen title)
@@ -171,15 +173,17 @@
     (when (php/> secs 0.0)
       (let [colour (get stats :locked-door-bump-colour)
             label  (cond
-                     (php/=== colour :blue) "  ⚿  NEED BLUE KEY  ⚿  "
-                     (php/=== colour :red)  "  ⚿  NEED RED KEY  ⚿   "
-                     (php/=== colour :boss) "  ☠  KILL THE BOSS  ☠  "
-                     :else                  "  ⚿  NEED KEY  ⚿  ")
+                     (php/=== colour :blue)   "  ⚿  NEED BLUE KEY  ⚿  "
+                     (php/=== colour :red)    "  ⚿  NEED RED KEY  ⚿   "
+                     (php/=== colour :yellow) "  ⚿  NEED YELLOW KEY  ⚿"
+                     (php/=== colour :boss)   "  ☠  KILL THE BOSS  ☠  "
+                     :else                    "  ⚿  NEED KEY  ⚿  ")
             sgr    (cond
-                     (php/=== colour :blue) "\e[40;94;1m"
-                     (php/=== colour :red)  "\e[40;91;1m"
-                     (php/=== colour :boss) "\e[40;38;5;196;1m"
-                     :else                  "\e[40;93;1m")
+                     (php/=== colour :blue)   "\e[40;94;1m"
+                     (php/=== colour :red)    "\e[40;91;1m"
+                     (php/=== colour :yellow) "\e[40;93;1m"
+                     (php/=== colour :boss)   "\e[40;38;5;196;1m"
+                     :else                    "\e[40;93;1m")
             row    (php/max 1 (php/intdiv vh 3))
             col0   (php/max 1 (php/- (php/+ (php/intdiv vw 2) 1)
                                      (php/intdiv (php/mb_strlen label) 2)))]
@@ -431,8 +435,9 @@
                    (php/=== diff :nightmare) "\e[40m \e[40;31;1m[nightmare]\e[40;97m"
                    :else                     "")
         keys'    (or (get stats :held-keys) #{})
-        keys-tag (str (if (contains? keys' :blue) "\e[40m \e[40;94;1m⚿\e[40;97m" "")
-                      (if (contains? keys' :red)  "\e[40m \e[40;91;1m⚿\e[40;97m" ""))
+        keys-tag (str (if (contains? keys' :blue)   "\e[40m \e[40;94;1m⚿\e[40;97m" "")
+                      (if (contains? keys' :red)    "\e[40m \e[40;91;1m⚿\e[40;97m" "")
+                      (if (contains? keys' :yellow) "\e[40m \e[40;93;1m⚿\e[40;97m" ""))
         sta-chip (stamina-chip stats)
         ;; Same wash-preserving pattern for the inline mag / reserve
         ;; recolours: replace bare \e[0m resets with \e[40;97m so
@@ -671,7 +676,8 @@
 (defn- quest-target-hint
   "Compass directional helper. Returns `{:sector 0..3 :tag kw}`
    where `:tag` is:
-     :blue / :red  — point at the matching un-picked keycard on a
+     :blue / :red / :yellow
+                   — point at the matching un-picked keycard on a
                      locked level (player still needs the key)
      :door         — point at the exit door (the key is already in
                      hand, or the level was never locked)
@@ -706,7 +712,7 @@
   "Top-centre 4-letter cardinal strip. Three highlights stack:
      - yellow bold = player's facing sector (always shown)
      - tinted bold = QUEST TARGET sector — points at the keycard
-       (blue / red, lock colour) on locked levels until the player
+       (blue / red / yellow, lock colour) on locked levels until the player
        grabs the card, then switches to the exit door (orange,
        SGR 214 to match the in-world door glyph).
    Quest tint wins over facing tint on the same letter so the cue
@@ -718,10 +724,11 @@
         quest  (quest-target-hint world)
         q-sec  (when quest (:sector quest))
         q-sgr  (cond
-                 (php/=== (and quest (:tag quest)) :blue) "\e[40;94;1m"
-                 (php/=== (and quest (:tag quest)) :red)  "\e[40;91;1m"
-                 (php/=== (and quest (:tag quest)) :door) "\e[40;38;5;214;1m"
-                 :else                                    nil)
+                 (php/=== (and quest (:tag quest)) :blue)   "\e[40;94;1m"
+                 (php/=== (and quest (:tag quest)) :red)    "\e[40;91;1m"
+                 (php/=== (and quest (:tag quest)) :yellow) "\e[40;93;1m"
+                 (php/=== (and quest (:tag quest)) :door)   "\e[40;38;5;214;1m"
+                 :else                                      nil)
         labels ["E" "S" "W" "N"]
         cells  (loop [i 0 acc ""]
                  (if (php/>= i 4)

--- a/src/io/render/palette.phel
+++ b/src/io/render/palette.phel
@@ -35,8 +35,10 @@
 (def backpack-marker "\e[40;33;1mP\e[0m")
 (def keycard-blue-marker "\e[40;94;1mk\e[0m")
 (def keycard-red-marker  "\e[40;91;1mk\e[0m")
+(def keycard-yellow-marker "\e[40;93;1mk\e[0m")
 (def door-blue-marker    "\e[40;94;1m▌\e[0m")
 (def door-red-marker     "\e[40;91;1m▌\e[0m")
+(def door-yellow-marker  "\e[40;93;1m▌\e[0m")
 (def shotgun-pickup-marker  "\e[40;33;1mS\e[0m")
 (def chaingun-pickup-marker "\e[40;32;1mC\e[0m")
 
@@ -284,6 +286,19 @@
 (def keycard-red-bright  "\e[48;5;124m ")
 (def keycard-red-glyph   "\e[48;5;52;38;5;231;1m⚿")
 (def keycard-red-glyph-bright "\e[48;5;124;38;5;231;1m⚿")
+(def keycard-yellow-shade
+  "Yellow keycard sprite idle frame: dim yellow BG."
+  "\e[48;5;100m ")
+(def keycard-yellow-bright
+  "Yellow keycard sprite pulse frame: brighter yellow BG flare."
+  "\e[48;5;184m ")
+(def keycard-yellow-glyph
+  "Yellow keycard ⚿ glyph on the dim yellow BG. FG is dark (16) rather
+   than white so the icon keeps contrast against the bright yellow."
+  "\e[48;5;100;38;5;16;1m⚿")
+(def keycard-yellow-glyph-bright
+  "Pulse frame: yellow keycard ⚿ in dark (16) FG on the bright yellow BG."
+  "\e[48;5;184;38;5;16;1m⚿")
 (def char-aspect 2.0)
 (def base-hud-rows 1)
 

--- a/tests/core/keycards-test.phel
+++ b/tests/core/keycards-test.phel
@@ -1,6 +1,6 @@
 (ns phel-doom-tests.core.keycards-test
   (:require phel.test :refer [deftest is])
-  (:require phel-doom.core.map :refer [cell-door-boss door-lock door? find-door-cell missing-key-for parse-layout passable? wall?]))
+  (:require phel-doom.core.map :refer [cell-door-boss cell-door-yellow door-lock door? find-door-cell missing-key-for parse-layout passable? wall?]))
 
 (def grid-with-doors
   ;; Row 1: wall, cell-door, cell-door-blue, cell-door-red, wall.
@@ -109,3 +109,40 @@
                            "#####"])
         g   (:grid out)]
     (is (= cell-door-boss (get-in g [1 4])))))
+
+;; ---------------------------------------------------------------------
+;; Yellow-locked door (cell-door-yellow = 9). The third physical
+;; keycard colour: a yellow keycard spawns on its level, and picking it
+;; up conj's `:yellow` into :held-keys. The standard passable? /
+;; missing-key-for / door? machinery then unlocks it via the same flow
+;; as :blue / :red. Gates the Level 7 exit.
+;; ---------------------------------------------------------------------
+
+(def grid-with-yellow-door
+  [[1 1 1 1 1]
+   [1 0 0 0 9]   ; cell-door-yellow at (4, 1)
+   [1 1 1 1 1]])
+
+(deftest test-yellow-door-is-a-door
+  (is (= true (door? grid-with-yellow-door 4 1))))
+
+(deftest test-yellow-door-lock-returns-yellow-kw
+  (is (= :yellow (door-lock grid-with-yellow-door 4 1))))
+
+(deftest test-yellow-door-blocks-without-key
+  (is (= false (passable? grid-with-yellow-door #{} 4 1)))
+  (is (= false (passable? grid-with-yellow-door #{:blue :red} 4 1))))
+
+(deftest test-yellow-door-opens-with-yellow-key
+  (is (= true (passable? grid-with-yellow-door #{:yellow} 4 1))))
+
+(deftest test-missing-key-for-yellow-door
+  (is (= :yellow (missing-key-for grid-with-yellow-door #{} 4 1)))
+  (is (= nil     (missing-key-for grid-with-yellow-door #{:yellow} 4 1))))
+
+(deftest test-parse-layout-y-char-produces-yellow-door
+  (let [out (parse-layout ["#####"
+                           "#.@.Y"
+                           "#####"])
+        g   (:grid out)]
+    (is (= cell-door-yellow (get-in g [1 4])))))


### PR DESCRIPTION
## What

Adds a **yellow keycard** as the third colour, completing the classic DOOM blue/yellow/red triad:

- **L4** blue · **L5** red · **L7** yellow

Level 7 (revenants) now spawns a yellow keycard and locks its exit door until the player holds it - same mechanic as the existing L4/L5 locked levels.

## How

`cell-door-yellow = 9` flows through the generic `lock-colours` machinery (`passable?` / `door-lock` / `missing-key-for` needed no per-colour branches). Render layer wires the rest:

| Layer | Change |
|-------|--------|
| `map.phel` | `cell-door-yellow` = 9, `lock-colours` 9→:yellow, `"Y"` layout glyph |
| `level.phel` | `lock-cell-for` :yellow, L7 `:door-lock :yellow` |
| `palette.phel` | yellow keycard sprite (256-color 100/184, dark-16 fg) + minimap markers |
| `main.phel` | pulse wiring, pickup paint chain, cell-9 in 3D door branch |
| `hud.phel` | minimap kymap/door/keycard markers, keys-str refactor (any blue/red/yellow combo) |
| `paint.phel` | intro splash, bump nag, held-keys tag, compass quest tint |

3D doors intentionally do not tint by lock colour (only minimap/HUD/splash convey it), so no new 3D door shade.

## Note

Locked levels skip procgen secret-seeding (existing `(not lock)` guard), so **L7 no longer auto-seeds its 2 random secrets** - consistent with L4/L5.

## Tests

- New yellow coverage in `keycards-test.phel` (door?, door-lock, passable?, missing-key-for, `"Y"` parse-layout).
- Full suite: **1711/1711 pass**, format clean.