### PR TITLE
fix(audio): respect SFX volume setting + scale fire report by enemy distance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,13 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 
 - Level 7 now has a yellow-keyed locked exit and a yellow keycard pickup - the third keycard colour (classic DOOM blue/yellow/red).
 
+### Fixed
+
+- SFX volume setting is now respected: the audio probe no longer wiped the player's SFX scalar back to full volume on the first sound, so weapon fire stayed loud even at a low SFX percent. Shots now play at the configured level relative to the music bed.
+
 ### Changed
 
+- The weapon fire report is now distance-attenuated by the enemy you hit: a point-blank hit plays at full volume, a far hit is quieter (down to a ~0.1 audible floor), and a clean miss stays at full volume. All scaled by your SFX setting, so a distant firefight reads quieter than one in your face.
 - Internal maintainability pass (no gameplay change): the 3564-line `render.phel` is split into a thin public facade plus focused `render/{buffer,palette,frame-math,hud,paint,main}` namespaces; all in-tick sound effects (pickups, interactions, reload) now flow through the pure `:sfx` queue so `tick-world` is fully effect-free; render pulse cadences and the near-death haze ramp are named constants; and the docstring convention, engine cache rationale, and `enemy` / `enemy-ai` split are documented. Behaviour is identical.
 
 ## [0.10.0] - 2026-06-03

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,16 +11,16 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 
 ### Added
 
-- Level 7 now has a yellow-keyed locked exit and a yellow keycard pickup - the third keycard colour (classic DOOM blue/yellow/red).
-
-### Fixed
-
-- SFX volume setting is now respected: the audio probe no longer wiped the player's SFX scalar back to full volume on the first sound, so weapon fire stayed loud even at a low SFX percent. Shots now play at the configured level relative to the music bed.
+- Level 7: a yellow-keyed locked exit and a yellow keycard pickup - the third keycard colour (classic DOOM blue/yellow/red).
 
 ### Changed
 
-- The weapon fire report is now distance-attenuated by the enemy you hit: a point-blank hit plays at full volume, a far hit is quieter (down to a ~0.1 audible floor), and a clean miss stays at full volume. All scaled by your SFX setting, so a distant firefight reads quieter than one in your face.
-- Internal maintainability pass (no gameplay change): the 3564-line `render.phel` is split into a thin public facade plus focused `render/{buffer,palette,frame-math,hud,paint,main}` namespaces; all in-tick sound effects (pickups, interactions, reload) now flow through the pure `:sfx` queue so `tick-world` is fully effect-free; render pulse cadences and the near-death haze ramp are named constants; and the docstring convention, engine cache rationale, and `enemy` / `enemy-ai` split are documented. Behaviour is identical.
+- Weapon fire report is distance-attenuated by the enemy hit: full volume point-blank, down to a ~0.1 floor when far, full on a clean miss. Scaled by your SFX setting.
+- Maintainability pass (no gameplay change): `render.phel` split into a facade plus `render/{buffer,palette,frame-math,hud,paint,main}`; all in-tick sfx flow through the pure `:sfx` queue so `tick-world` is effect-free; pulse cadences and the near-death haze ramp are named constants; docstring, engine-cache, and `enemy` / `enemy-ai` split conventions documented.
+
+### Fixed
+
+- SFX volume setting is respected: the audio probe no longer resets the SFX scalar to full on the first sound, so shots stayed loud at low SFX %. Now scaled correctly against the music bed.
 
 ## [0.10.0] - 2026-06-03
 

--- a/docs/audio.md
+++ b/docs/audio.md
@@ -14,7 +14,7 @@ macOS maps to `.aiff`: Pop (pistol/kill), Blow (shotgun), Morse (chaingun), Purr
 
 ## Per-weapon fire report
 
-Every shot plays the weapon's `:fire-sfx` unconditionally (hit or miss). Kill cue (`:kill`) layers on top, distance-attenuated. Wounds ride on fire report + floating HP digit + blood, no separate sound.
+Every shot plays the weapon's `:fire-sfx` unconditionally (hit or miss). The report is distance-attenuated by the struck enemy: a point-blank hit plays at full volume, a far hit drops toward the `distance-volume` floor (~0.1), and a clean miss plays at full volume (no enemy to reference, the gun is in your hands). Kill cue (`:kill`) layers on top at the same distance volume. Wounds ride on the fire report + floating HP digit + blood, no separate sound. All volumes are still multiplied by the global SFX scalar, so they stay relative to the SFX max set in options.
 
 ## Async firing + control
 
@@ -24,7 +24,7 @@ Each call shells out backgrounded (`&`). N key toggles `:sound-on`; mute is inst
 
 The settings page (see `docs/settings.md`) drives two levels via `afplay -v` (macOS only; other players ignore `-v`):
 
-- SFX: `set-sfx-scalar!` stores a 0..1 multiplier on the sound state atom; `play-sfx!` scales every event volume by it. 0 mutes sfx with no bell fallback.
+- SFX: `set-sfx-scalar!` stores a 0..1 multiplier on the sound state atom; `play-sfx!` scales every event volume by it. 0 mutes sfx with no bell fallback. The one-shot audio probe (`ensure-probed!`) merges into the state atom rather than replacing it, so it never wipes a scalar the settings page set before the first sound.
 - Music: `set-music-volume!` updates the drone `-v` and restarts the loop so the change is immediate. 0 stops the bed.
 
 ## Ambient drone

--- a/src/core/combat.phel
+++ b/src/core/combat.phel
@@ -626,25 +626,33 @@
   "Append the shot's sound events to `out`'s :sfx queue and return it.
    `src` is the pre-shot world (active weapon spec + player position).
 
-   Always queue the ACTIVE weapon's own report so every trigger pull
-   sounds like the gun going off — hit or miss. Earlier this only
-   played a gun sound on a MISS; a shot that connected swapped in the
-   enemy reaction, so the weapon (esp. the shotgun) felt silent when
-   you actually hit something. Per-weapon `:fire-sfx` (weapons spec)
-   gives each gun a distinct voice; falls back to :shoot.
+   The fire report is distance-attenuated by how far the struck enemy is
+   from the player (`distance-volume`): a point-blank hit plays at full
+   volume, a far hit drops toward the ~0.1 floor so a distant firefight
+   reads quieter than one in your face. A MISS (`hit?` false) has no
+   enemy to reference, so the gun plays at full volume — it is in your
+   hands. Every volume here is later multiplied by the player's global
+   SFX scalar in io/sound, so it stays relative to the SFX max set in
+   options.
 
-   On a kill, layer the kill cue ON TOP of the fire report so a kill
-   keeps its punch, distance-attenuated. Wounds ride on the fire sound
-   plus the floating HP digit + blood splatter — no separate thud."
-  [out src killed? hit-pos]
-  (let [fired (push-sfx out (or (:fire-sfx (w-spec src)) :shoot) 1.0)]
-    (if killed?
-      (let [p  (:player src)
-            dx (php/- (:x hit-pos) (:x p))
-            dy (php/- (:y hit-pos) (:y p))
-            d  (php/sqrt (php/+ (php/* dx dx) (php/* dy dy)))]
-        (push-sfx fired :kill (distance-volume d)))
-      fired)))
+   Always queue the ACTIVE weapon's own report so every trigger pull
+   sounds like the gun going off — hit or miss. Per-weapon `:fire-sfx`
+   (weapons spec) gives each gun a distinct voice; falls back to :shoot.
+
+   On a kill, layer the kill cue ON TOP of the fire report at the same
+   distance volume so a kill keeps its punch. Wounds ride on the fire
+   sound plus the floating HP digit + blood splatter — no separate thud."
+  [out src hit? killed? hit-pos]
+  (let [fire-sfx (or (:fire-sfx (w-spec src)) :shoot)]
+    (if hit?
+      (let [p     (:player src)
+            dx    (php/- (:x hit-pos) (:x p))
+            dy    (php/- (:y hit-pos) (:y p))
+            d     (php/sqrt (php/+ (php/* dx dx) (php/* dy dy)))
+            vol   (distance-volume d)
+            fired (push-sfx out fire-sfx vol)]
+        (if killed? (push-sfx fired :kill vol) fired))
+      (push-sfx out fire-sfx 1.0))))
 
 (defn can-fire?
   "True when the active weapon is ready: cooldown elapsed, not jammed,
@@ -771,9 +779,12 @@
                        (assoc unlocked :hit-stop-secs
                               (if boss-killed? hit-stop-boss-seconds hit-stop-tough-seconds))
                        unlocked)]
+    ;; bfg has no wound-only signal (splash returns just a kill count), so
+    ;; a kill is the hit proxy: a killing blast attenuates by the impact
+    ;; distance, a wall hit / whiff plays at full volume.
     (enqueue-shot-sfx
      (apply-heat (push-blood-fx (assoc juiced :fire-anim fire-anim-seconds) hit-pos))
-     world killed? hit-pos)))
+     world killed? killed? hit-pos)))
 
 (defn- finish-multikill
   "Shared tail for the multi-target hitscans (`pierce-fire`,
@@ -813,7 +824,7 @@
         based        (assoc juiced :fire-anim fire-anim-seconds)]
     (enqueue-shot-sfx
      (apply-heat (if hit? (push-blood-fx based hit-pos) based))
-     world killed? (or hit-pos {:x (:x p) :y (:y p)}))))
+     world hit? killed? (or hit-pos {:x (:x p) :y (:y p)}))))
 
 (defn- pierce-fire
   "Resolve a piercing shot (weapons flagged `:pierce?`, the pistol). The
@@ -877,7 +888,7 @@
        (apply-heat (if hit?
                      (on-shot-hit world woken hit-pos idx)
                      (on-shot-miss (assoc world :enemies woken))))
-       world killed? hit-pos))))
+       world hit? killed? hit-pos))))
 
 (defn- empty-trigger-pull
   "Trigger pulled while mag = 0 AND no cooldown / jam in the way. Arm

--- a/src/io/sound.phel
+++ b/src/io/sound.phel
@@ -102,9 +102,14 @@
 (defn- ensure-probed! []
   (let [s @state]
     (when (not (:probed s))
-      (reset! state {:player (resolve-player)
-                     :sounds (resolve-sounds)
-                     :probed true}))))
+      ;; merge, not reset!: the probe must NOT clobber :sfx-scalar /
+      ;; :mute-until. apply-audio-settings! runs set-sfx-scalar! BEFORE
+      ;; the first probe (start-ambient! -> audio-player -> here), so a
+      ;; reset! here would wipe the player's SFX volume back to 1.0 and
+      ;; every shot would play at full volume regardless of the setting.
+      (swap! state merge {:player (resolve-player)
+                          :sounds (resolve-sounds)
+                          :probed true}))))
 
 (defn- play-file-async!
   "Fire-and-forget shell-out to the resolved audio player. Optional

--- a/tests/core/combat-test.phel
+++ b/tests/core/combat-test.phel
@@ -1,6 +1,7 @@
 (ns phel-doom-tests.core.combat-test
   (:require phel.test :refer [deftest is])
   (:require phel-doom.core.state :refer [new-world new-player max-lives])
+  (:require phel-doom.core.enemy :refer [new-enemy])
   (:require phel-doom.core.combat
             :refer [arm-berserk armory-reserve closest-attacker attacker-side berserk? berserk-damage-mul berserk-melee-mul berserk-mul-for berserk-seconds can-fire? apply-heat damage-step empty-click-seconds enemy-hit-damage hit-damage-for hit-player-at hit-stop-for hit-stop-tough-seconds hit-stop-boss-seconds invuln? invuln-seconds knockback mag-size pick-loot-weapon reload reloading? roll-loot-kind tick-armory tick-shooting]))
 
@@ -254,6 +255,55 @@
         w  (assoc w0 :mag 6 :weapon :pistol :fire-cooldown 0.0 :enemies [])
         w' (tick-shooting w true)]
     (is (pos? (count (:sfx w'))) "fire report queued")))
+
+;; ---------------------------------------------------------------------
+;; Fire-report volume is distance-attenuated by the struck enemy:
+;; close hit -> near full, far hit -> quieter, miss -> full (gun in hand).
+;; The chaingun is single-target (no pierce/spread/splash) so it exercises
+;; the primary hitscan path. Player at (1.5,1.5) faces +x down a corridor.
+;; ---------------------------------------------------------------------
+
+(def corridor-grid
+  [[1 1 1 1 1 1 1 1 1 1 1 1]
+   [1 0 0 0 0 0 0 0 0 0 0 1]
+   [1 1 1 1 1 1 1 1 1 1 1 1]])
+
+(defn- shoot-at-enemy [enemy-x]
+  ;; Fire the chaingun once down the corridor at a single enemy placed
+  ;; on the player's facing axis; return the queued :shoot-chaingun vol.
+  (let [base (new-world corridor-grid (new-player 1.5 1.5 0.0))
+        w    (assoc base
+                    :weapon        :chaingun
+                    :owned-weapons #{:chaingun}
+                    :mag           30
+                    :ammo-reserve  10
+                    :fire-cooldown 0.0
+                    :reload-cooldown 0.0
+                    :jam-secs      0.0
+                    :iframes       0.0
+                    :enemies       [(new-enemy enemy-x 1.5 1)])
+        w'   (tick-shooting w true)]
+    (:vol (first (sfx-named w' :shoot-chaingun)))))
+
+(deftest test-fire-report-louder-for-close-enemy
+  (let [close (shoot-at-enemy 3.5)    ; d = 2.0
+        far   (shoot-at-enemy 9.5)]   ; d = 8.0
+    (is (php/> close far) "closer enemy => louder shot")
+    (is (php/<= close 1.0))
+    (is (php/> far 0.1) "still above the audible floor at range")))
+
+(deftest test-fire-report-full-volume-on-miss
+  ;; No enemy on the axis: the gun is in your hands, plays at full SFX
+  ;; volume (the global scalar is applied later in io/sound).
+  (let [base (new-world corridor-grid (new-player 1.5 1.5 0.0))
+        w    (assoc base
+                    :weapon        :chaingun
+                    :owned-weapons #{:chaingun}
+                    :mag           30 :ammo-reserve 10
+                    :fire-cooldown 0.0 :reload-cooldown 0.0
+                    :jam-secs 0.0 :iframes 0.0 :enemies [])
+        w'   (tick-shooting w true)]
+    (is (= 1.0 (:vol (first (sfx-named w' :shoot-chaingun)))))))
 
 (deftest test-tick-shooting-empty-mag-skip-when-jammed
   ;; Jam already has its own visual cue (paint-door-face / fire-anim).

--- a/tests/io/sound-test.phel
+++ b/tests/io/sound-test.phel
@@ -1,6 +1,6 @@
 (ns phel-doom-tests.io.sound-test
   (:require phel.test :refer [deftest is])
-  (:require phel-doom.io.sound :refer [play-sfx! set-sfx-scalar! state]))
+  (:require phel-doom.io.sound :refer [play-sfx! set-sfx-scalar! audio-player state]))
 
 ;; play-sfx! returns nil under PHEL_DOOM_SILENT=1 — that's the
 ;; contract `composer test` relies on so the test suite never shells
@@ -48,3 +48,14 @@
   ;; Restore the default so other tests / the live game are unaffected.
   (set-sfx-scalar! 1.0)
   (is (= 1.0 (:sfx-scalar @state))))
+
+(deftest test-probe-preserves-sfx-scalar
+  ;; Regression: the live boot order is set-sfx-scalar! (from the player's
+  ;; SFX setting) THEN the first probe (start-ambient! -> audio-player ->
+  ;; ensure-probed!). The probe must merge, not reset!, or it wipes the
+  ;; scalar back to 1.0 and every shot plays at full volume — exactly the
+  ;; "SFX louder than music despite 10% SFX" bug.
+  (set-sfx-scalar! 0.1)
+  (audio-player)                       ; forces ensure-probed!
+  (is (= 0.1 (:sfx-scalar @state)) "probe must not clobber the SFX scalar")
+  (set-sfx-scalar! 1.0))


### PR DESCRIPTION
Two audio fixes.

## 1. SFX volume setting was ignored (`fix`)

At boot, `set-sfx-scalar!` stored your SFX % just before the first audio probe. `ensure-probed!` used `reset!` on the sound-state atom, wiping `:sfx-scalar` back to 1.0 - so shots played at full volume regardless of the slider.

Fix: probe with `swap! state merge`, not `reset!`. Keeps `:sfx-scalar` + `:mute-until`.

## 2. Fire report scales with enemy distance (`feat`)

Gunshot volume now tracks the hit enemy's range (`distance-volume` curve, same as the kill cue):

- Point-blank hit: full
- Far hit: down to ~0.1 floor
- Miss: full (gun in hand)

Still multiplied by your SFX scalar.

## Tests

`composer ci` green: 1716 tests, format/lint clean, build 68 files. New: probe keeps scalar, close hit louder than far, miss stays full. Docs + CHANGELOG updated.