### PR TITLE
feat(site): correct stats, expand features, redesign controls UI

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -128,15 +128,41 @@ section{padding:64px 0; border-top:1px solid var(--line)}
 .card h3 .ic{color:var(--red); font-size:18px}
 .card p{color:var(--dim); font-size:13.5px}
 
-/* ---- controls table ---- */
-.controls{display:grid; grid-template-columns:repeat(auto-fit,minmax(220px,1fr)); gap:10px}
-.kc{display:flex; align-items:center; gap:12px; background:var(--panel); border:1px solid var(--line); border-radius:6px; padding:12px 16px}
-.keys{display:flex; gap:5px; flex-wrap:wrap}
+/* ---- stat strip ---- */
+.stats{
+  display:grid; grid-template-columns:repeat(auto-fit,minmax(120px,1fr)); gap:1px;
+  background:var(--line); border:1px solid var(--line); border-radius:8px; overflow:hidden; margin-bottom:30px;
+}
+.stat{background:var(--panel); padding:18px 12px; text-align:center}
+.stat b{display:block; font-size:30px; color:var(--red); font-weight:800; line-height:1}
+.stat span{display:block; margin-top:6px; font-size:12px; color:var(--dim); letter-spacing:.5px}
+
+/* ---- controls ---- */
 kbd{
   font-family:var(--mono); font-size:12px; background:#1d1d1d; border:1px solid #333; border-bottom-width:2px;
-  border-radius:4px; padding:3px 7px; color:#fff; min-width:24px; text-align:center
+  border-radius:4px; padding:3px 7px; color:#fff; min-width:22px; text-align:center; white-space:nowrap;
 }
-.kc span{color:var(--dim); font-size:13px}
+/* featured movement panel + WASD cross cluster */
+.move-panel{
+  display:flex; align-items:center; gap:28px; flex-wrap:wrap;
+  background:var(--panel); border:1px solid var(--line); border-radius:10px; padding:22px 26px; margin-bottom:14px;
+}
+.wasd{display:grid; grid-template-columns:repeat(3,40px); grid-auto-rows:40px; gap:6px; flex-shrink:0}
+.wasd kbd{
+  width:40px; height:40px; min-width:0; padding:0; font-size:15px;
+  display:flex; align-items:center; justify-content:center;
+}
+.wasd .w{grid-area:1/2} .wasd .a{grid-area:2/1} .wasd .s{grid-area:2/2} .wasd .d{grid-area:2/3}
+.move-meta h3{color:#fff; font-size:19px; margin-bottom:5px}
+.move-meta p{color:var(--dim); font-size:14px; max-width:46ch}
+.move-meta kbd{font-size:11px; vertical-align:middle}
+.move-meta .arrows{color:var(--fg); letter-spacing:1px; margin:0 2px}
+.controls{display:grid; grid-template-columns:repeat(auto-fit,minmax(190px,1fr)); gap:12px}
+.kc{display:flex; align-items:center; gap:13px; background:var(--panel); border:1px solid var(--line); border-radius:8px; padding:13px 16px; transition:.15s}
+.kc:hover{border-color:var(--red-deep)}
+.kc .keys{display:flex; gap:5px; flex-wrap:nowrap; flex-shrink:0; align-items:center}
+.kc .dots{color:var(--dim); letter-spacing:1px}
+.kc .lbl{color:var(--dim); font-size:13.5px}
 
 /* ---- video ---- */
 .video{position:relative; aspect-ratio:16/9; border:1px solid var(--line); border-radius:8px; overflow:hidden; box-shadow:0 20px 50px rgba(0,0,0,.6)}
@@ -181,10 +207,12 @@ footer a{color:var(--fg)}
     </p>
 
     <div class="badges">
-      <span class="badge"><b>10</b> procgen levels</span>
-      <span class="badge"><b>5</b> monster types</span>
-      <span class="badge"><b>7</b> weapons</span>
-      <span class="badge"><b>~5ms</b> frame @120&times;30</span>
+      <span class="badge"><b>10</b> levels</span>
+      <span class="badge"><b>10</b> enemy types</span>
+      <span class="badge"><b>8</b> weapons</span>
+      <span class="badge"><b>4</b> difficulties</span>
+      <span class="badge"><b>256</b>-color ANSI</span>
+      <span class="badge"><b>~5ms</b> frame</span>
       <span class="badge">PHP <b>&ge;8.4</b></span>
     </div>
 
@@ -220,13 +248,28 @@ footer a{color:var(--fg)}
   <div class="wrap">
     <div class="sec-title">// what's inside</div>
     <h2 class="sec-h">More game than a terminal has any right to be.</h2>
+
+    <!-- verified stat strip -->
+    <div class="stats">
+      <div class="stat"><b>10</b><span>hand-tuned levels</span></div>
+      <div class="stat"><b>10</b><span>enemy types</span></div>
+      <div class="stat"><b>8</b><span>weapons</span></div>
+      <div class="stat"><b>6</b><span>AI states</span></div>
+      <div class="stat"><b>8</b><span>pickup types</span></div>
+      <div class="stat"><b>9</b><span>save slots</span></div>
+    </div>
+
     <div class="grid">
-      <div class="card"><h3><span class="ic">&#9636;</span>Raycast engine</h3><p>256-color DDA raycaster, sub-5ms <code>frame&rarr;string</code> at 180&times;40. Resize widens FOV, not zoom. Perf mode auto-engages on huge terminals.</p></div>
-      <div class="card"><h3><span class="ic">&#9651;</span>Procgen levels</h3><p>10 levels: tutorial imps, 8 mixed procgen floors, a hand-authored cyberdemon boss arena. Keycards, locked doors, hidden secrets.</p></div>
-      <div class="card"><h3><span class="ic">&#9760;</span>Real AI</h3><p>Dormant &rarr; aware &rarr; hunting &rarr; attacking state machine. BFS noise-wake on every shot. Dodgeable telegraphed fireballs from casters.</p></div>
-      <div class="card"><h3><span class="ic">&#10037;</span>7-weapon loadout</h3><p>Pistol, shotgun, chaingun, chainsaw, BFG, incinerator, rocket launcher. DPS-balanced, mag/reserve persistence, auto-spray, overheat.</p></div>
-      <div class="card"><h3><span class="ic">&#9829;</span>Horror beats</h3><p>Heartbeat vignette on low HP, light flicker, jump-scares, sudden silence, blood drops, door-eye blinks. Tension, not just sprites.</p></div>
-      <div class="card"><h3><span class="ic">&#955;</span>Pure functional</h3><p>Immutable <code>world</code> map threaded through the loop. Side effects fenced into one IO layer. Seeded LCG &mdash; fully deterministic record/replay.</p></div>
+      <div class="card"><h3><span class="ic">&#9636;</span>256-color raycaster</h3><p>DDA ray-march, full viewport, sub-5ms <code>frame&rarr;string</code> at 180&times;40. Half-block sub-cell shading, distance-attenuated palette, RLE-coalesced ANSI emit, sprite z-buffer occlusion. Resize widens FOV, not zoom.</p></div>
+      <div class="card"><h3><span class="ic">&#9651;</span>10 levels, procgen + boss</h3><p>L1 tutorial imps, L2&ndash;L9 procgen mixed floors, L10 hand-authored cyberdemon arena (50 HP boss). Blue / red / yellow keycards, locked doors, and up to 2 hidden secrets per floor.</p></div>
+      <div class="card"><h3><span class="ic">&#9760;</span>10 enemy types, real AI</h3><p>Imp, demon, cacodemon, baron, cyberdemon, spectre, revenant, archvile, mancubus, pinky. A <b>dormant &rarr; aware &rarr; hunting &rarr; pain &rarr; attacking &rarr; wander</b> state machine with BFS noise-wake on every shot and dodgeable telegraphed fireballs.</p></div>
+      <div class="card"><h3><span class="ic">&#10037;</span>8-weapon arsenal</h3><p>Pistol, shotgun, chaingun, chainsaw, BFG, incinerator, rocket launcher, super shotgun. DPS-balanced with mag/reserve persistence, auto-spray, pistol overheat, splash AoE, and fire-resist mobs that shrug off the incinerator.</p></div>
+      <div class="card"><h3><span class="ic">&#9829;</span>Horror beats</h3><p>Heartbeat vignette + thump on low HP, light flicker, magenta jump-scares, sudden silence, wall haze, ceiling blood drops, blinking door-eyes, and a rear-arc "behind you" warning. Tension, not just sprites.</p></div>
+      <div class="card"><h3><span class="ic">&#955;</span>Pure-functional core</h3><p>One immutable <code>world</code> map threaded through <b>input &rarr; step &rarr; cast &rarr; render</b>. All side effects fenced into a single IO layer. Math lives in pure modules with 1:1 unit tests.</p></div>
+      <div class="card"><h3><span class="ic">&#9850;</span>Deterministic replay</h3><p>Every dice roll runs through one seeded Park-Miller LCG, so seed + input stream fully reproduce a run. <code>--record</code> / <code>--demo</code> capture and replay frame-for-frame; restart re-rolls or repeats the same map on demand.</p></div>
+      <div class="card"><h3><span class="ic">&#9000;</span>Terminal-native input</h3><p>Kitty keyboard protocol for instant key-release (kitty, WezTerm, Ghostty, Alacritty, iTerm2) with a hold-frame fallback for everyone else. Sprint, strafe, about-face, alt-screen redraw with zero scrollback.</p></div>
+      <div class="card"><h3><span class="ic">&#9835;</span>Synth audio + saves</h3><p>OS playback via <code>afplay</code>/<code>paplay</code>/<code>aplay</code>/<code>play</code> (bell fallback), distance-scaled SFX, and a synthesized ambient drone. Quick-save to any of 9 slots; high-scores persist best kills, level, and fastest victory.</p></div>
+      <div class="card"><h3><span class="ic">&#9881;</span>4 difficulties + perf mode</h3><p>Easy / normal / hard / nightmare scale enemy speed, HP, count, and respawn. Perf mode auto-engages past 200 columns or 12k cells (30 fps + 2&times; horizontal scale) so huge terminals stay smooth.</p></div>
     </div>
   </div>
 </section>
@@ -235,15 +278,28 @@ footer a{color:var(--fg)}
   <div class="wrap">
     <div class="sec-title">// hands on</div>
     <h2 class="sec-h">Controls</h2>
+
+    <!-- featured movement panel: proper WASD cross cluster -->
+    <div class="move-panel">
+      <div class="wasd">
+        <kbd class="w">W</kbd><kbd class="a">A</kbd><kbd class="s">S</kbd><kbd class="d">D</kbd>
+      </div>
+      <div class="move-meta">
+        <h3>Move &amp; turn</h3>
+        <p>Strafe and rotate with <b>WASD</b> or the arrow keys <span class="arrows">&uarr;&darr;&larr;&rarr;</span>.
+        Hold <kbd>&#8679;&nbsp;Shift</kbd> or <kbd>X</kbd> to sprint.</p>
+      </div>
+    </div>
+
     <div class="controls">
-      <div class="kc"><span class="keys"><kbd>W</kbd><kbd>A</kbd><kbd>S</kbd><kbd>D</kbd></span><span>Move / turn</span></div>
-      <div class="kc"><span class="keys"><kbd>&#8679; Shift</kbd></span><span>Sprint</span></div>
-      <div class="kc"><span class="keys"><kbd>Space</kbd><kbd>R</kbd></span><span>Fire / reload</span></div>
-      <div class="kc"><span class="keys"><kbd>1</kbd>&hellip;<kbd>8</kbd></span><span>Switch weapon</span></div>
-      <div class="kc"><span class="keys"><kbd>M</kbd></span><span>Toggle minimap</span></div>
-      <div class="kc"><span class="keys"><kbd>E</kbd></span><span>About-face 180&deg;</span></div>
-      <div class="kc"><span class="keys"><kbd>P</kbd></span><span>Pause</span></div>
-      <div class="kc"><span class="keys"><kbd>Q</kbd></span><span>Quit</span></div>
+      <div class="kc"><span class="keys"><kbd>Space</kbd><kbd>R</kbd></span><span class="lbl">Fire / reload</span></div>
+      <div class="kc"><span class="keys"><kbd>1</kbd><span class="dots">&middot;&middot;</span><kbd>8</kbd></span><span class="lbl">Switch weapon</span></div>
+      <div class="kc"><span class="keys"><kbd>F</kbd></span><span class="lbl">Open door / secret</span></div>
+      <div class="kc"><span class="keys"><kbd>E</kbd></span><span class="lbl">About-face 180&deg;</span></div>
+      <div class="kc"><span class="keys"><kbd>M</kbd></span><span class="lbl">Toggle minimap</span></div>
+      <div class="kc"><span class="keys"><kbd>N</kbd></span><span class="lbl">Toggle sound</span></div>
+      <div class="kc"><span class="keys"><kbd>P</kbd></span><span class="lbl">Pause</span></div>
+      <div class="kc"><span class="keys"><kbd>Q</kbd></span><span class="lbl">Quit</span></div>
     </div>
   </div>
 </section>
@@ -274,7 +330,7 @@ footer a{color:var(--fg)}
 <script>
 // Type out the install commands, then leave a blinking cursor.
 const lines = [
-  {pfx:'$ ', cmd:'curl -fsSL -o phel-doom.phar \\\n    https://github.com/Chemaclass/phel-doom/releases/latest/download/phel-doom.phar', out:''},
+  {pfx:'$ ', cmd:'curl -fsSL -o phel-doom.phar https://github.com/Chemaclass/phel-doom/releases/latest/download/phel-doom.phar', out:''},
   {pfx:'$ ', cmd:'php phel-doom.phar', out:'\n  loading WAD... 10 levels  rip and tear.'}
 ];
 const RAW = 'curl -fsSL -o phel-doom.phar https://github.com/Chemaclass/phel-doom/releases/latest/download/phel-doom.phar\nphp phel-doom.phar';


### PR DESCRIPTION
Follow-up polish on the landing page (#151).

## Fixes the user flagged
- **Install one-liner**: the curl command rendered across two lines (a `\` line-continuation). Now a single command.
- **Controls UI**: the movement card showed an awkward `W A S` / `D` wrap. Replaced with a featured movement panel using a proper **WASD cross cluster**, arrow-key + sprint hint, and uniform inline key cards. Added `F` (door/secret) and `N` (sound).

## Correct data (verified against `src/`, not stale docs)
| Stat | Was | Now | Source |
|------|-----|-----|--------|
| Enemy types | 5 | **10** | `src/core/enemies.phel` (imp, demon, caco, baron, cyber, spectre, revenant, archvile, mancubus, pinky) - all spawn in `level.phel` L1-L10 |
| Weapons | 7 | **8** | `src/core/weapons.phel:277` (`weapon-order`, slots 1-8, super-shotgun added) |
| AI states | - | **6** | `enemy_ai.phel` (dormant/aware/hunting/pain/attacking/wander) |
| Pickups | - | **8** | `level.phel` |
| Save slots | - | **9** | `savegame.phel` |

(Note: `docs/features.md` still says 5 types / 7 weapons - same drift. Can fix in a separate docs PR.)

## Content
- Added a verified **stat strip** and expanded the feature grid to 10 cards: raycaster, 10 levels, 10 enemy types + AI, 8-weapon arsenal, horror beats, pure-functional core, deterministic replay, terminal-native input, synth audio + saves, difficulties + perf mode.

Screenshotted locally (headless Chrome) to confirm the WASD cluster, stat strip, and grid render correctly.