### PR TITLE
ci(pages): bump Pages actions to Node 24 (+ simplify a heading)

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -29,13 +29,13 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Configure Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Upload site artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: site
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/site/index.html
+++ b/site/index.html
@@ -247,7 +247,7 @@ footer a{color:var(--fg)}
 <section id="features">
   <div class="wrap">
     <div class="sec-title">// what's inside</div>
-    <h2 class="sec-h">More game than a terminal has any right to be.</h2>
+    <h2 class="sec-h">A full game, in your terminal.</h2>
 
     <!-- verified stat strip -->
     <div class="stats">


### PR DESCRIPTION
## CI
Bump the GitHub Pages deploy actions to their Node 24 majors, clearing the Node 20 deprecation warning (Node 20 is forced off runners in Sep 2026):
- `actions/configure-pages` v5 -> **v6** (node24)
- `actions/upload-pages-artifact` v3 -> **v5** (composite)
- `actions/deploy-pages` v4 -> **v5** (node24)

Verified each new tag's `runs.using` is `node24`/`composite`. `actions/checkout@v6` already runs on Node 24.

## site
- Simplify the features heading: "More game than a terminal has any right to be." -> "A full game, in your terminal."