### PR TITLE
feat(level): scale ammo-box budget by difficulty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 
 ## [Unreleased]
 
+### Changed
+
+- Ammo-box budget now scales with difficulty: hard spawns x1.2, nightmare x1.5 boxes on top of the enemy-HP baseline, so spray weapons (chaingun, incinerator) don't starve when faster enemies raise the miss rate.
+
 ## [0.12.0] - 2026-06-09
 
 ### Added

--- a/docs/features.md
+++ b/docs/features.md
@@ -88,7 +88,7 @@ See [scores.md](scores.md), [savegame.md](savegame.md).
 
 ## CLI
 
-- `-d/--difficulty=easy|normal|hard|nightmare`: scales enemy speed, HP, count.
+- `-d/--difficulty=easy|normal|hard|nightmare`: scales enemy speed, HP, count, and the ammo-box budget (hard x1.2, nightmare x1.5 on top of the HP-driven baseline).
 - `-g/--god`: suppress contact damage, GOD badge. Dev.
 - `-a/--armory`: own all weapons, infinite reserves. Pairs with --god.
 - `-f/--full-map`: reveal minimap fog. Editor + screenshots.

--- a/docs/gameplay.md
+++ b/docs/gameplay.md
@@ -57,7 +57,7 @@ Hold `space` for auto-fire on pistol/chaingun/chainsaw/incinerator. Shotgun, BFG
 
 ## CLI flags
 
-- `--difficulty=easy|normal|hard|nightmare` (`-d`) - scale enemy speed, HP, count
+- `--difficulty=easy|normal|hard|nightmare` (`-d`) - scale enemy speed, HP, count, ammo-box budget
 - `--level=N` (`-l`) - start at level N
 - `--god` (`-g`) - invincible
 - `--armory` (`-a`) - start with all weapons

--- a/src/core/difficulty.phel
+++ b/src/core/difficulty.phel
@@ -69,7 +69,9 @@
    scales per-enemy HP + enemy count. For mixed-spec rooms
    (`:enemies` is a vector) scales each spec's :lives but leaves
    counts alone — the author's spec is the design, count tweaks
-   should be deliberate per-level."
+   should be deliberate per-level. Also stamps :ammo-mul from the
+   difficulty spec so level/ammo-box-count can read it without
+   re-querying the spec."
   [cfg diff]
   (let [d        (spec-for diff)
         chase    (or (:chase cfg) 1.0)

--- a/src/core/difficulty.phel
+++ b/src/core/difficulty.phel
@@ -6,25 +6,32 @@
 ;; Selected via --difficulty CLI flag (see commands/play.phel); default
 ;; is :normal so the existing balance shipped by /play stays unchanged.
 ;;
-;; Multipliers scale chase speed, enemy HP, and per-level enemy count.
-;; Powerups + ammo are unaffected — the dial is purely combat density
-;; and lethality.
+;; Multipliers scale chase speed, enemy HP, per-level enemy count, and
+;; the ammo-box budget. Other powerups are unaffected — the dial is
+;; combat density and lethality. `:ammo-mul` (issue #155) compensates
+;; for the higher miss rate faster enemies force on spray weapons: the
+;; HP-driven budget already grows with hp-mul * enemies-mul, but those
+;; assume every round lands.
 ;; ---------------------------------------------------------------------
 
 (def diff-table
   "Per-difficulty multipliers. Keys must match the CLI keyword."
   {:easy      {:speed-mul    0.7
                :hp-mul       1.0
-               :enemies-mul  0.7}
+               :enemies-mul  0.7
+               :ammo-mul     1.0}
    :normal    {:speed-mul    1.0
                :hp-mul       1.0
-               :enemies-mul  1.0}
+               :enemies-mul  1.0
+               :ammo-mul     1.0}
    :hard      {:speed-mul    1.3
                :hp-mul       1.3
-               :enemies-mul  1.3}
+               :enemies-mul  1.3
+               :ammo-mul     1.2}
    :nightmare {:speed-mul    1.8
                :hp-mul       1.5
-               :enemies-mul  1.5}})
+               :enemies-mul  1.5
+               :ammo-mul     1.5}})
 
 (def default-diff
   "Difficulty used when the CLI flag is absent / unrecognised."
@@ -75,6 +82,7 @@
                    (php/max 1 (php/intval (php/ceil (php/* (or enemies 1)
                                                            (:enemies-mul d))))))]
     (assoc cfg
+           :ammo-mul    (:ammo-mul d)
            :chase       (php/* chase (:speed-mul d))
            :enemy-lives (php/max 1 (php/intval (php/ceil (php/* (or (:enemy-lives cfg) 1)
                                                                 (:hp-mul d)))))

--- a/src/core/level.phel
+++ b/src/core/level.phel
@@ -328,19 +328,22 @@
           0
           specs))
 
-(defn- ammo-box-count
+(defn ammo-box-count
   "Per-level ammo-box budget. Scales with the expected shot count
    (sum of `count * lives` across enemies) so bigger maps with
-   tougher monsters get more refill points. Floor of 2 so every
-   level has at least one fallback. Divisor 8 tuned to give
-   roughly 1.3 mags of ammo per expected kill."
+   tougher monsters get more refill points, then multiplies by the
+   difficulty `:ammo-mul` (issue #155) so faster enemies — and the
+   misses they force on spray weapons — don't starve the player.
+   Floor of 2 so every level has at least one fallback. Divisor 8
+   tuned to give roughly 1.3 mags of ammo per expected kill."
   [cfg]
   (let [enemies (:enemies cfg)
         hp      (cond
                   (vector? enemies) (specs-total-hp enemies)
                   :else             (php/* (or enemies 0)
-                                           (or (:enemy-lives cfg) 1)))]
-    (php/max 2 (php/intval (php/ceil (php// hp 8))))))
+                                           (or (:enemy-lives cfg) 1)))
+        mul     (or (:ammo-mul cfg) 1.0)]
+    (php/max 2 (php/intval (php/ceil (php/* mul (php// hp 8)))))))
 
 (defn- lock-cell-for
   "Map a lock-colour kw to the matching locked-door cell value."

--- a/tests/core/difficulty-test.phel
+++ b/tests/core/difficulty-test.phel
@@ -36,6 +36,15 @@
     (is (= 3   (:enemy-lives cfg)))
     (is (= 6   (:enemies cfg)))))
 
+(deftest test-scale-cfg-stamps-ammo-mul
+  ;; Ammo budget multiplier (issue #155): harder difficulties pump the
+  ;; per-level ammo-box budget so spray weapons don't starve when the
+  ;; speed multiplier raises the miss rate.
+  (is (= 1.0 (:ammo-mul (scale-cfg {:enemies 6} :easy))))
+  (is (= 1.0 (:ammo-mul (scale-cfg {:enemies 6} :normal))))
+  (is (= 1.2 (:ammo-mul (scale-cfg {:enemies 6} :hard))))
+  (is (= 1.5 (:ammo-mul (scale-cfg {:enemies 6} :nightmare)))))
+
 (deftest test-scale-cfg-floors-at-one-on-tiny-inputs
   ;; Easy mode on a 1-enemy 1-HP level shouldn't empty it.
   (let [cfg (scale-cfg {:chase 1.0 :enemy-lives 1 :enemies 1} :easy)]

--- a/tests/core/level-test.phel
+++ b/tests/core/level-test.phel
@@ -1,6 +1,6 @@
 (ns phel-doom-tests.core.level-test
   (:require phel.test :refer [deftest is])
-  (:require phel-doom.core.level :refer [config-for num-levels build-world place-secret-reward secret-trophies])
+  (:require phel-doom.core.level :refer [ammo-box-count config-for num-levels build-world place-secret-reward secret-trophies])
   (:require phel-doom.core.rng :as rng))
 
 ;; ---------------------------------------------------------------------
@@ -251,3 +251,29 @@
 
 (deftest test-secret-trophies-are-the-rare-powerups
   (is (= [:soulspheres :berserks :invulns] secret-trophies)))
+
+;; ---------------------------------------------------------------------
+;; ammo-box-count: per-level ammo budget scales with the difficulty
+;; ammo multiplier (issue #155) on top of the enemy-HP scaling.
+;; ---------------------------------------------------------------------
+
+(deftest test-ammo-box-count-baseline-hp-over-divisor
+  ;; 6 enemies x 4 HP = 24 hp -> 24 / 8 = 3 boxes.
+  (is (= 3 (ammo-box-count {:enemies 6 :enemy-lives 4})))
+  (is (= 3 (ammo-box-count {:enemies 6 :enemy-lives 4 :ammo-mul 1.0}))))
+
+(deftest test-ammo-box-count-scales-with-ammo-mul
+  ;; x1.5 -> ceil(3 * 1.5) = 5 boxes.
+  (is (= 5 (ammo-box-count {:enemies 6 :enemy-lives 4 :ammo-mul 1.5})))
+  ;; x1.2 -> ceil(3 * 1.2) = 4 boxes.
+  (is (= 4 (ammo-box-count {:enemies 6 :enemy-lives 4 :ammo-mul 1.2}))))
+
+(deftest test-ammo-box-count-keeps-floor-of-two
+  (is (= 2 (ammo-box-count {:enemies 1 :enemy-lives 1})))
+  (is (= 2 (ammo-box-count {:enemies 1 :enemy-lives 1 :ammo-mul 1.5}))))
+
+(deftest test-ammo-box-count-mixed-spec-uses-total-hp
+  ;; specs: 2x3hp + 3x2hp = 12 hp -> 12/8 = 1.5 -> ceil 2; x1.5 -> ceil(2.25) = 3.
+  (let [specs [{:type :demon :count 2 :lives 3} {:type :imp :count 3 :lives 2}]]
+    (is (= 2 (ammo-box-count {:enemies specs})))
+    (is (= 3 (ammo-box-count {:enemies specs :ammo-mul 1.5})))))


### PR DESCRIPTION
## 📚 Description

Hard and nightmare now pump the per-level ammo-box budget (x1.2 / x1.5) on top of the enemy-HP baseline, so spray weapons (chaingun, incinerator) don't starve when faster enemies raise the miss rate.

## 🔖 Changes

- `diff-table` gains `:ammo-mul` (easy/normal 1.0, hard 1.2, nightmare 1.5); `scale-cfg` stamps it onto the level cfg
- `ammo-box-count` multiplies the hp/8 budget by `:ammo-mul` (floor of 2 kept), promoted to public for direct unit tests
- Tests: ammo-mul stamping, baseline/scaled/floor/mixed-spec budget arithmetic
- Docs: `features.md`, `gameplay.md` difficulty flag now mentions ammo scaling

Closes #155