### PR TITLE
feat(level): scale heal/armor pickup counts by difficulty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 ### Changed
 
 - Ammo-box budget now scales with difficulty: hard spawns x1.2, nightmare x1.5 boxes on top of the enemy-HP baseline, so spray weapons (chaingun, incinerator) don't starve when faster enemies raise the miss rate.
+- Heal/armor pickups now scale with difficulty too: nightmare seeds 2 hearts + 5 armor shards per level (hard 1 + 4) vs the 1 + 3 baseline, so supply tracks the denser roster instead of flattening into an attrition grind. Rare powerup odds (berserk/invuln/soulsphere) stay flat.
 
 ## [0.12.0] - 2026-06-09
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -88,7 +88,7 @@ See [scores.md](scores.md), [savegame.md](savegame.md).
 
 ## CLI
 
-- `-d/--difficulty=easy|normal|hard|nightmare`: scales enemy speed, HP, count, and the ammo-box budget (hard x1.2, nightmare x1.5 on top of the HP-driven baseline).
+- `-d/--difficulty=easy|normal|hard|nightmare`: scales enemy speed, HP, count, the ammo-box budget, and the heal/armor pickup counts (hard x1.2, nightmare x1.5: nightmare seeds 2 hearts + 5 armor shards vs the 1 + 3 baseline). Rare powerup odds stay flat.
 - `-g/--god`: suppress contact damage, GOD badge. Dev.
 - `-a/--armory`: own all weapons, infinite reserves. Pairs with --god.
 - `-f/--full-map`: reveal minimap fog. Editor + screenshots.

--- a/docs/gameplay.md
+++ b/docs/gameplay.md
@@ -57,7 +57,7 @@ Hold `space` for auto-fire on pistol/chaingun/chainsaw/incinerator. Shotgun, BFG
 
 ## CLI flags
 
-- `--difficulty=easy|normal|hard|nightmare` (`-d`) - scale enemy speed, HP, count, ammo-box budget
+- `--difficulty=easy|normal|hard|nightmare` (`-d`) - scale enemy speed, HP, count, ammo-box budget, heal/armor pickup counts
 - `--level=N` (`-l`) - start at level N
 - `--god` (`-g`) - invincible
 - `--armory` (`-a`) - start with all weapons

--- a/src/core/difficulty.phel
+++ b/src/core/difficulty.phel
@@ -6,12 +6,15 @@
 ;; Selected via --difficulty CLI flag (see commands/play.phel); default
 ;; is :normal so the existing balance shipped by /play stays unchanged.
 ;;
-;; Multipliers scale chase speed, enemy HP, per-level enemy count, and
-;; the ammo-box budget. Other powerups are unaffected — the dial is
-;; combat density and lethality. `:ammo-mul` (issue #155) compensates
-;; for the higher miss rate faster enemies force on spray weapons: the
-;; HP-driven budget already grows with hp-mul * enemies-mul, but those
-;; assume every round lands.
+;; Multipliers scale chase speed, enemy HP, per-level enemy count, the
+;; ammo-box budget, and the deterministic heal/armor pickup counts.
+;; `:ammo-mul` (issue #155) compensates for the higher miss rate faster
+;; enemies force on spray weapons: the HP-driven budget already grows
+;; with hp-mul * enemies-mul, but those assume every round lands.
+;; `:pickup-mul` (issue #156) scales hearts + armor shards so supply
+;; tracks the denser roster instead of flattening into an attrition
+;; grind. Rare powerup odds (berserk/invuln/soulsphere) stay
+;; author-tuned and are NOT scaled.
 ;; ---------------------------------------------------------------------
 
 (def diff-table
@@ -19,19 +22,23 @@
   {:easy      {:speed-mul    0.7
                :hp-mul       1.0
                :enemies-mul  0.7
-               :ammo-mul     1.0}
+               :ammo-mul     1.0
+               :pickup-mul   1.0}
    :normal    {:speed-mul    1.0
                :hp-mul       1.0
                :enemies-mul  1.0
-               :ammo-mul     1.0}
+               :ammo-mul     1.0
+               :pickup-mul   1.0}
    :hard      {:speed-mul    1.3
                :hp-mul       1.3
                :enemies-mul  1.3
-               :ammo-mul     1.2}
+               :ammo-mul     1.2
+               :pickup-mul   1.2}
    :nightmare {:speed-mul    1.8
                :hp-mul       1.5
                :enemies-mul  1.5
-               :ammo-mul     1.5}})
+               :ammo-mul     1.5
+               :pickup-mul   1.5}})
 
 (def default-diff
   "Difficulty used when the CLI flag is absent / unrecognised."
@@ -69,9 +76,10 @@
    scales per-enemy HP + enemy count. For mixed-spec rooms
    (`:enemies` is a vector) scales each spec's :lives but leaves
    counts alone — the author's spec is the design, count tweaks
-   should be deliberate per-level. Also stamps :ammo-mul from the
-   difficulty spec so level/ammo-box-count can read it without
-   re-querying the spec."
+   should be deliberate per-level. Also stamps :ammo-mul and
+   :pickup-mul from the difficulty spec so level's budget fns
+   (ammo-box-count, heart-count, armor-shard-count) can read them
+   without re-querying the spec."
   [cfg diff]
   (let [d        (spec-for diff)
         chase    (or (:chase cfg) 1.0)
@@ -85,6 +93,7 @@
                                                            (:enemies-mul d))))))]
     (assoc cfg
            :ammo-mul    (:ammo-mul d)
+           :pickup-mul  (:pickup-mul d)
            :chase       (php/* chase (:speed-mul d))
            :enemy-lives (php/max 1 (php/intval (php/ceil (php/* (or (:enemy-lives cfg) 1)
                                                                 (:hp-mul d)))))

--- a/src/core/level.phel
+++ b/src/core/level.phel
@@ -184,15 +184,33 @@
   [n]
   (get levels (php/max 0 (php/min (php/- num-levels 1) (php/- n 1)))))
 
+(defn- spawn-unique-pickups
+  "Seed `n` {:x :y} pickups at random open cells, retrying when
+   `random-spawn` collides with one already placed (otherwise stepping
+   on the shared cell silently consumes multiple pickups for a single
+   reward). Bails after `(* n 6)` attempts so a tight map can't
+   infinite-loop; the caller just gets the ones that fit."
+  [grid n]
+  (loop [acc [] attempts 0]
+    (cond
+      (php/>= (count acc) n)       acc
+      (php/> attempts (php/* n 6)) acc
+      :else
+      (let [[sx sy] (random-spawn grid)
+            dup?    (some (fn [p] (and (php/=== (:x p) sx) (php/=== (:y p) sy))) acc)]
+        (if dup?
+          (recur acc (php/+ attempts 1))
+          (recur (conj acc {:x sx :y sy}) (php/+ attempts 1)))))))
+
 (defn- maybe-spawn-heart
-  "Return a one-element vector with a heart pickup at a random open
-   cell, or [] when the player is already at max-lives (no point
-   spawning a heart they can't pick up)."
-  [grid lives]
+  "Return a vector with `n` heart pickups at random open cells, or []
+   when the player is already at max-lives (no point spawning hearts
+   they can't pick up). `n` > 1 only on harder difficulties (issue
+   #156, see heart-count)."
+  [grid lives n]
   (if (php/>= lives max-lives)
     []
-    (let [[hx hy] (random-spawn grid)]
-      [{:x hx :y hy}])))
+    (spawn-unique-pickups grid n)))
 
 (defn- maybe-spawn-armor
   "Roughly one in two levels carries an armor pickup. Picked up via
@@ -230,24 +248,6 @@
     (let [[sx sy] (random-spawn grid)]
       [{:x sx :y sy}])
     []))
-
-(defn- spawn-unique-pickups
-  "Seed `n` {:x :y} pickups at random open cells, retrying when
-   `random-spawn` collides with one already placed (otherwise stepping
-   on the shared cell silently consumes multiple pickups for a single
-   reward). Bails after `(* n 6)` attempts so a tight map can't
-   infinite-loop; the caller just gets the ones that fit."
-  [grid n]
-  (loop [acc [] attempts 0]
-    (cond
-      (php/>= (count acc) n)       acc
-      (php/> attempts (php/* n 6)) acc
-      :else
-      (let [[sx sy] (random-spawn grid)
-            dup?    (some (fn [p] (and (php/=== (:x p) sx) (php/=== (:y p) sy))) acc)]
-        (if dup?
-          (recur acc (php/+ attempts 1))
-          (recur (conj acc {:x sx :y sy}) (php/+ attempts 1)))))))
 
 (defn- spawn-armor-shards
   "Common armor shards (issue #68): seed `n` of them at random open
@@ -344,6 +344,22 @@
                                            (or (:enemy-lives cfg) 1)))
         mul     (or (:ammo-mul cfg) 1.0)]
     (php/max 2 (php/intval (php/ceil (php/* mul (php// hp 8)))))))
+
+(defn heart-count
+  "Hearts seeded per level: 1 baseline, scaled by the difficulty
+   :pickup-mul (issue #156). Rounded — hard's x1.2 keeps a single
+   heart, nightmare's x1.5 bumps to two — so heal supply tracks the
+   denser roster without trivialising mid difficulties."
+  [cfg]
+  (php/max 1 (php/intval (php/round (or (:pickup-mul cfg) 1.0)))))
+
+(defn armor-shard-count
+  "Armor shards seeded per level: `armor-shards-per-level` baseline,
+   scaled by the difficulty :pickup-mul (issue #156) and ceil'd —
+   hard gets 4, nightmare 5."
+  [cfg]
+  (php/intval (php/ceil (php/* armor-shards-per-level
+                               (or (:pickup-mul cfg) 1.0)))))
 
 (defn- lock-cell-for
   "Map a lock-colour kw to the matching locked-door cell value."
@@ -537,12 +553,12 @@
             :difficulty    diff'
             :backpack-level (pack->level pack)
             :owned-weapons (or owned #{:pistol})
-            :hearts        (maybe-spawn-heart grid life)
+            :hearts        (maybe-spawn-heart grid life (heart-count cfg))
             :armors        (maybe-spawn-armor grid)
             :berserks      (maybe-spawn-berserk grid)
             :invulns       (maybe-spawn-invuln grid)
             :soulspheres   (maybe-spawn-soulsphere grid)
-            :armor-shards  (spawn-armor-shards grid armor-shards-per-level)
+            :armor-shards  (spawn-armor-shards grid (armor-shard-count cfg))
             :backpacks     (maybe-spawn-backpack grid lv pack)
             :keycards      (maybe-spawn-keycard grid lock)
             :weapon-pickups (maybe-spawn-weapon-pickups grid lv (or owned #{:pistol}))

--- a/src/core/level.phel
+++ b/src/core/level.phel
@@ -345,13 +345,20 @@
         mul     (or (:ammo-mul cfg) 1.0)]
     (php/max 2 (php/intval (php/ceil (php/* mul (php// hp 8)))))))
 
+(def hearts-per-level
+  "Tunable: baseline hearts seeded per level before difficulty
+   scaling (see heart-count)."
+  1)
+
 (defn heart-count
-  "Hearts seeded per level: 1 baseline, scaled by the difficulty
-   :pickup-mul (issue #156). Rounded — hard's x1.2 keeps a single
-   heart, nightmare's x1.5 bumps to two — so heal supply tracks the
-   denser roster without trivialising mid difficulties."
+  "Hearts seeded per level: `hearts-per-level` baseline, scaled by
+   the difficulty :pickup-mul (issue #156) and rounded — hard's x1.2
+   keeps a single heart, nightmare's x1.5 bumps to two — so heal
+   supply tracks the denser roster without trivialising mid
+   difficulties. Floor of 1."
   [cfg]
-  (php/max 1 (php/intval (php/round (or (:pickup-mul cfg) 1.0)))))
+  (php/max 1 (php/intval (php/round (php/* hearts-per-level
+                                           (or (:pickup-mul cfg) 1.0))))))
 
 (defn armor-shard-count
   "Armor shards seeded per level: `armor-shards-per-level` baseline,

--- a/tests/core/difficulty-test.phel
+++ b/tests/core/difficulty-test.phel
@@ -45,6 +45,16 @@
   (is (= 1.2 (:ammo-mul (scale-cfg {:enemies 6} :hard))))
   (is (= 1.5 (:ammo-mul (scale-cfg {:enemies 6} :nightmare)))))
 
+(deftest test-scale-cfg-stamps-pickup-mul
+  ;; Heal/armor pickup multiplier (issue #156): harder difficulties
+  ;; seed more deterministic pickups (hearts, armor shards) so supply
+  ;; tracks the denser enemy roster instead of flattening into an
+  ;; attrition grind.
+  (is (= 1.0 (:pickup-mul (scale-cfg {:enemies 6} :easy))))
+  (is (= 1.0 (:pickup-mul (scale-cfg {:enemies 6} :normal))))
+  (is (= 1.2 (:pickup-mul (scale-cfg {:enemies 6} :hard))))
+  (is (= 1.5 (:pickup-mul (scale-cfg {:enemies 6} :nightmare)))))
+
 (deftest test-scale-cfg-floors-at-one-on-tiny-inputs
   ;; Easy mode on a 1-enemy 1-HP level shouldn't empty it.
   (let [cfg (scale-cfg {:chase 1.0 :enemy-lives 1 :enemies 1} :easy)]

--- a/tests/core/level-test.phel
+++ b/tests/core/level-test.phel
@@ -300,6 +300,8 @@
 
 (deftest test-build-world-nightmare-seeds-scaled-pickups
   (rng/seed! 42)
+  ;; lives=1 < max-lives so hearts are not suppressed; level 1 is
+  ;; spacious so spawn-unique-pickups never bails early.
   (let [w (build-world 1 1 0 :nightmare)]
     (is (= 5 (count (:armor-shards w))) "nightmare seeds 5 shards")
     (is (= 2 (count (:hearts w))) "nightmare seeds 2 hearts")))

--- a/tests/core/level-test.phel
+++ b/tests/core/level-test.phel
@@ -1,6 +1,6 @@
 (ns phel-doom-tests.core.level-test
   (:require phel.test :refer [deftest is])
-  (:require phel-doom.core.level :refer [ammo-box-count config-for num-levels build-world place-secret-reward secret-trophies])
+  (:require phel-doom.core.level :refer [ammo-box-count armor-shard-count config-for heart-count num-levels build-world place-secret-reward secret-trophies])
   (:require phel-doom.core.rng :as rng))
 
 ;; ---------------------------------------------------------------------
@@ -277,3 +277,29 @@
   (let [specs [{:type :demon :count 2 :lives 3} {:type :imp :count 3 :lives 2}]]
     (is (= 2 (ammo-box-count {:enemies specs})))
     (is (= 3 (ammo-box-count {:enemies specs :ammo-mul 1.5})))))
+
+;; ---------------------------------------------------------------------
+;; Heal/armor pickup scaling (issue #156): deterministic pickup counts
+;; (hearts, armor shards) track the difficulty :pickup-mul. Rare
+;; powerup odds (berserk/invuln/soulsphere) stay author-tuned.
+;; ---------------------------------------------------------------------
+
+(deftest test-heart-count-rounds-pickup-mul
+  ;; round, not ceil: hard's x1.2 shouldn't double the heart supply.
+  (is (= 1 (heart-count {})))
+  (is (= 1 (heart-count {:pickup-mul 1.0})))
+  (is (= 1 (heart-count {:pickup-mul 1.2})))
+  (is (= 2 (heart-count {:pickup-mul 1.5}))))
+
+(deftest test-armor-shard-count-ceils-pickup-mul
+  ;; baseline 3 shards; ceil(3.6) = 4, ceil(4.5) = 5.
+  (is (= 3 (armor-shard-count {})))
+  (is (= 3 (armor-shard-count {:pickup-mul 1.0})))
+  (is (= 4 (armor-shard-count {:pickup-mul 1.2})))
+  (is (= 5 (armor-shard-count {:pickup-mul 1.5}))))
+
+(deftest test-build-world-nightmare-seeds-scaled-pickups
+  (rng/seed! 42)
+  (let [w (build-world 1 1 0 :nightmare)]
+    (is (= 5 (count (:armor-shards w))) "nightmare seeds 5 shards")
+    (is (= 2 (count (:hearts w))) "nightmare seeds 2 hearts")))


### PR DESCRIPTION
## 📚 Description

Completes the difficulty-supply dial started in #167: hard and nightmare now also scale the deterministic heal/armor pickups (x1.2 / x1.5), so supply tracks the denser enemy roster instead of flattening into an attrition grind. Rare powerup odds (berserk/invuln/soulsphere) stay author-tuned and flat.

## 🔖 Changes

- `diff-table` gains `:pickup-mul` (easy/normal 1.0, hard 1.2, nightmare 1.5); `scale-cfg` stamps it
- New public `heart-count` (round, floor 1: nightmare 2 hearts) + `armor-shard-count` (ceil: hard 4, nightmare 5 shards)
- `maybe-spawn-heart` takes a count and seeds via `spawn-unique-pickups` (moved earlier for definition order)
- Tests: pickup-mul stamping, count formulas, seeded nightmare build-world integration
- Docs: `features.md`, `gameplay.md`; CHANGELOG updated

Closes #156