### PR TITLE
feat(combat): bump kill-loot drop rate from 25% to 35%

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 
 - Ammo-box budget now scales with difficulty: hard spawns x1.2, nightmare x1.5 boxes on top of the enemy-HP baseline, so spray weapons (chaingun, incinerator) don't starve when faster enemies raise the miss rate.
 - Heal/armor pickups now scale with difficulty too: nightmare seeds 2 hearts + 5 armor shards per level (hard 1 + 4) vs the 1 + 3 baseline, so supply tracks the denser roster instead of flattening into an attrition grind. Rare powerup odds (berserk/invuln/soulsphere) stay flat.
+- Kill-loot drop rate bumped from 25% to 35% (ammo 22%, armor 8%, heart 5%): the 8-weapon roster and faster pace made 3-in-4 kills dropping nothing read as sparse.
 
 ## [0.12.0] - 2026-06-09
 

--- a/docs/combat.md
+++ b/docs/combat.md
@@ -43,10 +43,10 @@ On kill, roll uniform float through `roll-loot-kind`:
 
 | Band | Drop | Notes |
 |------|------|-------|
-| [0.00, 0.15) | `:ammo` | Random owned weapon (excludes pistol); falls back to pistol |
-| [0.15, 0.22) | `:armor` | Absorb one hit |
-| [0.22, 0.25) | `:heart` | +1 life (suppressed at max health) |
-| [0.25, 1.00) | nothing | ~75% of kills |
+| [0.00, 0.22) | `:ammo` | Random owned weapon (excludes pistol); falls back to pistol |
+| [0.22, 0.30) | `:armor` | Absorb one hit |
+| [0.30, 0.35) | `:heart` | +1 life (suppressed at max health) |
+| [0.35, 1.00) | nothing | ~65% of kills |
 
 Drops push into `:hearts` / `:armors` / `:ammo-boxes` vectors (same as level spawns). `pickup-ammos` reads box's `:weapon` tag and refills that weapon's reserve.
 

--- a/src/core/combat.phel
+++ b/src/core/combat.phel
@@ -552,13 +552,15 @@
 
 (def loot-drop-chance
   "Probability cutoffs for a kill drop, layered on a single uniform roll
-   in [0, 1). Tuned DOWN after the v0.3 playtesting reported too much
-   loot — ~75% of kills now drop nothing so the floor doesn't fill
-   with pickups. Ammo dominates; armor mid; heart is rare AND only
-   rolls when it would actually heal (lives < cap)."
-  {:ammo  0.15          ; 0.00 .. 0.15
-   :armor 0.22          ; 0.15 .. 0.22
-   :heart 0.25})        ; 0.22 .. 0.25 (gated by lives < max-lives)
+   in [0, 1). Tuned DOWN to 25% total after the v0.3 playtesting
+   reported too much loot, then back UP to 35% (issue #157): the
+   8-weapon roster + faster pace made 75% no-drop read as sparse —
+   kill loot is the core dopamine feedback. Ammo dominates; armor
+   mid; heart is rare AND only rolls when it would actually heal
+   (lives < cap)."
+  {:ammo  0.22          ; 0.00 .. 0.22
+   :armor 0.30          ; 0.22 .. 0.30
+   :heart 0.35})        ; 0.30 .. 0.35 (gated by lives < max-lives)
 
 (defn roll-loot-kind
   "Decide which pickup (if any) drops on the current kill. nil = no
@@ -570,7 +572,7 @@
     (php/< roll (:armor loot-drop-chance)) :armor
     ;; A heart only drops when it would actually heal. At full HP a roll
     ;; in the heart band does NOT re-bucket to ammo/armor - it falls
-    ;; through to nil (no drop), by design (~3% of kills drop nothing
+    ;; through to nil (no drop), by design (~5% of kills drop nothing
     ;; that otherwise would have given a heart).
     (and (php/< roll (:heart loot-drop-chance))
          (php/< (or (:lives world) 0) max-lives)) :heart

--- a/tests/core/combat-test.phel
+++ b/tests/core/combat-test.phel
@@ -360,25 +360,25 @@
 
 ;; ---------------------------------------------------------------------
 ;; roll-loot-kind: deterministic cut-points for the kill drop roll.
-;; ammo 0.00..0.30, armor 0.30..0.45, heart 0.45..0.50 (gated by
-;; lives < max-lives), nothing 0.50..1.0.
+;; ammo 0.00..0.22, armor 0.22..0.30, heart 0.30..0.35 (gated by
+;; lives < max-lives), nothing 0.35..1.0 (issue #157 bump).
 ;; ---------------------------------------------------------------------
 
 (deftest test-roll-loot-kind-ammo-band
   (is (= :ammo (roll-loot-kind {:lives 3} 0.0)))
-  (is (= :ammo (roll-loot-kind {:lives 3} 0.149))))
+  (is (= :ammo (roll-loot-kind {:lives 3} 0.219))))
 
 (deftest test-roll-loot-kind-armor-band
-  (is (= :armor (roll-loot-kind {:lives 3} 0.15)))
-  (is (= :armor (roll-loot-kind {:lives 3} 0.219))))
+  (is (= :armor (roll-loot-kind {:lives 3} 0.22)))
+  (is (= :armor (roll-loot-kind {:lives 3} 0.299))))
 
 (deftest test-roll-loot-kind-heart-band-when-not-full
-  (is (= :heart (roll-loot-kind {:lives 3} 0.22)))
-  (is (= :heart (roll-loot-kind {:lives 4} 0.249))))
+  (is (= :heart (roll-loot-kind {:lives 3} 0.30)))
+  (is (= :heart (roll-loot-kind {:lives 4} 0.349))))
 
 (deftest test-roll-loot-kind-heart-band-suppressed-at-full-lives
   ;; lives == max-lives (10) -> heart would be wasted, drop nothing.
-  (is (= nil (roll-loot-kind {:lives 10} 0.22))))
+  (is (= nil (roll-loot-kind {:lives 10} 0.30))))
 
 ;; ---------------------------------------------------------------------
 ;; Half-heart damage system: per-enemy-type hit damage, armor absorbs
@@ -414,7 +414,7 @@
     (is (= 1 (:armor w')) "one armor unit consumed")))
 
 (deftest test-roll-loot-kind-nothing-band
-  (is (= nil (roll-loot-kind {:lives 3} 0.25)))
+  (is (= nil (roll-loot-kind {:lives 3} 0.35)))
   (is (= nil (roll-loot-kind {:lives 3} 0.99))))
 
 ;; ---------------------------------------------------------------------


### PR DESCRIPTION
## 📚 Description

Kill loot is the core dopamine feedback, and with the 8-weapon roster and faster pace, 3-in-4 kills dropping nothing read as sparse. Drop bands bumped per the issue proposal: ammo 22%, armor 8%, heart 5% (35% total, 65% nothing).

## 🔖 Changes

- `loot-drop-chance` cutoffs: ammo 0.15 -> 0.22, armor 0.22 -> 0.30, heart 0.25 -> 0.35; docstring carries the tune history
- Band tests updated; also fixed a stale test-header comment still describing the pre-v0.3 30/45/50 cutoffs
- `docs/combat.md` loot table synced; CHANGELOG updated
- Final review pass surfaced nothing

Closes #157