### PR TITLE
ref(engine): extract width-aware fov-proj-dist seam

### DIFF
--- a/src/core/engine.phel
+++ b/src/core/engine.phel
@@ -35,6 +35,17 @@
    'never crosses this axis'."
   1.0e9)
 
+(defn fov-proj-dist
+  "Projection distance used for the per-column RAY SPREAD (FOV), as
+   distinct from `proj-dist` which scales wall HEIGHT. Horizontal FOV
+   is `2 * atan(width / 2 / (fov-proj-dist width))`, so a larger return
+   value narrows the spread. Today it returns the flat `proj-dist` for
+   every width (FOV widens freely with the terminal); it exists as the
+   single seam where a width-aware FOV clamp can live without touching
+   wall-height projection."
+  [^int width]
+  proj-dist)
+
 ;; Per-column FOV offset (atan) and its cos are pure functions of the
 ;; ray's column index and the viewport width. They never change at
 ;; runtime for a given width, so we memoize one PHP-array per width.
@@ -45,11 +56,12 @@
 
 (defn- build-offset-tables [^int width]
   (let [center  (php/* 0.5 width)
+        pd      (fov-proj-dist width)
         offs    (php/array)
         cosoffs (php/array)]
     (loop [col 0]
       (when (php/< col width)
-        (let [o (php/atan (php// (php/- col center) proj-dist))]
+        (let [o (php/atan (php// (php/- col center) pd))]
           (php/aset offs col o)
           (php/aset cosoffs col (php/cos o))
           (recur (php/+ col 1)))))

--- a/tests/core/engine-test.phel
+++ b/tests/core/engine-test.phel
@@ -2,9 +2,17 @@
   (:require phel.test :refer [deftest is])
   (:require phel-doom.core.map    :refer [default-grid])
   (:require phel-doom.core.state  :refer [new-world new-player])
-  (:require phel-doom.core.engine :refer [cast-ray cast-frame mark-visible-cells max-depth visited? visit-radius]))
+  (:require phel-doom.core.engine :refer [cast-ray cast-frame mark-visible-cells max-depth visited? visit-radius fov-proj-dist proj-dist]))
 
 (def pgrid (to-php-array (map to-php-array default-grid)))
+
+(deftest test-fov-proj-dist-flat-across-widths
+  ;; Seam contract: FOV projection distance is the flat `proj-dist` at
+  ;; every width today, so the horizontal FOV widens freely with the
+  ;; terminal. The FOV-clamp change lives here and only here.
+  (is (= proj-dist (fov-proj-dist 80)))
+  (is (= proj-dist (fov-proj-dist 120)))
+  (is (= proj-dist (fov-proj-dist 400))))
 
 (deftest test-ray-hits-wall-eventually
   (let [d (cast-ray pgrid 8.0 8.0 0.0)]


### PR DESCRIPTION
## What

Decouples the FOV ray-spread projection distance from the wall-height `proj-dist`.

- New `fov-proj-dist` in `engine.phel`: returns the flat `proj-dist` for every width **today** (behaviour identical).
- `build-offset-tables` now reads `(fov-proj-dist width)` for the per-column ray angle.
- Wall-height projection still uses the flat `proj-dist` (render `main.phel`), so the two concerns are now separable.

## Why

Groundwork for the FOV-fisheye clamp on wide terminals: that fix becomes a one-function change in `fov-proj-dist`, with wall scale untouched.

## Tests

- Added `test-fov-proj-dist-flat-across-widths` pinning the current flat contract (80 / 120 / 400).
- Full suite green (1923 passed), build compiles.

No behaviour change.