### PR TITLE
fix(engine): clamp horizontal FOV at 90° on wide terminals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 
 ## [Unreleased]
 
+### Fixed
+
+- Horizontal FOV is now clamped at 90° on wide terminals. Past 140 cols the ray spread stops widening (it bowed out toward 110°+ on ultrawide / fullscreen terminals, warping walls at the screen edges); the extra columns now add horizontal resolution instead of fisheye distortion. Terminals at or below 140 cols are unchanged. Wall scale is untouched.
+
 ### Changed
 
 - Ammo-box budget now scales with difficulty: hard spawns x1.2, nightmare x1.5 boxes on top of the enemy-HP baseline, so spray weapons (chaingun, incinerator) don't starve when faster enemies raise the miss rate.

--- a/docs/raycaster.md
+++ b/docs/raycaster.md
@@ -13,6 +13,7 @@ For each screen column, fire a ray from the player at an angle offset from facin
 
 - `max-depth`: ray stops at 12 units (beyond renders sky/floor)
 - `proj-dist`: 70 cell perspective constant (controls wall scale)
+- `fov-proj-dist`: width-aware projection distance for ray spread; clamps FOV at 90° past 140 cols (see Angular offset below)
 
 ## DDA: grid-aligned traversal
 
@@ -64,7 +65,9 @@ Cast `width / scale` rays; return 5 parallel PHP arrays (one per output column).
 
 ### Angular offset, not linear sweep
 
-Each column's ray angle is `atan(col-offset / proj-dist)`. Making the terminal wider expands FOV without scaling walls. A linear sweep would scale walls with width - wrong.
+Each column's ray angle is `atan(col-offset / fov-proj-dist)`. Making the terminal wider expands FOV without scaling walls. A linear sweep would scale walls with width - wrong.
+
+FOV is clamped at 90°. `fov-proj-dist` returns the flat `proj-dist` below `fov-clamp-width` (= `2 * proj-dist` = 140 cols), so narrow terminals widen naturally (80 cols ~60°, 120 cols ~81°). At or above 140 cols it scales `proj-dist` up with width, pinning the horizontal FOV at 90° so ultrawide terminals gain horizontal resolution instead of bowing out into edge fisheye. Wall-height projection still uses the flat `proj-dist`, so the clamp never touches wall scale.
 
 ### Fish-eye correction
 

--- a/src/core/engine.phel
+++ b/src/core/engine.phel
@@ -35,16 +35,32 @@
    'never crosses this axis'."
   1.0e9)
 
+(def fov-clamp-width
+  "Viewport width at which horizontal FOV hits its 90° cap and stops
+   widening. At this width `proj-dist` already yields exactly 90°
+   (`2 * atan(width / 2 / proj-dist)` with `width = 2 * proj-dist`), so
+   the cap is the classic DOOM-ish horizontal FOV. Narrower terminals
+   keep the flat `proj-dist` (FOV grows naturally, 80→~60°, 120→~81°);
+   wider terminals scale `proj-dist` up in lock-step with width so the
+   angle holds at 90° instead of bowing out into edge fisheye."
+  (php/intval (php/* 2.0 proj-dist)))
+
 (defn fov-proj-dist
   "Projection distance used for the per-column RAY SPREAD (FOV), as
    distinct from `proj-dist` which scales wall HEIGHT. Horizontal FOV
    is `2 * atan(width / 2 / (fov-proj-dist width))`, so a larger return
-   value narrows the spread. Today it returns the flat `proj-dist` for
-   every width (FOV widens freely with the terminal); it exists as the
-   single seam where a width-aware FOV clamp can live without touching
-   wall-height projection."
+   value narrows the spread.
+
+   Below `fov-clamp-width` the flat `proj-dist` is returned and FOV
+   widens with the terminal as before. At or above it the distance
+   scales linearly with width (`proj-dist * width / fov-clamp-width`),
+   which pins the horizontal FOV at 90° for every wider terminal: the
+   extra columns buy horizontal RESOLUTION, not a wider, warped view.
+   Wall-height projection is untouched (still flat `proj-dist`)."
   [^int width]
-  proj-dist)
+  (if (php/<= width fov-clamp-width)
+    proj-dist
+    (php// (php/* proj-dist width) fov-clamp-width)))
 
 ;; Per-column FOV offset (atan) and its cos are pure functions of the
 ;; ray's column index and the viewport width. They never change at

--- a/tests/core/engine-test.phel
+++ b/tests/core/engine-test.phel
@@ -2,17 +2,40 @@
   (:require phel.test :refer [deftest is])
   (:require phel-doom.core.map    :refer [default-grid])
   (:require phel-doom.core.state  :refer [new-world new-player])
-  (:require phel-doom.core.engine :refer [cast-ray cast-frame mark-visible-cells max-depth visited? visit-radius fov-proj-dist proj-dist]))
+  (:require phel-doom.core.engine :refer [cast-ray cast-frame mark-visible-cells max-depth visited? visit-radius fov-proj-dist fov-clamp-width proj-dist]))
 
 (def pgrid (to-php-array (map to-php-array default-grid)))
 
-(deftest test-fov-proj-dist-flat-across-widths
-  ;; Seam contract: FOV projection distance is the flat `proj-dist` at
-  ;; every width today, so the horizontal FOV widens freely with the
-  ;; terminal. The FOV-clamp change lives here and only here.
+(defn- fov-degrees
+  "Full horizontal FOV in degrees for a viewport width, derived from
+   the live fov-proj-dist seam."
+  [width]
+  (php/* 2.0 (php/rad2deg (php/atan (php// (php/* 0.5 width) (fov-proj-dist width))))))
+
+(deftest test-fov-proj-dist-flat-below-clamp
+  ;; Narrow terminals keep the flat proj-dist: FOV widens with width
+  ;; exactly as before the clamp landed.
   (is (= proj-dist (fov-proj-dist 80)))
   (is (= proj-dist (fov-proj-dist 120)))
-  (is (= proj-dist (fov-proj-dist 400))))
+  (is (= proj-dist (fov-proj-dist fov-clamp-width))))   ; boundary stays flat
+
+(deftest test-fov-proj-dist-scales-above-clamp
+  ;; Past the clamp the distance grows linearly with width so the angle
+  ;; holds steady instead of bowing out.
+  (is (> (fov-proj-dist 200) proj-dist))
+  (is (> (fov-proj-dist 400) (fov-proj-dist 200))))
+
+(deftest test-fov-capped-at-90-degrees-on-wide-terminals
+  ;; The whole point: wide terminals top out at a 90° horizontal FOV
+  ;; instead of stretching toward 110°+ edge fisheye.
+  (is (< (php/abs (php/- (fov-degrees fov-clamp-width) 90.0)) 0.001))
+  (is (< (php/abs (php/- (fov-degrees 200) 90.0)) 0.001))
+  (is (< (php/abs (php/- (fov-degrees 400) 90.0)) 0.001)))
+
+(deftest test-fov-widens-naturally-below-clamp
+  ;; Below the clamp FOV still grows with width (no premature pinning).
+  (is (< (fov-degrees 80) (fov-degrees 120)))
+  (is (< (fov-degrees 120) (fov-degrees fov-clamp-width))))
 
 (deftest test-ray-hits-wall-eventually
   (let [d (cast-ray pgrid 8.0 8.0 0.0)]


### PR DESCRIPTION
## Problem

Horizontal FOV is `2·atan(width/2 / proj-dist)`. With the flat `proj-dist=70` the angle widened freely with terminal width:

| Width | Old FOV |
|------:|--------:|
| 80 | ~60° |
| 120 | ~81° |
| 180 | ~104° |
| 400 | ~140° |

Past ~100° walls bow out into heavy edge fisheye - bad on ultrawide / fullscreen terminals.

## Fix

`fov-proj-dist` (the seam from #170) now scales `proj-dist` with width at/above `fov-clamp-width` (= `2·proj-dist` = 140 cols), pinning the angle at **90°** (classic DOOM-ish):

| Width | New FOV |
|------:|--------:|
| 80 | ~60° (unchanged) |
| 120 | ~81° (unchanged) |
| 180 | 90° |
| 400 | 90° |

Wider terminals gain horizontal **resolution**, not a wider warped view. Terminals ≤140 cols are unchanged. Wall-height projection still uses the flat `proj-dist` - wall scale untouched.

## Tests

- FOV pinned at 90° for 140 / 200 / 400 cols; flat proj-dist below clamp; natural widening below clamp. Full suite green (1930).

## Docs

- `docs/raycaster.md` + CHANGELOG updated.