### PR TITLE
ref(perf): consolidate big-screen policy into perf-profile

### DIFF
--- a/docs/performance.md
+++ b/docs/performance.md
@@ -6,12 +6,18 @@
 
 Terminals >= 200 cols or > 12,000 cells (cols x rows) automatically engage perf-mode: 30 fps cadence + 2x render-scale. Each ray casts once and replicates to 2 columns; minimap caps at 40 cols. Physics and input still tick per frame.
 
+`perf-profile` is the single source of truth: it maps dimensions to `{:frame-us :scale}`, and `target-frame-us` / `render-scale` are thin reads off it so cadence and scale stay mutually consistent.
+
 ```phel
-(def perf-width-threshold  200)
-(def perf-area-threshold   12000)
+(def perf-width-threshold 200)
+(def perf-area-threshold  12000)
 (defn perf-mode? [cols rows] (or (>= cols 200) (> (* cols rows) 12000)))
-(defn target-frame-us [cols rows] (if (perf-mode? cols rows) 33333 16667))  ; µs
-(defn render-scale [cols rows] (if (perf-mode? cols rows) 2 1))
+(defn perf-profile [cols rows]
+  (if (perf-mode? cols rows)
+    {:frame-us perf-frame-us     :scale perf-scale}      ; 33333 µs, 2
+    {:frame-us standard-frame-us :scale standard-scale})) ; 16667 µs, 1
+(defn target-frame-us [cols rows] (:frame-us (perf-profile cols rows)))
+(defn render-scale    [cols rows] (:scale    (perf-profile cols rows)))
 ```
 
 ## PHP runtime: OPcache + JIT

--- a/src/core/perf.phel
+++ b/src/core/perf.phel
@@ -34,27 +34,55 @@
   (or (php/>= cols perf-width-threshold)
       (php/> (php/* cols rows) perf-area-threshold)))
 
-(defn target-frame-us
-  "Microsecond cadence target for one game-loop iteration. 16667
-   (~60fps) by default; perf-mode terminals drop to 33333 (~30fps)
-   so render doesn't thrash trying to push 60fps when each frame is
-   genuinely heavier. Physics / input still tick once per loop, just
-   half as often per wall-clock second — gameplay stays responsive,
-   the loop doesn't peg a core trying to outrun its render budget."
+(def standard-frame-us
+  "Cadence target (µs) for standard terminals — ~60fps."
+  16667)
+
+(def perf-frame-us
+  "Cadence target (µs) for perf-mode terminals — ~30fps. Doubling the
+   budget lets a genuinely heavier frame finish in time instead of the
+   loop pegging a core chasing an unreachable 60."
+  33333)
+
+(def standard-scale
+  "Horizontal render-scale on standard terminals: exact 1:1 path."
+  1)
+
+(def perf-scale
+  "Horizontal render-scale on perf-mode terminals: one ray per 2 output
+   columns, replicated across the pair (chunky-but-readable walls)."
+  2)
+
+(defn perf-profile
+  "Single source of truth for big-screen perf policy: maps terminal
+   dimensions to {:frame-us … :scale …}. `target-frame-us` and
+   `render-scale` are thin reads off this so the cadence + scale policy
+   lives in one place (and stays mutually consistent under future
+   tuning). Pure function of dimensions — safe to read per frame."
   [^int cols ^int rows]
-  (if (perf-mode? cols rows) 33333 16667))
+  (if (perf-mode? cols rows)
+    {:frame-us perf-frame-us :scale perf-scale}
+    {:frame-us standard-frame-us :scale standard-scale}))
+
+(defn target-frame-us
+  "Microsecond cadence target for one game-loop iteration: ~60fps on
+   standard terminals, ~30fps on perf-mode ones (see `perf-profile`).
+   Physics / input still tick once per loop, just less often per
+   wall-clock second on big screens — gameplay stays responsive, the
+   loop doesn't peg a core trying to outrun its render budget."
+  [^int cols ^int rows]
+  (:frame-us (perf-profile cols rows)))
 
 (defn render-scale
   "Horizontal render-scale factor consumed by `cast-frame`: it casts
    one ray per N output columns and replicates the sample across the
    next N entries of the dists/hits/sides/hxs/hys arrays. Downstream
-   row-loop code is unchanged — it still reads vw-sized buffers
-   column by column, just with N-wide runs of identical values that
-   read as chunky-but-readable wall blocks.
+   row-loop code is unchanged — it still reads vw-sized buffers column
+   by column, just with N-wide runs of identical values.
 
-   Returns 2 on perf-mode terminals (cuts cast + per-col wall-shade
-   work roughly in half), 1 on standard terminals (exact 1:1 path).
-   Sprites + HUD operate at full vw so the chunky look is contained
-   to the wall band."
+   2 on perf-mode terminals (cuts cast + per-col wall-shade work
+   roughly in half), 1 on standard terminals (exact 1:1 path). See
+   `perf-profile`. Sprites + HUD operate at full vw so the chunky look
+   is contained to the wall band."
   [^int cols ^int rows]
-  (if (perf-mode? cols rows) 2 1))
+  (:scale (perf-profile cols rows)))

--- a/tests/core/perf-test.phel
+++ b/tests/core/perf-test.phel
@@ -1,7 +1,7 @@
 (ns phel-doom-tests.core.perf-test
   (:require phel.test :refer [deftest is])
   (:require phel-doom.core.perf :refer [perf-mode? target-frame-us
-                                        render-scale
+                                        render-scale perf-profile
                                         perf-width-threshold
                                         perf-area-threshold]))
 
@@ -63,3 +63,14 @@
   (is (= 2 (render-scale 400 60)))
   (is (= 2 (render-scale 200 30)))
   (is (= 2 (render-scale 180 70))))
+
+(deftest test-perf-profile-is-single-source-of-truth
+  ;; target-frame-us + render-scale are thin reads off perf-profile;
+  ;; pin that they stay mutually consistent so a future policy tweak
+  ;; can't drift the cadence and the scale apart.
+  (let [small (perf-profile 80 24)
+        big   (perf-profile 400 60)]
+    (is (= (:frame-us small) (target-frame-us 80 24)))
+    (is (= (:scale small)    (render-scale 80 24)))
+    (is (= (:frame-us big)   (target-frame-us 400 60)))
+    (is (= (:scale big)      (render-scale 400 60)))))


### PR DESCRIPTION
## What

`target-frame-us` and `render-scale` each branched on `perf-mode?` independently. Now both read off a single `perf-profile` map:

```phel
(defn perf-profile [cols rows]
  (if (perf-mode? cols rows)
    {:frame-us perf-frame-us     :scale perf-scale}
    {:frame-us standard-frame-us :scale standard-scale}))
```

Magic numbers (16667 / 33333 / 1 / 2) become named defs.

## Why

Groundwork for the adaptive-cadence (60fps) and crisp-wall PRs: cadence + scale policy now lives in one locus and stays mutually consistent under tuning.

## Tests

- New `test-perf-profile-is-single-source-of-truth` pins that the two public fns agree with the profile.
- Full suite green (1934). `docs/performance.md` updated.

No behaviour change.