### PR TITLE
perf(loop): target 60fps on big screens, drop 30fps cadence cap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 
 ## [Unreleased]
 
+### Performance
+
+- Big screens are no longer capped at 30fps. The perf-mode cadence ceiling was artificial: on hardware fast enough to render a wide-terminal frame inside the 60fps budget the player was pinned to 30fps for no reason, and on slower hardware the per-frame sleep already floored at the minimum yield. Cadence is now a uniform 60fps target at every terminal size; framerate tracks render capability and degrades smoothly toward render-native below it.
+
 ### Fixed
 
 - Horizontal FOV is now clamped at 90° on wide terminals. Past 140 cols the ray spread stops widening (it bowed out toward 110°+ on ultrawide / fullscreen terminals, warping walls at the screen edges); the extra columns now add horizontal resolution instead of fisheye distortion. Terminals at or below 140 cols are unchanged. Wall scale is untouched.

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -4,9 +4,11 @@
 
 ## Big-screen perf mode
 
-Terminals >= 200 cols or > 12,000 cells (cols x rows) automatically engage perf-mode: 30 fps cadence + 2x render-scale. Each ray casts once and replicates to 2 columns; minimap caps at 40 cols. Physics and input still tick per frame.
+Terminals >= 200 cols or > 12,000 cells (cols x rows) engage perf-mode: 2x render-scale (each ray casts once and replicates to 2 columns; minimap caps at 40 cols). Physics and input tick per frame.
 
-`perf-profile` is the single source of truth: it maps dimensions to `{:frame-us :scale}`, and `target-frame-us` / `render-scale` are thin reads off it so cadence and scale stay mutually consistent.
+Cadence is a **uniform ~60fps at every size**. Big screens used to drop to 30fps, but that was an artificial ceiling: on hardware fast enough to render a perf-mode frame inside the 16.67ms budget the player was pinned to 30fps for no reason, and on hardware too slow to make it the per-iteration sleep already floors at `min-yield-us`. Framerate now tracks render capability up to the 60fps ceiling and degrades smoothly toward render-native below it.
+
+`perf-profile` is the single source of truth: it maps dimensions to `{:frame-us :scale}`, and `target-frame-us` / `render-scale` are thin reads off it.
 
 ```phel
 (def perf-width-threshold 200)
@@ -14,9 +16,9 @@ Terminals >= 200 cols or > 12,000 cells (cols x rows) automatically engage perf-
 (defn perf-mode? [cols rows] (or (>= cols 200) (> (* cols rows) 12000)))
 (defn perf-profile [cols rows]
   (if (perf-mode? cols rows)
-    {:frame-us perf-frame-us     :scale perf-scale}      ; 33333 µs, 2
+    {:frame-us standard-frame-us :scale perf-scale}      ; 16667 µs, 2
     {:frame-us standard-frame-us :scale standard-scale})) ; 16667 µs, 1
-(defn target-frame-us [cols rows] (:frame-us (perf-profile cols rows)))
+(defn target-frame-us [cols rows] (:frame-us (perf-profile cols rows)))  ; uniform 60fps
 (defn render-scale    [cols rows] (:scale    (perf-profile cols rows)))
 ```
 

--- a/src/commands/play.phel
+++ b/src/commands/play.phel
@@ -785,10 +785,12 @@
 
 (defn- adaptive-sleep!
   "Yield the CPU for whatever's left of the per-iteration budget,
-   never less than min-yield-us. Budget comes from target-frame-us
-   which doubles (~33ms) once the terminal crosses the perf-mode
-   threshold — big screens deliberately render at 30fps so the
-   loop doesn't peg a core chasing 60fps it can't reach.
+   never less than min-yield-us. Budget comes from target-frame-us,
+   a uniform ~60fps target at every terminal size: when render fits
+   the budget the loop sleeps the remainder (steady 60fps); when a
+   heavy big-screen frame overruns, `remaining` goes negative and the
+   sleep floors at min-yield-us, so framerate degrades smoothly toward
+   render-native instead of snapping to a 30fps ceiling.
 
    `render-start-s` is the microtime captured immediately before the
    render call (NOT the start of the whole loop iteration); the

--- a/src/core/perf.phel
+++ b/src/core/perf.phel
@@ -35,14 +35,15 @@
       (php/> (php/* cols rows) perf-area-threshold)))
 
 (def standard-frame-us
-  "Cadence target (µs) for standard terminals — ~60fps."
+  "Cadence target (µs) for one game-loop iteration — ~60fps, used at
+   EVERY terminal size. Big screens used to drop to ~30fps, but that
+   was an artificial ceiling: on hardware fast enough to render a
+   perf-mode frame inside this budget the player was still pinned to
+   30fps for no reason, and on hardware too slow to make it the sleep
+   already floors at `min-yield-us` (so the cap never bought anything
+   there either). Cadence is now uniform; framerate tracks render
+   capability up to this 60fps ceiling and degrades naturally below it."
   16667)
-
-(def perf-frame-us
-  "Cadence target (µs) for perf-mode terminals — ~30fps. Doubling the
-   budget lets a genuinely heavier frame finish in time instead of the
-   loop pegging a core chasing an unreachable 60."
-  33333)
 
 (def standard-scale
   "Horizontal render-scale on standard terminals: exact 1:1 path."
@@ -56,20 +57,23 @@
 (defn perf-profile
   "Single source of truth for big-screen perf policy: maps terminal
    dimensions to {:frame-us … :scale …}. `target-frame-us` and
-   `render-scale` are thin reads off this so the cadence + scale policy
-   lives in one place (and stays mutually consistent under future
-   tuning). Pure function of dimensions — safe to read per frame."
+   `render-scale` are thin reads off this so the policy lives in one
+   place. Pure function of dimensions — safe to read per frame.
+
+   `:frame-us` is now `standard-frame-us` at every size (cadence is
+   uniform 60fps, see that def); only `:scale` still varies by size."
   [^int cols ^int rows]
   (if (perf-mode? cols rows)
-    {:frame-us perf-frame-us :scale perf-scale}
+    {:frame-us standard-frame-us :scale perf-scale}
     {:frame-us standard-frame-us :scale standard-scale}))
 
 (defn target-frame-us
-  "Microsecond cadence target for one game-loop iteration: ~60fps on
-   standard terminals, ~30fps on perf-mode ones (see `perf-profile`).
-   Physics / input still tick once per loop, just less often per
-   wall-clock second on big screens — gameplay stays responsive, the
-   loop doesn't peg a core trying to outrun its render budget."
+  "Microsecond cadence target for one game-loop iteration: a uniform
+   ~60fps at every terminal size (see `standard-frame-us`). Big screens
+   no longer drop to 30fps; the per-iteration sleep fills whatever is
+   left of this budget and floors at `min-yield-us` when a heavy frame
+   overruns, so framerate degrades smoothly toward render-native
+   instead of snapping to a 30fps ceiling."
   [^int cols ^int rows]
   (:frame-us (perf-profile cols rows)))
 

--- a/tests/core/perf-test.phel
+++ b/tests/core/perf-test.phel
@@ -36,19 +36,15 @@
   (is (= false (perf-mode? 150 80)))                ; 150*80 = 12000
   (is (= true  (perf-mode? 150 81))))               ; 150*81 = 12150
 
-(deftest test-target-frame-us-60fps-on-small
-  ;; Standard sizes target ~60fps (16.67ms cadence) so motion stays
-  ;; smooth at every supported terminal.
+(deftest test-target-frame-us-uniform-60fps
+  ;; Cadence is a uniform ~60fps (16.67ms budget) at EVERY size. Big
+  ;; terminals no longer drop to 30fps — the artificial ceiling is
+  ;; gone; framerate tracks render capability and the per-iteration
+  ;; sleep floors at min-yield-us when a heavy frame overruns.
   (is (= 16667 (target-frame-us 80 24)))
-  (is (= 16667 (target-frame-us 120 30))))
-
-(deftest test-target-frame-us-30fps-on-big
-  ;; Big terminals drop to ~30fps (33.33ms cadence). Doubling the
-  ;; budget lets render finish in time even when each frame is
-  ;; genuinely heavier than a small terminal's, instead of the loop
-  ;; pegging a core chasing an unreachable 60.
-  (is (= 33333 (target-frame-us 400 60)))
-  (is (= 33333 (target-frame-us 200 30))))
+  (is (= 16667 (target-frame-us 120 30)))
+  (is (= 16667 (target-frame-us 200 30)))
+  (is (= 16667 (target-frame-us 400 60))))
 
 (deftest test-render-scale-1-on-small
   ;; Default 1:1 path on standard terminals — no chunky walls, exact


### PR DESCRIPTION
## Problem

Perf-mode (terminals ≥200 cols or >12,000 cells) forced a 33ms (~30fps) per-iteration budget. That ceiling was **artificial**:

- On hardware fast enough to render a wide-terminal frame inside the 16.6ms budget, the player was pinned to 30fps for no reason.
- On hardware too slow to make it, the per-iteration sleep already floors at `min-yield-us`, so the cap never bought anything there either.

## Change

Cadence is now a **uniform 60fps target at every size**. `target-frame-us` returns `standard-frame-us` regardless of dimensions; `adaptive-sleep!` fills whatever is left of the budget and floors at `min-yield-us` when a heavy frame overruns. Framerate tracks render capability up to the 60fps ceiling and degrades smoothly toward render-native below it - no 30fps snap.

- Removes the now-unused `perf-frame-us`.
- `perf-profile` keeps only the `:scale` axis varying by size (cadence is uniform).
- Physics/input still tick once per loop.

## Note

Big-screen smoothness is ultimately **render-bound**, not cadence-bound; this PR removes the artificial cap so capable runtimes reach 60fps. A separate pass (crisp-walls #5) addresses render scale. Local one-shot benches are not representative (no warm JIT), so absolute fps numbers are omitted deliberately.

## Tests

- `test-target-frame-us-uniform-60fps`: 60fps budget at 80×24 / 120×30 / 200×30 / 400×60.
- Full suite green (1934). `docs/performance.md` + CHANGELOG updated.