### PR TITLE
feat(render): crisp 1:1 walls on big screens (kill chunky 2× mode)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 
 ## [Unreleased]
 
+### Changed
+
+- Wide terminals now render crisp 1:1 walls. The big-screen "perf mode" that cast one ray per 2 columns and replicated it (chunky-looking walls past 200 cols / 12,000 cells) has been removed; every terminal size now uses the exact 1:1 cast. Combined with the uniform 60fps cadence, big screens render at full quality and let framerate track the machine instead of snapping to a degraded mode.
+
 ### Performance
 
 - Big screens are no longer capped at 30fps. The perf-mode cadence ceiling was artificial: on hardware fast enough to render a wide-terminal frame inside the 60fps budget the player was pinned to 30fps for no reason, and on slower hardware the per-frame sleep already floored at the minimum yield. Cadence is now a uniform 60fps target at every terminal size; framerate tracks render capability and degrades smoothly toward render-native below it.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -22,7 +22,7 @@ src/
 │   ├── weapons.phel                 ; per-weapon stats + switch/reload
 │   ├── format.phel                  ; render format helpers
 │   ├── settings.phel                ; difficulty + volume + minimap settings
-│   ├── perf.phel                    ; big-screen perf-mode predicates
+│   ├── perf.phel                    ; frame cadence + render-scale (uniform)
 │   ├── rng.phel                     ; seeded PRNG
 │   ├── difficulty.phel              ; easy/normal/hard/nightmare multipliers
 │   └── version.phel                 ; version string

--- a/docs/features.md
+++ b/docs/features.md
@@ -2,8 +2,8 @@
 
 - 256-color ANSI raycaster, full viewport
 - Sub-5ms `frame->string` at 180x40 (2ms at 80x24, 3ms at 120x30)
-- Perf mode (auto-engage >= 200 cols or > 12k cells): 30 fps + 2x horizontal scale
-- `proj-dist` decoupled from viewport width - resize widens FOV, not zoom
+- Uniform ~60fps target + crisp 1:1 walls at every terminal size (no big-screen 30fps / chunky-scale degradation)
+- `proj-dist` decoupled from viewport width - resize widens FOV, not zoom - FOV clamps at 90° past 140 cols so wide terminals gain horizontal resolution, not edge fisheye
 - Half-block sub-cell shading on wall edges; brick glyphs (4% of cells)
 - 5-stage death animation: flash -> slump -> collapse -> blood mid -> blood dim
 - Responsive help panel, collapses on tight screens

--- a/docs/game-loop.md
+++ b/docs/game-loop.md
@@ -82,9 +82,8 @@ The pipeline enqueues effects (sfx, hits) into `:sfx` on the world itself; the g
 
 ## Frame timing + adaptive FPS
 
-- **60 fps target** (16.667 ms) on standard terminals (< 200 cols OR area ≤ 12000 cells).
-- **30 fps** on big screens (area > 12000 cells) - perf-mode engagement via `core/perf.phel`.
-- `target-frame-us` reads terminal dimensions and selects 16667 µs (60 fps) or 33333 µs (30 fps). Render time is the real bottleneck; sleep yields CPU.
+- **60 fps target** (16.667 ms) at every terminal size, via `core/perf.phel`. The old big-screen 30fps cap was removed - it was an artificial ceiling (see `docs/performance.md`).
+- `target-frame-us` returns a uniform 16667 µs. Render time is the real bottleneck on big screens; `adaptive-sleep!` fills the remainder of the budget and floors at `min-yield-us`, so framerate degrades smoothly toward render-native instead of snapping to 30fps.
 - `ms-since` computes wall-clock delta. Args tagged `^float` so Phel doesn't infer `int` from `* 1000` and trigger PHP 8.4+ implicit-conversion deprecation on microtime values.
 - `dt` is elapsed-seconds float used by physics, AI, decay. Same dt across sub-steps keeps simulation consistent inside a frame.
 

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -2,24 +2,20 @@
 
 `frame->string` at 180×40 runs in ~5ms. Inner loop is ~7200 iterations per frame (180 cols × 40 rows). Tricks that got it from "tens of ms" to "single-digit ms".
 
-## Big-screen perf mode
+## Big screens: uniform cadence + crisp walls
 
-Terminals >= 200 cols or > 12,000 cells (cols x rows) engage perf-mode: 2x render-scale (each ray casts once and replicates to 2 columns; minimap caps at 40 cols). Physics and input tick per frame.
+Cadence and render-scale are **uniform at every terminal size**. The old "big-screen perf mode" (a width/area threshold that dropped wide terminals to 30fps and a chunky 2x render-scale) has been removed:
 
-Cadence is a **uniform ~60fps at every size**. Big screens used to drop to 30fps, but that was an artificial ceiling: on hardware fast enough to render a perf-mode frame inside the 16.67ms budget the player was pinned to 30fps for no reason, and on hardware too slow to make it the per-iteration sleep already floors at `min-yield-us`. Framerate now tracks render capability up to the 60fps ceiling and degrades smoothly toward render-native below it.
+- **Cadence**: a uniform ~60fps target. The 30fps cap was artificial - on hardware fast enough to render a wide-terminal frame inside the 16.67ms budget the player was pinned to 30fps for no reason, and on hardware too slow to make it the per-iteration sleep already floors at `min-yield-us`. Framerate now tracks render capability up to the 60fps ceiling and degrades smoothly toward render-native below it.
+- **Scale**: a uniform 1 (exact 1:1 cast). Wide terminals render crisp walls instead of 2x replicated pairs. `cast-frame` still accepts a `scale` argument, so the replication path stays available, it is just always called with 1.
 
-`perf-profile` is the single source of truth: it maps dimensions to `{:frame-us :scale}`, and `target-frame-us` / `render-scale` are thin reads off it.
+Wide terminals are render-bound, not cadence-bound: the cost is the per-column cast + wall-shade work, which scales with column count. The minimap still caps at 40 cols (see `layout`). Physics and input tick once per frame.
 
 ```phel
-(def perf-width-threshold 200)
-(def perf-area-threshold  12000)
-(defn perf-mode? [cols rows] (or (>= cols 200) (> (* cols rows) 12000)))
-(defn perf-profile [cols rows]
-  (if (perf-mode? cols rows)
-    {:frame-us standard-frame-us :scale perf-scale}      ; 16667 µs, 2
-    {:frame-us standard-frame-us :scale standard-scale})) ; 16667 µs, 1
-(defn target-frame-us [cols rows] (:frame-us (perf-profile cols rows)))  ; uniform 60fps
-(defn render-scale    [cols rows] (:scale    (perf-profile cols rows)))
+(def standard-frame-us 16667)   ; ~60fps, every size
+(def standard-scale     1)      ; crisp 1:1, every size
+(defn target-frame-us [cols rows] standard-frame-us)
+(defn render-scale    [cols rows] standard-scale)
 ```
 
 ## PHP runtime: OPcache + JIT

--- a/docs/rendering.md
+++ b/docs/rendering.md
@@ -115,9 +115,9 @@ Grounding shadow and face glyph need depth-culling: paint only if in front of wa
 
 Consecutive same-color cells coalesce: one escape + N spaces (terminal repeats BG). Cuts output 5-10x on monochrome rows. State machine tracks `prev` + `run`, flushes on color change.
 
-## Render-scale on big screens
+## Render-scale: uniform crisp walls
 
-Perf mode (>= 200 cols or > 12k cell area): `render-scale = 2` - cast once per 2 cols, horizontally replicate. Wall data accurate per original ray; horizontally stretched but not distorted.
+`render-scale` is a uniform 1 at every terminal size: one ray per output column, exact 1:1 cast, crisp walls. The old big-screen perf mode (cast once per 2 cols and replicate, for a chunky look on wide terminals) has been removed. `cast-frame` still accepts a `scale` argument so the replication path stays available, it is just always called with 1.
 
 ## Responsive help panel
 

--- a/src/core/enemy_ai.phel
+++ b/src/core/enemy_ai.phel
@@ -76,10 +76,9 @@
 
 (def pain-stagger-secs
   "Seconds a freshly-painted enemy stays frozen. ~0.3s reads as a
-   visible flinch on screen at 60fps (and double that at 30fps perf
-   mode) without making the enemy a soft target for the next 2-3
-   shots. Long enough that the player can capitalise + reload; short
-   enough that hits don't cancel into a stun-lock chain."
+   visible flinch on screen without making the enemy a soft target for
+   the next 2-3 shots. Long enough that the player can capitalise +
+   reload; short enough that hits don't cancel into a stun-lock chain."
   0.3)
 
 (def default-pain-chance

--- a/src/core/engine.phel
+++ b/src/core/engine.phel
@@ -210,14 +210,14 @@
               hx      (php/aget hit-arr 3)
               hy      (php/aget hit-arr 4)]
            ;; Replicate this sample across the next `scale` output
-           ;; columns. Inner loop bound by `width` so a non-divisible
-           ;; tail (e.g. width=401, scale=2) doesn't overshoot. The
-           ;; fish-eye correction uses the SAMPLE column's `offset`
-           ;; for every neighbour cell — deliberate approximation:
-           ;; at scale=2 the two replicated cells share the same
-           ;; cos(offset), reading as slightly chunkier walls. The
-           ;; per-cell-accurate alternative would mean N atan + cos
-           ;; calls per sample, defeating the perf-mode win.
+           ;; columns. `scale` is 1 today (crisp 1:1 walls everywhere),
+           ;; so this fills exactly one cell; the loop keeps the
+           ;; replication capability for any caller that passes scale>1.
+           ;; Inner loop bound by `width` so a non-divisible tail (e.g.
+           ;; width=401, scale=2) doesn't overshoot. When scale>1 the
+           ;; fish-eye correction reuses the SAMPLE column's `offset`
+           ;; for every neighbour cell (the per-cell-accurate
+           ;; alternative would mean N atan + cos calls per sample).
           (loop [c col fill 0]
             (when (and (php/< c width) (php/< fill scale))
               (php/aset dists c d-corr)

--- a/src/core/perf.phel
+++ b/src/core/perf.phel
@@ -1,92 +1,48 @@
 (ns phel-doom.core.perf)
 
 ;; ---------------------------------------------------------------------
-;; Big-screen perf mode.
+;; Frame cadence + render scale.
 ;;
-;; Pure predicates + scaling helpers used by the play loop (cadence
-;; throttle) and the renderer (virtual-width emit, future expansions).
-;; At standard terminal sizes (80×24, 120×30) every helper here is a
-;; no-op — perf mode only kicks in once the terminal crosses a width
-;; or area threshold where the 1:1 60fps render path stops fitting
-;; cleanly inside a frame budget.
+;; Both are now UNIFORM across every terminal size. The old "big-screen
+;; perf mode" (a width/area threshold that dropped wide terminals to
+;; 30fps and a chunky 2× render-scale) is gone:
+;;   - cadence: the 30fps cap was artificial — capable hardware was
+;;     pinned to 30fps for no reason, and slow hardware already floored
+;;     at min-yield-us. See `standard-frame-us`.
+;;   - scale: wide terminals now render crisp 1:1 walls instead of
+;;     replicated 2× pairs.
+;; `cast-frame` still accepts a `scale` argument (replication capability
+;; is intact), it is just always called with 1.
 ;; ---------------------------------------------------------------------
 
-(def perf-width-threshold
-  "Column count at or above which a terminal counts as 'wide' for
-   perf-mode purposes. 200 covers the realistic gap between a
-   regular tiling-WM pane (~120-180) and a true ultrawide /
-   full-screen 4K terminal (300-500+). Below 200 → 1:1 path."
-  200)
-
-(def perf-area-threshold
-  "Cell-count threshold (cols × rows) — a tall-but-narrow terminal
-   (say 120×60) still benefits from perf mode because the renderer
-   walks rows too. 12000 cells ≈ 200×60 OR 300×40 OR 400×30, all of
-   which strain the 16ms frame budget on the standard render path."
-  12000)
-
-(defn perf-mode?
-  "True when the terminal is wide / tall enough that big-screen perf
-   optimisations should engage (cadence drop to 30fps, virtual-width
-   2× emit, etc). Pure function of dimensions so it's safe to read
-   per frame — `term-size` is the only varying input."
-  [^int cols ^int rows]
-  (or (php/>= cols perf-width-threshold)
-      (php/> (php/* cols rows) perf-area-threshold)))
-
 (def standard-frame-us
-  "Cadence target (µs) for one game-loop iteration — ~60fps, used at
-   EVERY terminal size. Big screens used to drop to ~30fps, but that
-   was an artificial ceiling: on hardware fast enough to render a
-   perf-mode frame inside this budget the player was still pinned to
-   30fps for no reason, and on hardware too slow to make it the sleep
-   already floors at `min-yield-us` (so the cap never bought anything
-   there either). Cadence is now uniform; framerate tracks render
-   capability up to this 60fps ceiling and degrades naturally below it."
+  "Cadence target (µs) for one game-loop iteration — ~60fps, at EVERY
+   terminal size. Big screens used to drop to ~30fps, but that was an
+   artificial ceiling: on hardware fast enough to render a wide-terminal
+   frame inside this budget the player was still pinned to 30fps, and on
+   hardware too slow to make it the per-iteration sleep already floors
+   at `min-yield-us`. Framerate now tracks render capability up to this
+   60fps ceiling and degrades naturally below it."
   16667)
 
 (def standard-scale
-  "Horizontal render-scale on standard terminals: exact 1:1 path."
+  "Horizontal render-scale: exact 1:1 path (one ray per output column)
+   at EVERY terminal size — crisp walls, no chunky 2× replication."
   1)
-
-(def perf-scale
-  "Horizontal render-scale on perf-mode terminals: one ray per 2 output
-   columns, replicated across the pair (chunky-but-readable walls)."
-  2)
-
-(defn perf-profile
-  "Single source of truth for big-screen perf policy: maps terminal
-   dimensions to {:frame-us … :scale …}. `target-frame-us` and
-   `render-scale` are thin reads off this so the policy lives in one
-   place. Pure function of dimensions — safe to read per frame.
-
-   `:frame-us` is now `standard-frame-us` at every size (cadence is
-   uniform 60fps, see that def); only `:scale` still varies by size."
-  [^int cols ^int rows]
-  (if (perf-mode? cols rows)
-    {:frame-us standard-frame-us :scale perf-scale}
-    {:frame-us standard-frame-us :scale standard-scale}))
 
 (defn target-frame-us
   "Microsecond cadence target for one game-loop iteration: a uniform
-   ~60fps at every terminal size (see `standard-frame-us`). Big screens
-   no longer drop to 30fps; the per-iteration sleep fills whatever is
-   left of this budget and floors at `min-yield-us` when a heavy frame
-   overruns, so framerate degrades smoothly toward render-native
-   instead of snapping to a 30fps ceiling."
+   ~60fps at every terminal size (see `standard-frame-us`). Takes the
+   live dimensions so the call site stays stable, but the budget no
+   longer varies by size."
   [^int cols ^int rows]
-  (:frame-us (perf-profile cols rows)))
+  standard-frame-us)
 
 (defn render-scale
-  "Horizontal render-scale factor consumed by `cast-frame`: it casts
-   one ray per N output columns and replicates the sample across the
-   next N entries of the dists/hits/sides/hxs/hys arrays. Downstream
-   row-loop code is unchanged — it still reads vw-sized buffers column
-   by column, just with N-wide runs of identical values.
-
-   2 on perf-mode terminals (cuts cast + per-col wall-shade work
-   roughly in half), 1 on standard terminals (exact 1:1 path). See
-   `perf-profile`. Sprites + HUD operate at full vw so the chunky look
-   is contained to the wall band."
+  "Horizontal render-scale factor consumed by `cast-frame`. A uniform
+   1 (exact 1:1 cast) at every terminal size — wide terminals render
+   crisp walls rather than the chunky 2× pairs the old perf mode used.
+   Takes the live dimensions so the call site stays stable, but the
+   factor no longer varies by size."
   [^int cols ^int rows]
-  (:scale (perf-profile cols rows)))
+  standard-scale)

--- a/src/io/render/main.phel
+++ b/src/io/render/main.phel
@@ -263,10 +263,9 @@
         ;; off path — a single `(get stats :debug?)` check per frame.
         debug?                             (get stats :debug?)
         t-cast-start                       (if debug? (php/microtime true) 0.0)
-        ;; render-scale = 2 on perf-mode terminals: one ray per pair
-        ;; of output columns, each sample replicated across the pair.
-        ;; Halves cast + wall-shade work with a chunky-per-2-cols
-        ;; look. Standard sizes return 1 → identical to before.
+        ;; render-scale is a uniform 1 at every size: exact 1:1 cast,
+        ;; crisp walls. cast-frame still takes the factor so the
+        ;; replication path stays available if ever needed.
         scale                              (render-scale vw vh)
         {:keys [dists hits sides]}
         (cast-frame world vw scale)

--- a/tests/core/perf-test.phel
+++ b/tests/core/perf-test.phel
@@ -1,72 +1,27 @@
 (ns phel-doom-tests.core.perf-test
   (:require phel.test :refer [deftest is])
-  (:require phel-doom.core.perf :refer [perf-mode? target-frame-us
-                                        render-scale perf-profile
-                                        perf-width-threshold
-                                        perf-area-threshold]))
-
-(deftest test-perf-mode-off-on-small-terminals
-  ;; Standard terminal sizes never engage perf mode — 1:1 60fps stays
-  ;; the default path so existing CI / dev workflows are unaffected.
-  (is (= false (perf-mode? 80 24)))
-  (is (= false (perf-mode? 120 30)))
-  (is (= false (perf-mode? 180 40))))
-
-(deftest test-perf-mode-on-by-width
-  ;; At or above the width threshold perf mode engages regardless of
-  ;; row count — wide ultrawides still strain the render path even
-  ;; when vh is modest.
-  (is (= true (perf-mode? perf-width-threshold 24)))
-  (is (= true (perf-mode? 400 30)))
-  (is (= true (perf-mode? 250 20))))
-
-(deftest test-perf-mode-on-by-area
-  ;; Tall-but-narrow terminals (120×60 = 7200 cells, below) stay on
-  ;; the standard path; once total cells cross `perf-area-threshold`
-  ;; the render walks become heavy enough to justify the drop to
-  ;; 30fps cadence.
-  (is (= false (perf-mode? 120 60)))
-  (is (= true  (perf-mode? 180 70))))               ; 12600 cells
-
-(deftest test-perf-mode-area-boundary-is-strict
-  ;; perf-mode? uses strict `>` for the area predicate — exactly
-  ;; equal to perf-area-threshold (12000) must NOT engage perf mode.
-  ;; Pin the boundary so a future refactor doesn't silently swap to
-  ;; >= and shift every "just at the limit" terminal into perf mode.
-  (is (= false (perf-mode? 150 80)))                ; 150*80 = 12000
-  (is (= true  (perf-mode? 150 81))))               ; 150*81 = 12150
+  (:require phel-doom.core.perf :refer [target-frame-us render-scale
+                                        standard-frame-us standard-scale]))
 
 (deftest test-target-frame-us-uniform-60fps
-  ;; Cadence is a uniform ~60fps (16.67ms budget) at EVERY size. Big
-  ;; terminals no longer drop to 30fps — the artificial ceiling is
-  ;; gone; framerate tracks render capability and the per-iteration
-  ;; sleep floors at min-yield-us when a heavy frame overruns.
-  (is (= 16667 (target-frame-us 80 24)))
-  (is (= 16667 (target-frame-us 120 30)))
-  (is (= 16667 (target-frame-us 200 30)))
-  (is (= 16667 (target-frame-us 400 60))))
+  ;; Cadence is a uniform ~60fps (16.67ms budget) at EVERY size. The
+  ;; old 30fps big-screen ceiling is gone; framerate tracks render
+  ;; capability and the per-iteration sleep floors at min-yield-us when
+  ;; a heavy frame overruns.
+  (is (= standard-frame-us (target-frame-us 80 24)))
+  (is (= standard-frame-us (target-frame-us 120 30)))
+  (is (= standard-frame-us (target-frame-us 200 30)))
+  (is (= standard-frame-us (target-frame-us 400 100))))
 
-(deftest test-render-scale-1-on-small
-  ;; Default 1:1 path on standard terminals — no chunky walls, exact
-  ;; one ray per column.
-  (is (= 1 (render-scale 80 24)))
-  (is (= 1 (render-scale 120 30)))
-  (is (= 1 (render-scale 180 40))))
+(deftest test-render-scale-uniform-crisp
+  ;; Render scale is a uniform 1 (exact 1:1 cast) at EVERY size. Wide
+  ;; terminals render crisp walls instead of chunky 2× replicated pairs.
+  (is (= standard-scale (render-scale 80 24)))
+  (is (= standard-scale (render-scale 120 30)))
+  (is (= standard-scale (render-scale 200 30)))
+  (is (= standard-scale (render-scale 400 100))))
 
-(deftest test-render-scale-2-on-big
-  ;; Perf mode halves cast + per-col wall-shade work by sampling every
-  ;; 2nd column and replicating the result across the pair.
-  (is (= 2 (render-scale 400 60)))
-  (is (= 2 (render-scale 200 30)))
-  (is (= 2 (render-scale 180 70))))
-
-(deftest test-perf-profile-is-single-source-of-truth
-  ;; target-frame-us + render-scale are thin reads off perf-profile;
-  ;; pin that they stay mutually consistent so a future policy tweak
-  ;; can't drift the cadence and the scale apart.
-  (let [small (perf-profile 80 24)
-        big   (perf-profile 400 60)]
-    (is (= (:frame-us small) (target-frame-us 80 24)))
-    (is (= (:scale small)    (render-scale 80 24)))
-    (is (= (:frame-us big)   (target-frame-us 400 60)))
-    (is (= (:scale big)      (render-scale 400 60)))))
+(deftest test-scale-is-one
+  ;; Pin the actual value: crisp means 1, not "some small N".
+  (is (= 1 standard-scale))
+  (is (= 1 (render-scale 500 120))))


### PR DESCRIPTION
## What

`render-scale` was 2 on wide terminals (≥200 cols / >12,000 cells): one ray per 2 output columns, replicated across the pair - chunky-looking walls. It is now a **uniform 1** at every size: exact 1:1 cast, crisp walls.

## The chunky mode bought almost nothing

Full-frame `frame->string` time is unchanged scale=2 → scale=1:

| Viewport | scale=2 | scale=1 | Δ |
|---------:|--------:|--------:|---|
| 240×67 | 112 ms | 116 ms | noise |
| 300×80 | 166 ms | 171 ms | noise |
| 400×100 | 275 ms | 278 ms | noise |

(Local one-shot bench, no warm JIT - absolute numbers inflated, but the **delta** is the point.) The per-cell row-loop walk (sky/floor gradients, sprite paint, RLE) at full `vw` dominates; `scale` only affected the sub-ms cast (+0.4-0.6ms at 600 cols) and the per-column wall prebake. So crisp walls cost effectively nothing.

## Cleanup

With cadence already uniform (#173), `perf-mode` no longer varied anything. Removed `perf-mode?`, `perf-width-threshold`, `perf-area-threshold`, `perf-scale`, `perf-profile`. `cast-frame` keeps its `scale` argument - the replication path stays available, just always called with 1.

## Tests / docs

- perf-test rewritten for the uniform API; full suite green (1920).
- Updated `docs/performance.md`, `rendering.md`, `game-loop.md`, `architecture.md`, `features.md` + CHANGELOG. Scrubbed stale perf-mode comments in `engine.phel` / `render/main.phel` / `enemy_ai.phel`.