### PR TITLE
feat(play): --max-cols / --max-rows render-size caps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 
 ## [Unreleased]
 
+### Added
+
+- `--max-cols=N` / `--max-rows=N` flags cap the render size on a larger terminal: the game draws a smaller inset frame and leaves the surplus as a blank border. Useful on ultrawide / fullscreen terminals where a full-width cast is heavy and (past the 90-degree FOV clamp) adds no field of view - cap to ~140 cols for a crisp, cheap render. 0 / unset fills the terminal. Caps only shrink, never grow past the real terminal, and never below a small playable floor. The inset is anchored top-left; centered letterboxing is a possible follow-up (the HUD/minimap overlays use absolute cursor positioning that would need a global offset).
+
 ### Changed
 
 - Wide terminals now render crisp 1:1 walls. The big-screen "perf mode" that cast one ray per 2 columns and replicated it (chunky-looking walls past 200 cols / 12,000 cells) has been removed; every terminal size now uses the exact 1:1 cast. Combined with the uniform 60fps cadence, big screens render at full quality and let framerate track the machine instead of snapping to a degraded mode.

--- a/docs/game-loop.md
+++ b/docs/game-loop.md
@@ -84,6 +84,7 @@ The pipeline enqueues effects (sfx, hits) into `:sfx` on the world itself; the g
 
 - **60 fps target** (16.667 ms) at every terminal size, via `core/perf.phel`. The old big-screen 30fps cap was removed - it was an artificial ceiling (see `docs/performance.md`).
 - `target-frame-us` returns a uniform 16667 µs. Render time is the real bottleneck on big screens; `adaptive-sleep!` fills the remainder of the budget and floors at `min-yield-us`, so framerate degrades smoothly toward render-native instead of snapping to 30fps.
+- The live `term-size` is clamped through `cap-dims` (`core/perf.phel`) before render, applying the `--max-cols` / `--max-rows` caps. A cap shrinks the render area and leaves the surplus terminal as a blank inset border (the full-screen clear on resize keeps it clean). Caps only shrink, never grow past the real terminal.
 - `ms-since` computes wall-clock delta. Args tagged `^float` so Phel doesn't infer `int` from `* 1000` and trigger PHP 8.4+ implicit-conversion deprecation on microtime values.
 - `dt` is elapsed-seconds float used by physics, AI, decay. Same dt across sub-steps keeps simulation consistent inside a frame.
 

--- a/docs/gameplay.md
+++ b/docs/gameplay.md
@@ -62,3 +62,5 @@ Hold `space` for auto-fire on pistol/chaingun/chainsaw/incinerator. Shotgun, BFG
 - `--god` (`-g`) - invincible
 - `--armory` (`-a`) - start with all weapons
 - `--full-map` (`-f`) - reveal map
+- `--max-cols=N` - cap render width to N columns on a wider terminal; the surplus becomes a blank inset border (0 / unset fills the terminal)
+- `--max-rows=N` - cap render height to N rows on a taller terminal (0 / unset fills the terminal)

--- a/src/commands/play.phel
+++ b/src/commands/play.phel
@@ -24,7 +24,7 @@
   (:require phel-doom.demo.phases :as showcase)
   (:require phel-doom.core.rng    :as rng)
   (:require phel-doom.core.level    :refer [build-world num-levels place-secret-reward])
-  (:require phel-doom.core.perf     :refer [target-frame-us])
+  (:require phel-doom.core.perf     :refer [target-frame-us cap-dims])
   (:require phel-doom.core.version  :refer [version])
   (:require phel-doom.io.scores   :refer [update-scores!])
   (:require phel-doom.io.render   :refer [render! clear-screen
@@ -828,7 +828,7 @@
         (assoc world :save-flash-secs save-flash-seconds :save-flash-msg "NO SAVE")))
     :else         world))
 
-(defn- game-loop [world0]
+(defn- game-loop [world0 max-rows max-cols]
   (let [t-start (php/microtime true)]
     (loop [world     world0
            t-last    t-start
@@ -836,7 +836,12 @@
            fps       0
            prev-keys initial-key-snapshot
            dims      [0 0]]
-      (let [[rows cols] (term-size)]
+      ;; Cap the live terminal size to the configured render bounds
+      ;; (--max-cols / --max-rows). A 0 cap fills the terminal; a
+      ;; positive cap shrinks the render area, leaving the surplus as a
+      ;; blank inset border (clear-screen on resize keeps it clean).
+      (let [[trows tcols] (term-size)
+            [rows cols]   (cap-dims trows tcols max-rows max-cols)]
         (redraw-if-resized dims rows cols)
         (let [render-start (php/microtime true)]
           (draw-frame world fps frame-ms rows cols)
@@ -989,8 +994,12 @@
    clamped. Death + retry reset to L1 (the start-level only seeds
    the initial loop entry). `demo-phase` (nil for normal play, 1..4 for
    the tech-talk showcase) applies a per-phase world transform after
-   build-world (see phel-doom.demo.phases/apply-phase)."
-  [diff god? armory? full-map? demo-phase start-level init-seed init-settings]
+   build-world (see phel-doom.demo.phases/apply-phase). `max-rows` /
+   `max-cols` (from --max-rows / --max-cols, 0 = uncapped) clamp the
+   per-frame render size; the game-loop applies them to the live
+   terminal size so a big terminal renders a smaller inset frame."
+  [diff god? armory? full-map? demo-phase start-level init-seed init-settings
+   max-rows max-cols]
   (loop [level       (php/max 1 (php/min num-levels (or start-level 1)))
          lives       max-lives
          carry-kills 0
@@ -1040,7 +1049,7 @@
           ;; Tech-talk showcase: strip subsystems this phase hasn't
           ;; revealed yet. Pure world->world; no-op for normal play.
           w3d    (if demo-phase (showcase/apply-phase demo-phase w3) w3)
-          result (game-loop w3d)]
+          result (game-loop w3d max-rows max-cols)]
       (cond
         (= result :quit)
         nil
@@ -1162,6 +1171,14 @@
       d
       (:difficulty settings))))
 
+(defn- opt-int
+  "Coerce a CLI option string to a non-negative int. nil / empty / a
+   non-numeric value → 0 (treated as 'no cap' by the render-size caps)."
+  [raw]
+  (if (or (nil? raw) (= raw ""))
+    0
+    (php/max 0 (php/intval raw))))
+
 (defn- run-play [ctx]
   (init-input!)
   (let [diff-raw    (cli/opt ctx "difficulty")
@@ -1174,6 +1191,11 @@
                       (nil? lv-raw) nil
                       (= lv-raw "") nil
                       :else         (php/intval lv-raw))
+        ;; Render-size caps (--max-cols / --max-rows). Empty / nil / 0 →
+        ;; no cap on that axis (fill the terminal). A positive value
+        ;; shrinks the render area, leaving a blank inset border.
+        max-cols    (opt-int (cli/opt ctx "max-cols"))
+        max-rows    (opt-int (cli/opt ctx "max-rows"))
         ;; Demo (issue #64): --demo replays a recorded run (forces its
         ;; seed + input stream, skips the menu); --record captures the
         ;; run's seed + per-frame input to a file on exit.
@@ -1208,7 +1230,8 @@
           ;; + end screens). N-toggle starts/stops it mid-run; teardown
           ;; always stops it so no loop process is orphaned.
           (music/start-music!)
-          (run-levels diff god? armory? full-map? nil lv init-seed settings)
+          (run-levels diff god? armory? full-map? nil lv init-seed settings
+                      max-rows max-cols)
           (music/stop-music!)
           (when record? (demo/save-recording! record-path))
           (demo/reset-off!)
@@ -1239,7 +1262,7 @@
     ;; god + armory (own every weapon, ammo refilled to :armory-reserve
     ;; = 99 each tick by combat/tick-armory) + full-map. The phase stamps
     ;; :show-map true so the corner minimap is visible by default.
-    (run-levels :normal true true true phase 1 (rng/fresh-seed) settings0)
+    (run-levels :normal true true true phase 1 (rng/fresh-seed) settings0 0 0)
     (music/stop-music!)
     (demo/reset-off!)
     (restore!)
@@ -1281,5 +1304,13 @@
           {:name    "demo"
            :mode    :optional
            :doc     "Replay a demo file recorded with --record (skips the start menu)."
+           :default ""}
+          {:name    "max-cols"
+           :mode    :optional
+           :doc     "Cap the render width to N columns on a wider terminal (the surplus becomes a blank inset border). 0 / unset fills the terminal. Handy on ultrawide / fullscreen terminals where a full-width cast is heavy and adds no FOV past the 90-degree clamp."
+           :default ""}
+          {:name    "max-rows"
+           :mode    :optional
+           :doc     "Cap the render height to N rows on a taller terminal (surplus becomes a blank inset border). 0 / unset fills the terminal."
            :default ""}]
    :run  run-play})

--- a/src/core/perf.phel
+++ b/src/core/perf.phel
@@ -46,3 +46,36 @@
    factor no longer varies by size."
   [^int cols ^int rows]
   standard-scale)
+
+(def min-render-cols
+  "Hard floor for a capped render width: a `--max-cols` smaller than
+   this is raised to it so the viewport never collapses below a
+   playable width (HUD + 3D view still read)."
+  40)
+
+(def min-render-rows
+  "Hard floor for a capped render height (see `min-render-cols`)."
+  15)
+
+(defn- cap-axis
+  "Clamp one axis. `cap <= 0` means no cap → return the terminal value
+   untouched. A positive cap renders at most `cap`, but never below
+   `floor` and never above the terminal value itself (you cannot draw
+   wider than the terminal). So the result is the cap clamped into
+   [floor, val]; when the terminal is smaller than the floor the
+   terminal value wins."
+  [^int val ^int cap ^int floor]
+  (if (php/<= cap 0)
+    val
+    (php/min val (php/max floor (php/min cap val)))))
+
+(defn cap-dims
+  "Clamp a terminal `[rows cols]` to the configured render caps,
+   returning the `[rows cols]` the renderer should actually draw. A cap
+   of 0 (or less) on an axis means 'fill the terminal' on that axis.
+   Caps only ever SHRINK the render area (the surplus terminal becomes a
+   blank inset border); they never grow it past the real terminal size.
+   Pure — safe to call per frame on the live `term-size`."
+  [^int rows ^int cols ^int max-rows ^int max-cols]
+  [(cap-axis rows max-rows min-render-rows)
+   (cap-axis cols max-cols min-render-cols)])

--- a/tests/core/perf-test.phel
+++ b/tests/core/perf-test.phel
@@ -1,7 +1,8 @@
 (ns phel-doom-tests.core.perf-test
   (:require phel.test :refer [deftest is])
   (:require phel-doom.core.perf :refer [target-frame-us render-scale
-                                        standard-frame-us standard-scale]))
+                                        standard-frame-us standard-scale
+                                        cap-dims min-render-cols min-render-rows]))
 
 (deftest test-target-frame-us-uniform-60fps
   ;; Cadence is a uniform ~60fps (16.67ms budget) at EVERY size. The
@@ -25,3 +26,28 @@
   ;; Pin the actual value: crisp means 1, not "some small N".
   (is (= 1 standard-scale))
   (is (= 1 (render-scale 500 120))))
+
+(deftest test-cap-dims-zero-cap-fills-terminal
+  ;; A cap of 0 on an axis means "use the full terminal" on that axis.
+  (is (= [60 240] (cap-dims 60 240 0 0)))
+  (is (= [60 120] (cap-dims 60 240 0 120)))   ; only cols capped
+  (is (= [40 240] (cap-dims 60 240 40 0))))   ; only rows capped
+
+(deftest test-cap-dims-shrinks-only
+  ;; Caps shrink the render area; they never grow past the real terminal.
+  (is (= [30 120] (cap-dims 30 120 60 240)))  ; caps exceed terminal → no-op
+  (is (= [30 120] (cap-dims 30 120 30 120)))) ; cap == terminal → no-op
+
+(deftest test-cap-dims-applies-cap-below-terminal
+  ;; A cap below the terminal size clamps the render area; the surplus
+  ;; becomes a blank inset border.
+  (is (= [40 160] (cap-dims 80 320 40 160))))
+
+(deftest test-cap-dims-respects-floor
+  ;; A cap below the hard floor is raised to the floor (viewport never
+  ;; collapses) — as long as the terminal itself is at least the floor.
+  (is (= [min-render-rows min-render-cols]
+         (cap-dims 100 200 5 10)))
+  ;; …but a terminal smaller than the floor still wins (can't draw
+  ;; wider than the terminal).
+  (is (= [10 20] (cap-dims 10 20 5 10))))


### PR DESCRIPTION
## What

Two new CLI flags let the player cap the render size on a larger terminal:

- `--max-cols=N` - render at most N columns wide
- `--max-rows=N` - render at most N rows tall

0 / unset fills the terminal (unchanged default). A positive cap shrinks the render area; the surplus terminal becomes a blank inset border.

## Why

On ultrawide / fullscreen terminals a full-width cast is heavy and - past the 90° FOV clamp (#171) - adds **no field of view**, only horizontal resolution. Capping to ~140 cols gives a crisp, cheap render at the natural 90° FOV instead of casting 300+ columns. It is also just a comfort knob (play in a smaller window).

## How

`cap-dims` (`core/perf.phel`, pure) clamps the live `term-size` each frame:

- cap ≤ 0 → fill the terminal on that axis
- cap > 0 → clamp into `[floor, terminal]` (never below a small playable floor of 40×15, never above the real terminal)

`game-loop` applies it before render + resize detection; the existing full-screen clear on resize keeps the inset border clean. `render!` / `frame->string` already render correctly at any size, so there are **zero changes to render internals**.

## Scope note

The inset is anchored **top-left**. Centered letterboxing is a deliberate follow-up: the HUD / minimap / end-screen overlays use absolute cursor positioning (`\e[r;cH`) that would each need a global (left, top) offset, which is hard to verify without a human in the loop. The functional cap (the actual ask) is complete and safe.

## Tests / docs

- 5 new `cap-dims` cases (zero-cap, shrink-only, apply-below-terminal, floor, terminal-smaller-than-floor). Full suite green (1928).
- Smoke-tested launch with `--max-cols 120 --max-rows 30` (clean menu + quit).
- Docs: `gameplay.md`, `game-loop.md` + CHANGELOG.