### PR TITLE
perf(render): memoize sky/floor gradients by viewport height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 
 ### Performance
 
+- Sky/floor gradients are memoized by viewport height. They were rebuilt from scratch every frame (6 arrays sized to the viewport) though they depend only on the height; a single-slot cache now rebuilds them only on resize. Worth ~0.3-0.5ms/frame at 40-100 rows - small in absolute terms but a meaningful slice of the sub-5ms frame budget on the JIT runtime.
 - Big screens are no longer capped at 30fps. The perf-mode cadence ceiling was artificial: on hardware fast enough to render a wide-terminal frame inside the 60fps budget the player was pinned to 30fps for no reason, and on slower hardware the per-frame sleep already floored at the minimum yield. Cadence is now a uniform 60fps target at every terminal size; framerate tracks render capability and degrades smoothly toward render-native below it.
 
 ### Fixed

--- a/src/io/render/main.phel
+++ b/src/io/render/main.phel
@@ -198,6 +198,36 @@
 ;; § Per-frame pipeline
 ;; =====================================================================
 
+;; Sky / floor gradients (shade arrays + their code twins, normal +
+;; blood variants) depend ONLY on `vh`: the palettes are compile-time
+;; constants and the floor base-code / banding are literals. They were
+;; rebuilt from scratch every frame (6 × O(vh) allocations); now a
+;; single-slot atom memoizes the whole bundle keyed by vh, so they
+;; rebuild only when the viewport height changes (resize / F3 toggle).
+;; Input-determined cache — same vh always yields the same arrays — so
+;; it preserves frame->string's referential transparency, same as the
+;; engine's offset-cache.
+(def- gradient-cache (atom {:vh -1}))
+
+(defn- frame-gradients
+  "Memoized sky/floor gradient bundle for viewport height `vh`. Returns
+   a map of the 6 gradient arrays (normal + blood, shade + code twins),
+   rebuilding only on a vh change. Blood variants are always built here;
+   the caller still gates their USE on the live `bloody?` flag."
+  [^int vh]
+  (let [c @gradient-cache]
+    (if (php/=== vh (:vh c))
+      c
+      (let [bundle {:vh             vh
+                    :sky            (build-horizon-gradient vh shade-table)
+                    :floor          (build-themed-gradient vh 239 true)
+                    :sky-code       (build-horizon-gradient-codes vh shade-code-table)
+                    :floor-code     (build-themed-gradient-codes vh 239 true)
+                    :blood-sky      (build-horizon-gradient vh shade-table-blood)
+                    :blood-sky-code (build-horizon-gradient-codes vh shade-code-table-blood)}]
+        (reset! gradient-cache bundle)
+        bundle))))
+
 (defn frame->string
   "Render the world sized to cols x rows. Walls project at a constant
    scale (proj-dist from engine) with a 2:1 character-aspect correction,
@@ -213,17 +243,20 @@
         ;; horizon. No per-level wall tinting; level distinction comes
         ;; from enemy sprites + intro splash + audio.
         stbl                               shade-table
-        sky-gradient                       (build-horizon-gradient vh shade-table)
+        ;; Sky/floor gradients (+ blood + code twins) are memoized by vh
+        ;; (see frame-gradients); the per-frame rebuild is gone.
+        grads                              (frame-gradients vh)
+        sky-gradient                       (:sky grads)
         ;; Floor: same grey gradient with subtle tile banding (odd
         ;; rows one fade step darker).
-        floor-gradient                     (build-themed-gradient vh 239 true)
+        floor-gradient                     (:floor grads)
         ;; Pre-baked red gradients used when a column sits inside the
         ;; blood band: sky + floor go red for those cols so the band
         ;; reads as a coherent red corner, not red walls floating in a
-        ;; grey ceiling. Built only when bloody?; otherwise nil and
-        ;; the inner row loop short-circuits the blood swap.
-        blood-sky-gradient                 (when bloody?
-                                             (build-horizon-gradient vh shade-table-blood))
+        ;; grey ceiling. nil unless bloody? so the inner row loop
+        ;; short-circuits the blood swap (the cache always holds them;
+        ;; the bloody? gate keeps the nil-when-inactive contract).
+        blood-sky-gradient                 (when bloody? (:blood-sky grads))
         ;; Intentional alias: floor reuses the sky red gradient so the
         ;; blood band is one uniform red wash top-to-bottom (not a copy
         ;; -paste slip). A separate floor curve would split the corner.
@@ -233,10 +266,9 @@
         ;; in FG; using a flat sky-code produced a dark notch at the seam
         ;; wherever the gradient is brighter than code 236. Similarly the
         ;; bot-edge blends the floor shade at its row into the BG half.
-        sky-code-gradient                  (build-horizon-gradient-codes vh shade-code-table)
-        floor-code-gradient                (build-themed-gradient-codes vh 239 true)
-        blood-sky-code-gradient            (when bloody?
-                                             (build-horizon-gradient-codes vh shade-code-table-blood))
+        sky-code-gradient                  (:sky-code grads)
+        floor-code-gradient                (:floor-code grads)
+        blood-sky-code-gradient            (when bloody? (:blood-sky-code grads))
         blood-floor-code-gradient          blood-sky-code-gradient
         ;; Directional blood mask: per-column intensity in [0, 1]. Only
         ;; non-zero during i-frames AND when :hurt-side is set. Fades

--- a/tests/io/render-cache-test.phel
+++ b/tests/io/render-cache-test.phel
@@ -1,0 +1,41 @@
+(ns phel-doom-tests.io.render-cache-test
+  (:require phel.test :refer [deftest is])
+  (:require phel-doom.core.level :refer [build-world])
+  (:require phel-doom.core.engine :refer [mark-visible-cells])
+  (:require phel-doom.io.render.main :refer [frame->string]))
+
+;; ---------------------------------------------------------------------
+;; Gradient memo (frame-gradients) transparency. The sky/floor gradient
+;; bundle is cached by vh in a module atom; these tests pin that the
+;; cache stays transparent: same size renders identically (cache hit),
+;; and a size that changes vh and changes back renders identically again
+;; (the rebuild path can't leave a stale/corrupt bundle).
+;; ---------------------------------------------------------------------
+
+(def world (mark-visible-cells (build-world 1 5 0 :normal #{:pistol})))
+
+(def stats
+  {:game-time 1.0 :debug? false :iframes 0.0 :lives 5 :max-lives 5
+   :armor 0 :kills 0 :level 1 :weapon :pistol :weapon-name "pistol"
+   :mag 10 :mag-size 10 :ammo-reserve 50 :stamina 100 :max-stamina 100
+   :owned-weapons #{:pistol} :difficulty :normal :held-keys #{}
+   :fire-anim-duration 0.1 :reload-duration 1.0 :game-time-s 1.0
+   :secrets-total 0 :secrets-found 0 :backpack-level 0})
+
+(deftest test-same-size-renders-identically
+  ;; Deterministic at a fixed vh — the cache hit returns the same arrays.
+  (is (= (frame->string world stats 120 30)
+         (frame->string world stats 120 30))))
+
+(deftest test-vh-change-and-back-is-stable
+  ;; vh changes (30 -> 40) force a rebuild; coming back to 30 must
+  ;; render exactly as the first 30 did (no stale bundle bleed-through).
+  (let [a (frame->string world stats 120 30)]
+    (frame->string world stats 120 40)   ; rebuild at vh' = 40 - hud rows
+    (is (= a (frame->string world stats 120 30)))))
+
+(deftest test-different-size-differs
+  ;; A genuinely different viewport produces different output (sanity:
+  ;; the cache isn't pinning one frame for all sizes).
+  (is (not= (frame->string world stats 80 24)
+            (frame->string world stats 160 44))))


### PR DESCRIPTION
## What

`frame->string` rebuilt all **6** sky/floor gradient arrays every frame (normal + blood, shade + code twins), though they depend only on `vh` - the palettes are compile-time constants and the floor base-code / banding are literals. A single-slot atom now memoizes the bundle keyed by `vh` and rebuilds only on a height change (resize / F3 toggle).

## Measured

Isolated build cost of the gradient set:

| vh | 4-build cost |
|---:|---:|
| 30 | 0.15 ms |
| 40 | 0.20 ms |
| 67 | 0.34 ms |
| 100 | 0.51 ms |

~0.3-0.5ms/frame at 40-100 rows. Small in absolute terms, but a **meaningful slice of the sub-5ms frame budget** on the shipped JIT runtime. (Full-frame local bench can't show it - no warm JIT inflates the per-cell row loop ~10x and buries the gradient fraction; the row loop, not the gradients, dominates locally. See the note below.)

## Behaviour identical

Blood variants stay `nil` unless `bloody?` (exposed via `(when bloody? …)`), exactly as before - the `in-blood?` / blood-code guards keep their meaning. Input-determined cache preserves `frame->string`'s referential transparency, same pattern as the engine's `offset-cache`.

## Note on the real bottleneck

The per-cell row-loop walk (`vw×vh` cells: shade lookups, blood mask, RLE, string assembly) + sprite paint dominate big-screen cost, not the cast and not the gradients. This PR removes a genuine per-frame redundancy; deeper big-screen wins live in the row loop (harder, riskier).

## Tests

- New `tests/io/render-cache-test.phel`: determinism at fixed vh, vh-change-and-back stability (no stale bundle), different-size differs. Full suite green (1931).