### PR TITLE
feat(render): half-block sky/floor for 2x vertical gradient detail [prototype]

### DIFF
--- a/src/io/render/frame_math.phel
+++ b/src/io/render/frame_math.phel
@@ -200,6 +200,67 @@
         (recur (php/+ r 1))))
     arr))
 
+;; ---------------------------------------------------------------------
+;; Half-block sky/floor: each terminal ROW carries TWO vertical gradient
+;; sub-samples via the ▀ upper-half-block glyph (fg = upper sub-row,
+;; bg = lower sub-row). Sampling the same gradient curve at 2×vh
+;; resolution doubles the vertical gradient detail across the large
+;; sky/floor regions without changing the wall band. The cell ends in a
+;; single ▀ glyph so the RLE coalescer (now fill-glyph aware) still
+;; collapses a uniform row to one escape + a ▀ run.
+;; ---------------------------------------------------------------------
+
+(defn- horizon-sub-idx
+  "Shade-table index (0..23) for sky/floor sub-row `s` of a `sub-vh`
+   (= 2×vh) sub-grid: brightest at the screen edges, darkest at the
+   horizon line. Same curve as build-horizon-gradient, finer sampled."
+  [^int s ^int vh]
+  (php/max 0
+           (php/min 23
+                    (php/intval (php/* (php/- 1.0
+                                              (php// (php/abs (php/- s vh))
+                                                     (php/max 1 vh)))
+                                       23)))))
+
+(defn build-horizon-gradient-halfblock
+  "Half-block twin of build-horizon-gradient: per-row ▀ cells whose top
+   half is the sky/floor shade at sub-row 2r and bottom half at 2r+1,
+   doubling the vertical gradient resolution. `ctbl` is a code table."
+  [^int vh ctbl]
+  (let [arr (buf-mk)]
+    (loop [r 0]
+      (when (php/< r vh)
+        (let [top (buf-get ctbl (horizon-sub-idx (php/* 2 r) vh))
+              bot (buf-get ctbl (horizon-sub-idx (php/+ (php/* 2 r) 1) vh))]
+          (buf-set arr r (str "\e[38;5;" top "m\e[48;5;" bot "m▀")))
+        (recur (php/+ r 1))))
+    arr))
+
+(defn- themed-sub-code
+  "fade-256 floor/sky code for sub-row `s` of a 2×vh sub-grid. Stripe
+   banding lands per SUB-row (finer tile lines than the full-cell path)."
+  [^int s ^int vh ^int base-code stripe?]
+  (let [t     (php// (php/abs (php/- s vh)) (php/max 1 vh))
+        fade  (php/- 1.0 t)
+        fade' (if (and stripe? (php/=== (mod s 2) 1))
+                (php/max 0.0 (php/- fade 0.12))
+                fade)]
+    (fade-256 base-code fade')))
+
+(defn build-themed-gradient-halfblock
+  "Half-block twin of build-themed-gradient: per-row ▀ cells, top half
+   sampled at sub-row 2r, bottom at 2r+1, for 2× vertical floor/sky
+   detail with sub-row tile banding."
+  [^int vh ^int base-code stripe?]
+  (let [arr (buf-mk)]
+    (loop [r 0]
+      (when (php/< r vh)
+        (let [top (themed-sub-code (php/* 2 r) vh base-code stripe?)
+              bot (themed-sub-code (php/+ (php/* 2 r) 1) vh base-code stripe?)]
+          (buf-set arr r (str "\e[38;5;" top "m\e[48;5;" bot "m▀")))
+        (recur (php/+ r 1))))
+    arr))
+
 (defn direction-char
   "Map an angle in radians to one of 8 unicode arrow chars, snapping to
    the nearest π/4 sector. Public so the minimap layer and tests can

--- a/src/io/render/main.phel
+++ b/src/io/render/main.phel
@@ -3,7 +3,7 @@
 (ns phel-doom.io.render.main
   (:require phel-doom.io.render.buffer :refer [buf-mk buf-set buf-get buf-push])
   (:require phel-doom.io.render.palette :refer [sky floor enemy-head enemy-body door-shade boss-door-shade sky-code floor-code door-code boss-door-code sprite-shadow heart-shade heart-shade-bright heart-glyph heart-glyph-bright armor-shade armor-shade-bright armor-glyph armor-glyph-bright armor-shard-shade armor-shard-shade-bright armor-shard-glyph armor-shard-glyph-bright ammo-shade ammo-shade-bright ammo-glyph ammo-glyph-bright berserk-shade berserk-shade-bright berserk-glyph berserk-glyph-bright invuln-shade invuln-shade-bright invuln-glyph invuln-glyph-bright soulsphere-shade soulsphere-shade-bright soulsphere-glyph soulsphere-glyph-bright backpack-shade backpack-shade-bright backpack-glyph backpack-glyph-bright shotgun-pickup-shade shotgun-pickup-bright shotgun-pickup-glyph shotgun-pickup-glyph-bright chaingun-pickup-shade chaingun-pickup-bright chaingun-pickup-glyph chaingun-pickup-glyph-bright bfg-pickup-shade bfg-pickup-bright bfg-pickup-glyph bfg-pickup-glyph-bright incinerator-pickup-shade incinerator-pickup-bright incinerator-pickup-glyph incinerator-pickup-glyph-bright rocket-pickup-shade rocket-pickup-bright rocket-pickup-glyph rocket-pickup-glyph-bright keycard-blue-shade keycard-blue-bright keycard-blue-glyph keycard-blue-glyph-bright keycard-red-shade keycard-red-bright keycard-red-glyph keycard-red-glyph-bright keycard-yellow-shade keycard-yellow-bright keycard-yellow-glyph keycard-yellow-glyph-bright char-aspect shade-table shade-code-table shade-table-blood shade-code-table-blood])
-  (:require phel-doom.io.render.frame-math :refer [enemy-shade-string enemy-textured-shade-string boss-col-paint aggro-distance enemy-aggro-head-string build-horizon-gradient build-themed-gradient build-horizon-gradient-codes build-themed-gradient-codes collect-enemy-projs layout pulse visuals-for-type enemy-front-visible-at?])
+  (:require phel-doom.io.render.frame-math :refer [enemy-shade-string enemy-textured-shade-string boss-col-paint aggro-distance enemy-aggro-head-string build-horizon-gradient build-themed-gradient build-horizon-gradient-codes build-themed-gradient-codes build-horizon-gradient-halfblock build-themed-gradient-halfblock collect-enemy-projs layout pulse visuals-for-type enemy-front-visible-at?])
   (:require phel-doom.io.render.enemy-sprite :refer [sprite-for-type sprite-col-x enemy-sprite-cell])
   (:require phel-doom.io.render.hud :refer [minimap-door minimap-door-pulse minimap-rows hud-debug-line hud-line-str help-menu-string settings-menu-string])
   (:require phel-doom.io.render.paint :refer [paint-face-overlay paint-crosshair paint-intro-splash paint-locked-bump paint-door-face paint-blood-drops paint-rear-warning paint-low-ammo paint-reload-reminder paint-save-flash paint-game-info paint-berserk-badge paint-invuln-badge paint-empty-click paint-flicker paint-heartbeat-vignette paint-hit-vignette paint-berserk-tint paint-heat-bar paint-kill-streak paint-compass paint-enemy-hp-flashes paint-hearts-hud paint-pistol-hud paint-weapon-hud paint-blood-fx-into paint-pickups-into paint-projectiles-into paint-tracers-into build-blood-cols])
@@ -209,6 +209,16 @@
 ;; engine's offset-cache.
 (def- gradient-cache (atom {:vh -1}))
 
+(defn- cell-fill
+  "The single trailing printable glyph of a pre-baked cell string: the
+   slice after its last SGR `m`. A space for bg-only cells, a block
+   glyph (▀ / █) for half-block + sprite cells. This is the unit the RLE
+   coalescer repeats across a run of identical cells. Multibyte-safe: it
+   slices on the ASCII `m` boundary and takes the remainder, so a 3-byte
+   ▀ is repeated whole rather than by a stray trailing byte."
+  [c]
+  (php/substr c (php/+ 1 (php/strrpos c "m"))))
+
 (defn- frame-gradients
   "Memoized sky/floor gradient bundle for viewport height `vh`. Returns
    a map of the 6 gradient arrays (normal + blood, shade + code twins),
@@ -219,12 +229,19 @@
     (if (php/=== vh (:vh c))
       c
       (let [bundle {:vh             vh
+                    ;; Space-bg arrays: still used by the weapon HUD
+                    ;; backdrop + crosshair-prefix sampling.
                     :sky            (build-horizon-gradient vh shade-table)
                     :floor          (build-themed-gradient vh 239 true)
                     :sky-code       (build-horizon-gradient-codes vh shade-code-table)
                     :floor-code     (build-themed-gradient-codes vh 239 true)
                     :blood-sky      (build-horizon-gradient vh shade-table-blood)
-                    :blood-sky-code (build-horizon-gradient-codes vh shade-code-table-blood)}]
+                    :blood-sky-code (build-horizon-gradient-codes vh shade-code-table-blood)
+                    ;; Half-block twins: 2× vertical gradient detail for
+                    ;; the sky/floor body cells in the row loop.
+                    :sky-hb         (build-horizon-gradient-halfblock vh shade-code-table)
+                    :floor-hb       (build-themed-gradient-halfblock vh 239 true)
+                    :blood-sky-hb   (build-horizon-gradient-halfblock vh shade-code-table-blood)}]
         (reset! gradient-cache bundle)
         bundle))))
 
@@ -261,6 +278,13 @@
         ;; blood band is one uniform red wash top-to-bottom (not a copy
         ;; -paste slip). A separate floor curve would split the corner.
         blood-floor-gradient               blood-sky-gradient
+        ;; Half-block sky/floor body cells: each row shows 2 vertical
+        ;; gradient sub-samples via ▀. Used by the row loop + crosshair
+        ;; centre sampling; the space-bg twins above stay for the HUD.
+        sky-hb                             (:sky-hb grads)
+        floor-hb                           (:floor-hb grads)
+        blood-sky-hb                       (when bloody? (:blood-sky-hb grads))
+        blood-floor-hb                     blood-sky-hb
         ;; Code-only gradient twins for ▀ half-block edge composition.
         ;; The top-edge cell blends wall BG with the sky shade AT THAT ROW
         ;; in FG; using a flat sky-code produced a dark notch at the seam
@@ -722,20 +746,20 @@
                                         (:player world) dists edists vw vh)
           parts     (buf-mk)]
       (dotimes [row vh]
-        (loop [col 0 prev nil run 0]
+        (loop [col 0 prev nil fill " " run 0]
           (if (php/>= col vw)
             (when (php/> run 0)
               (buf-push parts prev)
-              (buf-push parts (php/str_repeat " " (php/- run 1))))
+              (buf-push parts (php/str_repeat fill (php/- run 1))))
             (let [;; Blood-band sky/floor swap: cols in the
                          ;; directional blood band use the pre-baked red
                          ;; gradients so sky + floor + walls all flush
                          ;; red on the affected side. Short-circuits to
                          ;; the normal gradients when no blood is active.
-                  in-blood? (and blood-sky-gradient
+                  in-blood? (and blood-sky-hb
                                  (php/> (buf-get blood-cols col) 0.4))
-                  sky-row   (buf-get (if in-blood? blood-sky-gradient sky-gradient) row)
-                  flr-row   (buf-get (if in-blood? blood-floor-gradient floor-gradient) row)
+                  sky-row   (buf-get (if in-blood? blood-sky-hb sky-hb) row)
+                  flr-row   (buf-get (if in-blood? blood-floor-hb floor-hb) row)
                          ;; Base cell: wall/sky/floor + (glyph mode only)
                          ;; the enemy zones. In sprite mode the glyph
                          ;; branch is skipped so this resolves the real
@@ -775,12 +799,12 @@
                                         (buf-get e-stop col) (buf-get e-sbot col) row))
                                   base))]
               (cond
-                (php/=== run 0)  (recur (php/+ col 1) c 1)
-                (php/=== c prev) (recur (php/+ col 1) prev (php/+ run 1))
+                (php/=== run 0)  (recur (php/+ col 1) c (cell-fill c) 1)
+                (php/=== c prev) (recur (php/+ col 1) prev fill (php/+ run 1))
                 :else            (do
                                    (buf-push parts prev)
-                                   (buf-push parts (php/str_repeat " " (php/- run 1)))
-                                   (recur (php/+ col 1) c 1))))))
+                                   (buf-push parts (php/str_repeat fill (php/- run 1)))
+                                   (recur (php/+ col 1) c (cell-fill c) 1))))))
         (buf-push parts "\e[0m\n"))
       (when (get stats :debug?)
         (buf-push parts (hud-debug-line world stats))
@@ -808,8 +832,8 @@
             ;; lands on the real cell colour, including a sampled enemy
             ;; sprite pixel in sprite mode (glyph zones only in glyph mode).
             center-base (cond
-                          (php/< c-row top-col)                        (buf-get sky-gradient c-row)
-                          (php/>= c-row bot-col)                       (buf-get floor-gradient c-row)
+                          (php/< c-row top-col)                        (buf-get sky-hb c-row)
+                          (php/>= c-row bot-col)                       (buf-get floor-hb c-row)
                           (and (not sprites-on) (buf-get emask c-col))
                           (cond
                             (php/< c-row (buf-get mids c-col))   (buf-get eheads c-col)


### PR DESCRIPTION
## Prototype - needs your eyes (`/play`) + a ship/no-ship call

Renders the **sky + floor body cells** as `▀` half-blocks (fg = gradient sub-row 2r, bg = 2r+1), sampling the gradient curve at 2× vh resolution. 2× vertical smoothness across those large regions. Walls + edges unchanged (walls are flat strips - nothing to gain there).

## Honest cost (local no-JIT bench, same harness)

| Viewport | render ms (was → now) | bytes (was → now) |
|---|---|---|
| 120×30 | 29 → 45 ms | ~9k → 12.8k |
| 180×40 | 55 → 86 ms | ~15.6k → 22.8k |
| 240×67 | 116 → 183 ms | ~33k → 49k |

**~+50% render time, ~+46% bytes.** A flat `▀` run is 3 bytes/cell vs 1 for a space run, so the big flat sky/floor regions get markedly more expensive to build + emit.

## My recommendation

**Lean no-ship as default.** The gain (smoother gradient banding) is subtle on regions that are already smooth, and the cost is steep. Options if you want it: (a) ship behind a flag / env toggle, (b) half-block only the floor (banding is more visible there) to halve the cost, (c) drop it. Eyeball via `/play` and decide - I'll wire whichever way.

## Implementation notes

- New `build-horizon-gradient-halfblock` / `build-themed-gradient-halfblock` in `frame_math.phel`; cached by vh alongside the existing bundle.
- RLE coalescer now tracks a per-run **fill glyph** (`cell-fill`: slice after the last SGR `m`, multibyte-safe) so uniform `▀` rows still collapse to one escape + a glyph run. This also fixes a latent space-only assumption in the flush.
- Space-bg gradient twins kept for the weapon-HUD backdrop + crosshair-prefix sampling (untouched).
- Tests green (1931); launch smoke clean.