### PR TITLE
feat(render): procedural running-bond brick wall texture [prototype]

### DIFF
--- a/src/io/render/main.phel
+++ b/src/io/render/main.phel
@@ -228,6 +228,23 @@
         (reset! gradient-cache bundle)
         bundle))))
 
+(def brick-course-h
+  "Rows per brick course in the procedural wall texture. A darker mortar
+   line is drawn at each course boundary; adjacent brick columns stagger
+   by half a course (running bond) so courses read as offset bricks
+   rather than continuous horizontal stripes."
+  4)
+
+(defn- wall-mortar?
+  "True when screen `row` lands on a brick-course mortar line for a wall
+   column whose hit cell is (hx, hy). The per-column half-course stagger
+   keyed off hit-cell parity offsets alternate brick columns so the
+   courses read as running-bond brick. Pure + cheap (two mods); called
+   once per wall-body cell."
+  [^int row ^int top ^int hx ^int hy]
+  (let [phase (if (php/=== 0 (mod (php/+ hx hy) 2)) 0 (php/intdiv brick-course-h 2))]
+    (php/=== 0 (mod (php/+ (php/- row top) phase) brick-course-h))))
+
 (defn frame->string
   "Render the world sized to cols x rows. Walls project at a constant
    scale (proj-dist from engine) with a 2:1 character-aspect correction,
@@ -299,7 +316,7 @@
         ;; crisp walls. cast-frame still takes the factor so the
         ;; replication path stays available if ever needed.
         scale                              (render-scale vw vh)
-        {:keys [dists hits sides]}
+        {:keys [dists hits sides hxs hys]}
         (cast-frame world vw scale)
         _                                  (when debug?
                                              (record-cast-ms!
@@ -755,6 +772,14 @@
                               (php/=== row (php/- (buf-get bots col) 1))
                               (buf-get shades-bot-edge col)
                               (php/=== row (php/- (buf-get bots col) 2))
+                              (buf-get shades-bot-shadow col)
+                              ;; Wall body: procedural running-bond brick.
+                              ;; Mortar rows take the darker shadow shade;
+                              ;; the rest take the flat wall shade. Adds
+                              ;; vertical structure to the otherwise flat
+                              ;; strip without a texture map or cast change.
+                              (wall-mortar? row (buf-get tops col)
+                                            (buf-get hxs col) (buf-get hys col))
                               (buf-get shades-bot-shadow col)
                               :else
                               (buf-get shades-normal col))


### PR DESCRIPTION
## Prototype - needs your eyes (`/play`) + a ship/no-ship call

Walls are flat-shaded vertical strips today (one shade per column - deliberate, `main.phel:149`). This adds a **procedural running-bond brick** texture: a darker mortar line every `brick-course-h` (4) rows, adjacent brick columns staggered half a course (keyed off hit-cell parity) so it reads as offset brick, not continuous stripes.

## Cost (clean same-harness delta, no-JIT local)

| Viewport | baseline | brick | Δ |
|---|---|---|---|
| 120×30 | 43.3 ms | 50.2 ms | +16% |
| 180×40 | 80.8 ms | 94.7 ms | +17% |

Cost is the per-wall-cell `wall-mortar?` check (two mods); it JITs well so shipped delta is likely smaller. Mortar rows **reuse the already-computed darker shadow shade** - no new per-cell string building.

## Aesthetic note

**Reverses the deliberate flat-stone look** - your call. Built so you can see it next to flat. Knobs: `brick-course-h` (course height); drop the stagger for stacked bond.

## Higher-fidelity follow-up

An already-baked Freedoom texture (`wall-tex`, WALL70_2, 64×64) sits unused in `wall_texture_data.phel`. Real textures need the raycaster to emit a per-column **wall-U** coordinate (`cast-frame` doesn't today) - bigger change, deferred unless wanted.

## Tests

Suite green (1931); launch smoke clean. `hxs`/`hys` now destructured from the cast for the brick stagger.