### PR TITLE
feat(render): 2×2 quadrant detail on opaque enemy-sprite cells [prototype]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 
 ### Added
 
+- Sharper enemy/pickup sprites via 2x2 quadrant sub-cells. Fully-opaque interior sprite cells now reduce their 2x2 sub-pixel sample to two colours and pick a quadrant glyph (`▘▀▌▚▛▜▙█`) for horizontal detail; transparent/edge cells keep the prior half-block so silhouettes stay clean (no halo). Subtle in practice (sprites are usually higher-res than the terminal) but free where it applies. `cast-frame` is unaffected.
 - Textured floor. The ground plane is now floor-cast and sampled from the same stone texture as the walls (distance-fogged, pulled a few shades darker so it reads as shadowed ground) instead of a flat grey gradient. The raycaster emits a per-column floor basis so the per-cell sample is two mul-adds + a texture fetch (no trig). Blood columns keep the red gradient; `PHEL_DOOM_FLAT_FLOOR=1` restores the flat floor. ~+12% render cost.
 - Textured stone walls. Plain walls now sample the baked Freedoom flat (WALL70_2) instead of rendering flat grayscale: the raycaster emits a per-column wall-hit fraction (texture U), and each wall cell looks up the stone texture fogged by distance + side-shading via a prebaked fade LUT (~2% render cost). Doors / boss door / blood-wash columns stay flat as nav cues. `PHEL_DOOM_FLAT_WALLS=1` restores the flat look.
 

--- a/src/io/render/enemy_sprite.phel
+++ b/src/io/render/enemy_sprite.phel
@@ -69,6 +69,26 @@
                         (php/intval (php// (php/* (php/- col (php/- ecol ehw)) sw)
                                            span))))))
 
+(defn sprite-subcol-x
+  "Sprite x for the RIGHT half of screen column `col` (sampled at
+   col+0.5), the horizontal companion to `sprite-col-x`'s left/centre
+   sample. The two samples feed the 2×2 quadrant cell so a downscaled
+   sprite (more sprite px than screen cols) shows horizontal detail
+   within a single cell. Clamped to [0, sw-1]."
+  [^int sw ^int ecol ^int ehw ^int col]
+  (let [span (php/max 1 (php/+ (php/* 2 ehw) 1))]
+    (php/max 0 (php/min (php/- sw 1)
+                        (php/intval (php// (php/* (php/+ (php/- col (php/- ecol ehw)) 0.5) sw)
+                                           span))))))
+
+(def quadrant-glyph
+  "Glyph for a 2×2 sub-cell, keyed by the bitmask of which corners take
+   the FOREGROUND colour: TL=8, TR=4, BL=2, BR=1. The top-left corner is
+   always the fg reference (bit 8 always set), so only masks 8..15 occur.
+   Off corners take the background colour."
+  {8  "▘" 12 "▀" 10 "▌" 9  "▚"
+   14 "▛" 13 "▜" 11 "▙" 15 "█"})
+
 (defn enemy-sprite-cell
   "Sample one cell from a baked enemy sprite at screen `row`, given the
    precomputed sprite column `sx` (see sprite-col-x) and the enemy's
@@ -90,14 +110,36 @@
                                  no halo against the wall behind)
      - both transparent       -> nil (caller keeps the wall/floor cell)
    sy is clamped to [0, sh-1]."
-  [px ^int sw ^int sh ^int sx ^int etop ^int ebot ^int row]
+  [px ^int sw ^int sh ^int sx ^int sxr ^int etop ^int ebot ^int row]
   (let [h2  (php/max 1 (php/* 2 (php/- ebot etop)))
         sub (php/* 2 (php/- row etop))
         ty  (php/max 0 (php/min (php/- sh 1) (php/intval (php// (php/* sub sh) h2))))
         by  (php/max 0 (php/min (php/- sh 1) (php/intval (php// (php/* (php/+ sub 1) sh) h2))))
-        top (php/aget px (php/+ (php/* ty sw) sx))
-        bot (php/aget px (php/+ (php/* by sw) sx))]
+        ;; 2×2 sub-pixel sample: top/bottom rows × left(sx)/right(sxr) cols.
+        tl  (php/aget px (php/+ (php/* ty sw) sx))
+        tr  (php/aget px (php/+ (php/* ty sw) sxr))
+        bl  (php/aget px (php/+ (php/* by sw) sx))
+        br  (php/aget px (php/+ (php/* by sw) sxr))]
     (cond
-      (php/=== top -1) (when (php/!== bot -1) (php/aget block-cache bot))
-      (php/=== bot -1) (php/aget block-cache top)
-      :else            (str (php/aget fg-cache top) (php/aget bg-cache bot) "▀"))))
+      ;; Fully-opaque interior cell: render a 2×2 quadrant for horizontal
+      ;; detail. Reduce the (up to 4) colours to fg = top-left and bg =
+      ;; the first differing corner; the quadrant glyph paints which
+      ;; corners take fg. Uniform 4 → solid block. When there is no
+      ;; horizontal variation (tl=tr, bl=br) the mask is 12 → ▀, i.e.
+      ;; byte-identical to the previous half-block, so only genuinely
+      ;; varying interior cells change.
+      (and (php/!== tl -1) (php/!== tr -1) (php/!== bl -1) (php/!== br -1))
+      (if (and (php/=== tl tr) (php/=== tl bl) (php/=== tl br))
+        (php/aget block-cache tl)
+        (let [c2 (cond (php/!== tr tl) tr (php/!== bl tl) bl :else br)
+              m  (php/+ 8
+                        (if (php/=== tr tl) 4 0)
+                        (if (php/=== bl tl) 2 0)
+                        (if (php/=== br tl) 1 0))]
+          (str (php/aget fg-cache tl) (php/aget bg-cache c2) (get quadrant-glyph m))))
+      ;; Edge / transparent cells: unchanged vertical half-block behaviour
+      ;; on the left sample, so silhouettes stay clean (no halo, no
+      ;; wall-behind dependency).
+      (php/=== tl -1)                                                       (when (php/!== bl -1) (php/aget block-cache bl))
+      (php/=== bl -1)                                                       (php/aget block-cache tl)
+      :else                                                                 (str (php/aget fg-cache tl) (php/aget bg-cache bl) "▀"))))

--- a/src/io/render/main.phel
+++ b/src/io/render/main.phel
@@ -5,7 +5,7 @@
   (:require phel-doom.io.render.palette :refer [sky floor enemy-head enemy-body door-shade boss-door-shade sky-code floor-code door-code boss-door-code sprite-shadow heart-shade heart-shade-bright heart-glyph heart-glyph-bright armor-shade armor-shade-bright armor-glyph armor-glyph-bright armor-shard-shade armor-shard-shade-bright armor-shard-glyph armor-shard-glyph-bright ammo-shade ammo-shade-bright ammo-glyph ammo-glyph-bright berserk-shade berserk-shade-bright berserk-glyph berserk-glyph-bright invuln-shade invuln-shade-bright invuln-glyph invuln-glyph-bright soulsphere-shade soulsphere-shade-bright soulsphere-glyph soulsphere-glyph-bright backpack-shade backpack-shade-bright backpack-glyph backpack-glyph-bright shotgun-pickup-shade shotgun-pickup-bright shotgun-pickup-glyph shotgun-pickup-glyph-bright chaingun-pickup-shade chaingun-pickup-bright chaingun-pickup-glyph chaingun-pickup-glyph-bright bfg-pickup-shade bfg-pickup-bright bfg-pickup-glyph bfg-pickup-glyph-bright incinerator-pickup-shade incinerator-pickup-bright incinerator-pickup-glyph incinerator-pickup-glyph-bright rocket-pickup-shade rocket-pickup-bright rocket-pickup-glyph rocket-pickup-glyph-bright keycard-blue-shade keycard-blue-bright keycard-blue-glyph keycard-blue-glyph-bright keycard-red-shade keycard-red-bright keycard-red-glyph keycard-red-glyph-bright keycard-yellow-shade keycard-yellow-bright keycard-yellow-glyph keycard-yellow-glyph-bright char-aspect shade-table shade-code-table shade-table-blood shade-code-table-blood])
   (:require phel-doom.io.render.frame-math :refer [enemy-shade-string enemy-textured-shade-string boss-col-paint aggro-distance enemy-aggro-head-string build-horizon-gradient build-themed-gradient build-horizon-gradient-codes build-themed-gradient-codes tex-fade-table bg-cell-cache collect-enemy-projs layout pulse visuals-for-type enemy-front-visible-at?])
   (:require phel-doom.io.render.wall-texture-data :refer [wall-tex])
-  (:require phel-doom.io.render.enemy-sprite :refer [sprite-for-type sprite-col-x enemy-sprite-cell])
+  (:require phel-doom.io.render.enemy-sprite :refer [sprite-for-type sprite-col-x sprite-subcol-x enemy-sprite-cell])
   (:require phel-doom.io.render.hud :refer [minimap-door minimap-door-pulse minimap-rows hud-debug-line hud-line-str help-menu-string settings-menu-string])
   (:require phel-doom.io.render.paint :refer [paint-face-overlay paint-crosshair paint-intro-splash paint-locked-bump paint-door-face paint-blood-drops paint-rear-warning paint-low-ammo paint-reload-reminder paint-save-flash paint-game-info paint-berserk-badge paint-invuln-badge paint-empty-click paint-flicker paint-heartbeat-vignette paint-hit-vignette paint-berserk-tint paint-heat-bar paint-kill-streak paint-compass paint-enemy-hp-flashes paint-hearts-hud paint-pistol-hud paint-weapon-hud paint-blood-fx-into paint-pickups-into paint-projectiles-into paint-tracers-into build-blood-cols])
   (:require phel-doom.core.engine :refer [cast-frame max-depth proj-dist])
@@ -558,6 +558,7 @@
         e-stop                             (buf-mk)
         e-sbot                             (buf-mk)
         e-sx                               (buf-mk)
+        e-sxr                              (buf-mk)
         e-spx                              (buf-mk)
         e-sw                               (buf-mk)
         e-sh                               (buf-mk)
@@ -674,6 +675,7 @@
                         (buf-set e-stop c e-top)
                         (buf-set e-sbot c e-bot)
                         (buf-set e-sx c (sprite-col-x sw col ehw c))
+                        (buf-set e-sxr c (sprite-subcol-x sw col ehw c))
                         (buf-set e-spx c spx)
                         (buf-set e-sw c sw)
                         (buf-set e-sh c sh)
@@ -905,7 +907,7 @@
                                        (php/< row (buf-get e-sbot col))
                                        (enemy-sprite-cell
                                         (buf-get e-spx col) (buf-get e-sw col) (buf-get e-sh col)
-                                        (buf-get e-sx col)
+                                        (buf-get e-sx col) (buf-get e-sxr col)
                                         (buf-get e-stop col) (buf-get e-sbot col) row))
                                   base))]
               (cond
@@ -961,7 +963,7 @@
                                  (php/< c-row (buf-get e-sbot c-col))
                                  (enemy-sprite-cell
                                   (buf-get e-spx c-col) (buf-get e-sw c-col) (buf-get e-sh c-col)
-                                  (buf-get e-sx c-col)
+                                  (buf-get e-sx c-col) (buf-get e-sxr c-col)
                                   (buf-get e-stop c-col) (buf-get e-sbot c-col) c-row))
                             center-base)
             center-bg   (php/mb_substr center-cell 0

--- a/src/io/render/paint.phel
+++ b/src/io/render/paint.phel
@@ -6,7 +6,7 @@
   (:require phel-doom.io.render.frame-math :refer [sprite-h aggro-distance project-enemy collect-enemy-projs pulse visuals-for-type enemy-front-visible-at?])
   (:require phel-doom.io.render.weapon-sprites-data :refer [baked-weapons weapon-flashes])
   (:require phel-doom.io.render.enemy-sprites-data :refer [projectile-sprites death-sprites blood-sprites pickup-sprites])
-  (:require phel-doom.io.render.enemy-sprite :refer [sprite-col-x enemy-sprite-cell])
+  (:require phel-doom.io.render.enemy-sprite :refer [sprite-col-x sprite-subcol-x enemy-sprite-cell])
   (:require phel-doom.core.combat :refer [fx-ttl-seconds corpse-ttl-seconds])
   (:require phel-doom.core.map :refer [find-door-cell]))
 
@@ -1149,10 +1149,11 @@
     (loop [c c-from]
       (when (php/<= c c-to)
         (when (pickup-visible-at? d c dists edists)
-          (let [sx (sprite-col-x sw col ehw c)]
+          (let [sx  (sprite-col-x sw col ehw c)
+                sxr (sprite-subcol-x sw col ehw c)]
             (loop [r r-lo]
               (when (php/< r r-hi)
-                (let [cell (enemy-sprite-cell px sw sh sx etop ebot r)]
+                (let [cell (enemy-sprite-cell px sw sh sx sxr etop ebot r)]
                   (when cell (buf-set buf (php/+ (php/* r vw) c) cell)))
                 (recur (php/+ r 1))))))
         (recur (php/+ c 1))))

--- a/tests/io/enemy-sprite-test.phel
+++ b/tests/io/enemy-sprite-test.phel
@@ -46,21 +46,40 @@
   (is (= 1 (sprite-col-x 2 5 2 99)) "far right clamps to sw-1"))
 
 (deftest test-both-subpixels-opaque-is-halfblock
-  ;; cell 0: top=row0=10, bot=row1=20 -> ▀ fg=top bg=bot.
-  (is (= "\e[38;5;10m\e[48;5;20m▀" (enemy-sprite-cell grid 1 4 0 0 2 0))))
+  ;; cell 0: top=row0=10, bot=row1=20. sw=1 so left=right sample (no
+  ;; horizontal variation) -> quadrant mask 12 -> ▀ fg=top bg=bot,
+  ;; byte-identical to the pre-quadrant half-block.
+  (is (= "\e[38;5;10m\e[48;5;20m▀" (enemy-sprite-cell grid 1 4 0 0 0 2 0))))
 
 (deftest test-one-subpixel-opaque-is-solid-block
   ;; cell 1: top=row2=-1, bot=row3=30 -> solid block of the opaque half.
-  (is (= "\e[38;5;30m█" (enemy-sprite-cell grid 1 4 0 0 2 1))))
+  (is (= "\e[38;5;30m█" (enemy-sprite-cell grid 1 4 0 0 0 2 1))))
 
 (deftest test-both-subpixels-transparent-is-nil
   ;; A fully transparent column -> nil (caller keeps the wall/floor cell).
   (let [g (php/array -1 -1 -1 -1)]
-    (is (nil? (enemy-sprite-cell g 1 4 0 0 2 0)))))
+    (is (nil? (enemy-sprite-cell g 1 4 0 0 0 2 0)))))
 
 (deftest test-sy-clamps-into-range
   ;; A row well past the box clamps to the last sub-rows (still in-range).
-  (is (some? (enemy-sprite-cell grid 1 4 0 0 2 99))))
+  (is (some? (enemy-sprite-cell grid 1 4 0 0 0 2 99))))
+
+;; ---------------------------------------------------------------------
+;; Quadrant horizontal detail: a 2-wide grid with left != right colours
+;; on a fully-opaque cell picks a quadrant glyph (here ▌: left column =
+;; fg, right column = bg). Grid 2x2 row-major: row0=[10 20] row1=[10 20].
+;;   tl=10 tr=20 bl=10 br=20 -> fg=10, c2=20, mask=8|2=10 -> ▌
+;; ---------------------------------------------------------------------
+
+(deftest test-quadrant-horizontal-split-picks-left-half-block
+  (let [g (php/array 10 20 10 20)]
+    ;; sw=2, sx=0 (left col), sxr=1 (right col), box rows [0,1) -> row 0.
+    (is (= "\e[38;5;10m\e[48;5;20m▌" (enemy-sprite-cell g 2 2 0 1 0 1 0)))))
+
+(deftest test-quadrant-uniform-opaque-is-solid-block
+  ;; All four sub-pixels the same colour -> solid block, no ▀ pair.
+  (let [g (php/array 7 7 7 7)]
+    (is (= "\e[38;5;7m█" (enemy-sprite-cell g 2 2 0 1 0 1 0)))))
 
 ;; ---------------------------------------------------------------------
 ;; Projectile + death sprite data (baked from Freedoom).


### PR DESCRIPTION
## Prototype - needs your eyes (`/play`) + a ship/no-ship call

Enemy sprites sampled 2 vertical sub-pixels at one sprite x (`▀` half-block). Now `enemy-sprite-cell` samples a **2×2** sub-pixel block (left + right sprite columns via `sprite-subcol-x`), and on **fully-opaque interior cells** reduces the corners to 2 colours (fg = top-left, bg = first differing corner) and picks a quadrant glyph (`▘▀▌▚▛▜▙█`) for horizontal detail.

## Safe by construction

- **Edge / partially-transparent cells keep the exact prior half-block behaviour** (left sample) - silhouettes stay clean, no halo, no wall-behind dependency.
- Cells with no horizontal variation (`tl=tr, bl=br`) produce mask 12 → `▀`, **byte-identical** to before. Only genuinely varying interior cells change.

## Limit + cost

- **2 colours per cell** is the hard terminal limit, so >2 distinct corner colours are approximated (extra colours fold into bg). Inherent to sub-cell glyphs.
- ~+14% render on a sprite-heavy frame (no-JIT local; 4 samples + quadrant pick per opaque sprite cell). Less on JIT; zero on frames without sprites.

## Tests

- 2 new cases: horizontal split → `▌`, uniform opaque → `█`. Existing 4 cases updated for the new `sxr` arg (byte-identical results). Suite green (1933).

Eyeball the enemy sprites via `/play` and decide; `brick-course-h`-style knobs are minimal here (it's all-or-nothing per cell).