### PR TITLE
fix(engine): widen FOV clamp from 90° to 100°

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 
 ### Fixed
 
-- Horizontal FOV is now clamped at 90° on wide terminals. Past 140 cols the ray spread stops widening (it bowed out toward 110°+ on ultrawide / fullscreen terminals, warping walls at the screen edges); the extra columns now add horizontal resolution instead of fisheye distortion. Terminals at or below 140 cols are unchanged. Wall scale is untouched.
+- Horizontal FOV is now clamped at 100° on wide terminals (the widescreen sweet spot - roomy without warp). The ray spread widens naturally up to ~167 cols, then holds at 100° instead of bowing out toward 110°+ edge fisheye on ultrawide / fullscreen terminals; the extra columns add horizontal resolution. Narrower terminals are unchanged. Wall scale is untouched.
 
 ### Changed
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -3,7 +3,7 @@
 - 256-color ANSI raycaster, full viewport
 - Sub-5ms `frame->string` at 180x40 (2ms at 80x24, 3ms at 120x30)
 - Uniform ~60fps target + crisp 1:1 walls at every terminal size (no big-screen 30fps / chunky-scale degradation)
-- `proj-dist` decoupled from viewport width - resize widens FOV, not zoom - FOV clamps at 90° past 140 cols so wide terminals gain horizontal resolution, not edge fisheye
+- `proj-dist` decoupled from viewport width - resize widens FOV, not zoom - FOV clamps at 100° on wide terminals so they gain horizontal resolution, not edge fisheye
 - Half-block sub-cell shading on wall edges; brick glyphs (4% of cells)
 - 5-stage death animation: flash -> slump -> collapse -> blood mid -> blood dim
 - Responsive help panel, collapses on tight screens

--- a/docs/raycaster.md
+++ b/docs/raycaster.md
@@ -13,7 +13,7 @@ For each screen column, fire a ray from the player at an angle offset from facin
 
 - `max-depth`: ray stops at 12 units (beyond renders sky/floor)
 - `proj-dist`: 70 cell perspective constant (controls wall scale)
-- `fov-proj-dist`: width-aware projection distance for ray spread; clamps FOV at 90° past 140 cols (see Angular offset below)
+- `fov-proj-dist`: width-aware projection distance for ray spread; clamps FOV at 100° (`fov-max-deg`) on wide terminals (see Angular offset below)
 
 ## DDA: grid-aligned traversal
 
@@ -67,7 +67,7 @@ Cast `width / scale` rays; return 5 parallel PHP arrays (one per output column).
 
 Each column's ray angle is `atan(col-offset / fov-proj-dist)`. Making the terminal wider expands FOV without scaling walls. A linear sweep would scale walls with width - wrong.
 
-FOV is clamped at 90°. `fov-proj-dist` returns the flat `proj-dist` below `fov-clamp-width` (= `2 * proj-dist` = 140 cols), so narrow terminals widen naturally (80 cols ~60°, 120 cols ~81°). At or above 140 cols it scales `proj-dist` up with width, pinning the horizontal FOV at 90° so ultrawide terminals gain horizontal resolution instead of bowing out into edge fisheye. Wall-height projection still uses the flat `proj-dist`, so the clamp never touches wall scale.
+FOV is clamped at `fov-max-deg` (100°, the widescreen sweet spot - roomy without warp). `fov-proj-dist` returns the flat `proj-dist` below `fov-clamp-width` (~167 cols, derived so the natural FOV reaches 100° there), so narrow terminals widen naturally (80 cols ~60°, 120 cols ~81°, 140 cols ~90°). At or above the clamp width it scales `proj-dist` up with width, pinning the horizontal FOV at 100° so ultrawide terminals gain horizontal resolution instead of bowing out into edge fisheye (which set in past ~110°). Wall-height projection still uses the flat `proj-dist`, so the clamp never touches wall scale.
 
 ### Fish-eye correction
 

--- a/src/core/engine.phel
+++ b/src/core/engine.phel
@@ -35,15 +35,24 @@
    'never crosses this axis'."
   1.0e9)
 
+(def fov-max-deg
+  "Maximum horizontal FOV (degrees) on wide terminals. Set wider than
+   the classic ~90° so big / ultrawide terminals keep an immersive,
+   roomy view, but still capped: past ~110° the angular projection bows
+   out into noticeable edge fisheye. 100° is the widescreen sweet spot
+   (DOOM source-port territory) - generous without the warp."
+  100.0)
+
 (def fov-clamp-width
-  "Viewport width at which horizontal FOV hits its 90° cap and stops
-   widening. At this width `proj-dist` already yields exactly 90°
-   (`2 * atan(width / 2 / proj-dist)` with `width = 2 * proj-dist`), so
-   the cap is the classic DOOM-ish horizontal FOV. Narrower terminals
-   keep the flat `proj-dist` (FOV grows naturally, 80→~60°, 120→~81°);
+  "Viewport width at which horizontal FOV reaches `fov-max-deg` and
+   stops widening. Derived so `2 * atan(width / 2 / proj-dist)` equals
+   `fov-max-deg` at this width. Narrower terminals keep the flat
+   `proj-dist` (FOV grows naturally, 80→~60°, 120→~81°, 140→~90°);
    wider terminals scale `proj-dist` up in lock-step with width so the
-   angle holds at 90° instead of bowing out into edge fisheye."
-  (php/intval (php/* 2.0 proj-dist)))
+   angle holds at `fov-max-deg` instead of bowing out into edge fisheye."
+  (php/intval
+   (php/round (php/* 2.0 proj-dist
+                     (php/tan (php/deg2rad (php// fov-max-deg 2.0)))))))
 
 (defn fov-proj-dist
   "Projection distance used for the per-column RAY SPREAD (FOV), as
@@ -54,9 +63,10 @@
    Below `fov-clamp-width` the flat `proj-dist` is returned and FOV
    widens with the terminal as before. At or above it the distance
    scales linearly with width (`proj-dist * width / fov-clamp-width`),
-   which pins the horizontal FOV at 90° for every wider terminal: the
-   extra columns buy horizontal RESOLUTION, not a wider, warped view.
-   Wall-height projection is untouched (still flat `proj-dist`)."
+   which pins the horizontal FOV at `fov-max-deg` (100°) for every wider
+   terminal: the extra columns buy horizontal RESOLUTION on top of an
+   already-roomy view, not edge fisheye. Wall-height projection is
+   untouched (still flat `proj-dist`)."
   [^int width]
   (if (php/<= width fov-clamp-width)
     proj-dist

--- a/tests/core/engine-test.phel
+++ b/tests/core/engine-test.phel
@@ -2,7 +2,7 @@
   (:require phel.test :refer [deftest is])
   (:require phel-doom.core.map    :refer [default-grid])
   (:require phel-doom.core.state  :refer [new-world new-player])
-  (:require phel-doom.core.engine :refer [cast-ray cast-frame mark-visible-cells max-depth visited? visit-radius fov-proj-dist fov-clamp-width proj-dist]))
+  (:require phel-doom.core.engine :refer [cast-ray cast-frame mark-visible-cells max-depth visited? visit-radius fov-proj-dist fov-clamp-width fov-max-deg proj-dist]))
 
 (def pgrid (to-php-array (map to-php-array default-grid)))
 
@@ -25,12 +25,13 @@
   (is (> (fov-proj-dist 200) proj-dist))
   (is (> (fov-proj-dist 400) (fov-proj-dist 200))))
 
-(deftest test-fov-capped-at-90-degrees-on-wide-terminals
-  ;; The whole point: wide terminals top out at a 90° horizontal FOV
-  ;; instead of stretching toward 110°+ edge fisheye.
-  (is (< (php/abs (php/- (fov-degrees fov-clamp-width) 90.0)) 0.001))
-  (is (< (php/abs (php/- (fov-degrees 200) 90.0)) 0.001))
-  (is (< (php/abs (php/- (fov-degrees 400) 90.0)) 0.001)))
+(deftest test-fov-capped-at-fov-max-on-wide-terminals
+  ;; The whole point: wide terminals top out at fov-max-deg (100°, the
+  ;; widescreen sweet spot) instead of stretching toward 110°+ edge
+  ;; fisheye — and without snapping to a too-narrow 90°.
+  (is (< (php/abs (php/- (fov-degrees fov-clamp-width) fov-max-deg)) 0.2))
+  (is (< (php/abs (php/- (fov-degrees 200) fov-max-deg)) 0.2))
+  (is (< (php/abs (php/- (fov-degrees 400) fov-max-deg)) 0.2)))
 
 (deftest test-fov-widens-naturally-below-clamp
   ;; Below the clamp FOV still grows with width (no premature pinning).


### PR DESCRIPTION
## Problem

The 90° FOV clamp (#171) was **too narrow** on wide terminals - it snapped ultrawide views down from ~110° to a cramped 90°, reading as zoomed-in.

## Fix

New `fov-max-deg` = **100°** (widescreen sweet spot). `fov-clamp-width` derived from it (~167 cols): FOV widens naturally up to that width, then holds at 100° instead of bowing into edge fisheye (past ~110°).

| Width | FOV |
|------:|----:|
| 80 | 59.5° |
| 120 | 81.2° |
| 140 | 90.0° |
| 167+ | 100.1° (held) |

Narrow terminals unchanged. Wall scale untouched.

## Tests / docs

- `test-fov-capped-at-fov-max-on-wide-terminals`. Suite green (1931).
- `docs/raycaster.md`, `features.md`, CHANGELOG updated.