### PR TITLE
feat(render): textured stone walls (baked Freedoom flat)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 
 ### Added
 
+- Textured stone walls. Plain walls now sample the baked Freedoom flat (WALL70_2) instead of rendering flat grayscale: the raycaster emits a per-column wall-hit fraction (texture U), and each wall cell looks up the stone texture fogged by distance + side-shading via a prebaked fade LUT (~2% render cost). Doors / boss door / blood-wash columns stay flat as nav cues. `PHEL_DOOM_FLAT_WALLS=1` restores the flat look.
+
 - `--max-cols=N` / `--max-rows=N` flags cap the render size on a larger terminal: the game draws a smaller inset frame and leaves the surplus as a blank border. Useful on ultrawide / fullscreen terminals where a full-width cast is heavy and (past the 90-degree FOV clamp) adds no field of view - cap to ~140 cols for a crisp, cheap render. 0 / unset fills the terminal. Caps only shrink, never grow past the real terminal, and never below a small playable floor. The inset is anchored top-left; centered letterboxing is a possible follow-up (the HUD/minimap overlays use absolute cursor positioning that would need a global offset).
 
 ### Changed

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,6 +1,7 @@
 ## Rendering
 
 - 256-color ANSI raycaster, full viewport
+- Textured stone walls: baked Freedoom flat sampled per cell by wall-hit fraction + depth fog (`PHEL_DOOM_FLAT_WALLS=1` for flat shading)
 - Sub-5ms `frame->string` at 180x40 (2ms at 80x24, 3ms at 120x30)
 - Uniform ~60fps target + crisp 1:1 walls at every terminal size (no big-screen 30fps / chunky-scale degradation)
 - `proj-dist` decoupled from viewport width - resize widens FOV, not zoom - FOV clamps at 100° on wide terminals so they gain horizontal resolution, not edge fisheye

--- a/docs/raycaster.md
+++ b/docs/raycaster.md
@@ -55,11 +55,12 @@ Returns raw (uncorrected) distance. Detailed tuple `[dist side hx hy]` is comput
   ...returns {:dists :hits :sides :hxs :hys})
 ```
 
-Cast `width / scale` rays; return 5 parallel PHP arrays (one per output column).
+Cast `width / scale` rays; return 6 parallel PHP arrays (one per output column).
 - `dists`: fish-eye corrected wall distance
 - `hits`: cell value at hit (0 if escaped to max-depth)
 - `sides`: 0 = vertical, 1 = horizontal (side-shading)
 - `hxs, hys`: hit cell coordinates
+- `wallxs`: wall-hit fraction in [0, 1) - the texture U coordinate (frac of world-y on a vertical face, world-x on a horizontal face, from the raw perpendicular distance)
 
 ## Two key details
 

--- a/docs/rendering.md
+++ b/docs/rendering.md
@@ -119,6 +119,12 @@ Consecutive same-color cells coalesce: one escape + N spaces (terminal repeats B
 
 `render-scale` is a uniform 1 at every terminal size: one ray per output column, exact 1:1 cast, crisp walls. The old big-screen perf mode (cast once per 2 cols and replicate, for a chunky look on wide terminals) has been removed. `cast-frame` still accepts a `scale` argument so the replication path stays available, it is just always called with 1.
 
+## Textured walls
+
+Plain stone walls are sampled from the baked Freedoom flat `wall-tex` (WALL70_2, 64x64, in `wall_texture_data.phel`). Per wall-body cell: `u` = `wallxs[col] * 64` (the ray's wall-hit fraction from the cast), `v` = row-within-wall * 64 / wall-height. The texture code is fogged by the column's 0..23 shade level through `tex-fade-table` (a prebaked 24x256 fade LUT) and resolved to a ready cell via `bg-cell-cache` - one nested `aget`, no per-cell `fade-256` or string alloc, so texturing costs ~2% over flat shading.
+
+Doors, the boss door, and blood-band columns are NOT textured (`tex-level = -1`): they keep their flat shade so nav glyphs / the red hit-wash stay clean. Wall-top/bottom `▀` seams are unchanged. `PHEL_DOOM_FLAT_WALLS=1` forces the old flat-shaded stone.
+
 ## Responsive help panel
 
 H/ESC info menu width-adaptive: max 44 chars, min 36. Drops CONTROLS section first, then COMPASS HINT on squeeze.

--- a/src/core/engine.phel
+++ b/src/core/engine.phel
@@ -174,7 +174,8 @@
         hits                (php/array)
         sides               (php/array)
         hxs                 (php/array)
-        hys                 (php/array)]
+        hys                 (php/array)
+        wallxs              (php/array)]
      ;; DDA traversal is inlined: avoids one fn call per column AND
      ;; replaces the per-ray Phel-vector `[d h side hx hy]` return
      ;; with a cheap `php/array` so the hot loop allocates a plain
@@ -214,11 +215,20 @@
                               (php/!== 0 hit)        (php/array dist hit 1 cx cy')
                               :else
                               (recur cx cy' sidex (php/+ sidey deltay))))))
-              d-corr  (php/* (php/aget hit-arr 0) (php/aget cos-offs col))
+              rawd    (php/aget hit-arr 0)
+              d-corr  (php/* rawd (php/aget cos-offs col))
               h       (php/aget hit-arr 1)
               side    (php/aget hit-arr 2)
               hx      (php/aget hit-arr 3)
-              hy      (php/aget hit-arr 4)]
+              hy      (php/aget hit-arr 4)
+              ;; Texture U: fractional position along the wall face where
+              ;; the ray hit. Vertical face (side 0) → frac of world-y at
+              ;; the hit; horizontal face (side 1) → frac of world-x.
+              ;; Uses the raw (perpendicular) side distance, not the
+              ;; fish-eye-corrected one. In [0, 1) → texture column.
+              wallx   (if (php/=== side 0)
+                        (let [wy (php/+ y (php/* rawd diry))] (php/- wy (php/floor wy)))
+                        (let [wx (php/+ x (php/* rawd dirx))] (php/- wx (php/floor wx))))]
            ;; Replicate this sample across the next `scale` output
            ;; columns. `scale` is 1 today (crisp 1:1 walls everywhere),
            ;; so this fills exactly one cell; the loop keeps the
@@ -235,9 +245,10 @@
               (php/aset sides c side)
               (php/aset hxs c hx)
               (php/aset hys c hy)
+              (php/aset wallxs c wallx)
               (recur (php/+ c 1) (php/+ fill 1))))
           (recur (php/+ col scale)))))
-    {:dists dists :hits hits :sides sides :hxs hxs :hys hys}))
+    {:dists dists :hits hits :sides sides :hxs hxs :hys hys :wallxs wallxs}))
 
 (def visit-radius
   "Square radius (cells) around the player scanned each frame for

--- a/src/io/render/frame_math.phel
+++ b/src/io/render/frame_math.phel
@@ -38,6 +38,38 @@
 
     :else             code))
 
+(def tex-fade-table
+  "24-level × 256-code distance-fog lookup for textured walls:
+   `tex-fade-table[level][code]` is `code` darkened toward black by
+   `1 - level/23`. Level 23 = full brightness (near wall), 0 = darkest
+   (far). Lets the wall-texture path apply per-cell fog with a single
+   nested `aget` instead of a `fade-256` call per cell. Built once at
+   load (24×256 fade-256 calls); pure + immutable thereafter."
+  (let [outer (php/array)]
+    (loop [lvl 0]
+      (when (php/< lvl 24)
+        (let [inner (php/array)
+              t     (php/- 1.0 (php// lvl 23.0))]
+          (loop [c 0]
+            (when (php/< c 256)
+              (php/aset inner c (fade-256 c t))
+              (recur (php/+ c 1))))
+          (php/aset outer lvl inner))
+        (recur (php/+ lvl 1))))
+    outer))
+
+(def bg-cell-cache
+  "256 pre-baked BG paint cells `\\e[48;5;<code>m ` (escape + one space),
+   indexed by 256-colour code. The textured-wall path resolves a faded
+   code via `tex-fade-table` then fetches its ready cell here — no
+   per-cell string allocation."
+  (let [a (php/array)]
+    (loop [c 0]
+      (when (php/< c 256)
+        (php/aset a c (str "\e[48;5;" c "m "))
+        (recur (php/+ c 1))))
+    a))
+
 (defn enemy-shade-string
   "Compose the ANSI BG-only paint cell for one enemy zone at the
    given fade factor."

--- a/src/io/render/main.phel
+++ b/src/io/render/main.phel
@@ -3,7 +3,8 @@
 (ns phel-doom.io.render.main
   (:require phel-doom.io.render.buffer :refer [buf-mk buf-set buf-get buf-push])
   (:require phel-doom.io.render.palette :refer [sky floor enemy-head enemy-body door-shade boss-door-shade sky-code floor-code door-code boss-door-code sprite-shadow heart-shade heart-shade-bright heart-glyph heart-glyph-bright armor-shade armor-shade-bright armor-glyph armor-glyph-bright armor-shard-shade armor-shard-shade-bright armor-shard-glyph armor-shard-glyph-bright ammo-shade ammo-shade-bright ammo-glyph ammo-glyph-bright berserk-shade berserk-shade-bright berserk-glyph berserk-glyph-bright invuln-shade invuln-shade-bright invuln-glyph invuln-glyph-bright soulsphere-shade soulsphere-shade-bright soulsphere-glyph soulsphere-glyph-bright backpack-shade backpack-shade-bright backpack-glyph backpack-glyph-bright shotgun-pickup-shade shotgun-pickup-bright shotgun-pickup-glyph shotgun-pickup-glyph-bright chaingun-pickup-shade chaingun-pickup-bright chaingun-pickup-glyph chaingun-pickup-glyph-bright bfg-pickup-shade bfg-pickup-bright bfg-pickup-glyph bfg-pickup-glyph-bright incinerator-pickup-shade incinerator-pickup-bright incinerator-pickup-glyph incinerator-pickup-glyph-bright rocket-pickup-shade rocket-pickup-bright rocket-pickup-glyph rocket-pickup-glyph-bright keycard-blue-shade keycard-blue-bright keycard-blue-glyph keycard-blue-glyph-bright keycard-red-shade keycard-red-bright keycard-red-glyph keycard-red-glyph-bright keycard-yellow-shade keycard-yellow-bright keycard-yellow-glyph keycard-yellow-glyph-bright char-aspect shade-table shade-code-table shade-table-blood shade-code-table-blood])
-  (:require phel-doom.io.render.frame-math :refer [enemy-shade-string enemy-textured-shade-string boss-col-paint aggro-distance enemy-aggro-head-string build-horizon-gradient build-themed-gradient build-horizon-gradient-codes build-themed-gradient-codes collect-enemy-projs layout pulse visuals-for-type enemy-front-visible-at?])
+  (:require phel-doom.io.render.frame-math :refer [enemy-shade-string enemy-textured-shade-string boss-col-paint aggro-distance enemy-aggro-head-string build-horizon-gradient build-themed-gradient build-horizon-gradient-codes build-themed-gradient-codes tex-fade-table bg-cell-cache collect-enemy-projs layout pulse visuals-for-type enemy-front-visible-at?])
+  (:require phel-doom.io.render.wall-texture-data :refer [wall-tex])
   (:require phel-doom.io.render.enemy-sprite :refer [sprite-for-type sprite-col-x enemy-sprite-cell])
   (:require phel-doom.io.render.hud :refer [minimap-door minimap-door-pulse minimap-rows hud-debug-line hud-line-str help-menu-string settings-menu-string])
   (:require phel-doom.io.render.paint :refer [paint-face-overlay paint-crosshair paint-intro-splash paint-locked-bump paint-door-face paint-blood-drops paint-rear-warning paint-low-ammo paint-reload-reminder paint-save-flash paint-game-info paint-berserk-badge paint-invuln-badge paint-empty-click paint-flicker paint-heartbeat-vignette paint-hit-vignette paint-berserk-tint paint-heat-bar paint-kill-streak paint-compass paint-enemy-hp-flashes paint-hearts-hud paint-pistol-hud paint-weapon-hud paint-blood-fx-into paint-pickups-into paint-projectiles-into paint-tracers-into build-blood-cols])
@@ -61,6 +62,26 @@
         on)
       cached)))
 ;; =====================================================================
+;; § Wall texture (baked Freedoom WALL70_2)
+;; =====================================================================
+
+(def wall-tex-px
+  "Flat row-major xterm-256 palette array of the baked stone wall
+   texture, sampled per wall cell by (u, v)."
+  (:px wall-tex))
+
+(def wall-tex-w
+  "Wall texture width/height (square, 64). Both the U and V sample wrap
+   into [0, wall-tex-w)."
+  (:w wall-tex))
+
+(defn- wall-textures-enabled?
+  "Textured walls are ON by default; PHEL_DOOM_FLAT_WALLS=1 forces the
+   old flat-shaded stone (A/B compare, or taste). Resolved per frame."
+  []
+  (not (php/=== "1" (php/getenv "PHEL_DOOM_FLAT_WALLS"))))
+
+;; =====================================================================
 ;; § Per-column wall shading
 ;; =====================================================================
 
@@ -82,7 +103,7 @@
    `haze-shift` int 0-23: how many shade-table steps to pull walls
                 toward black. Doors are kept bright as a nav cue."
   [vw vh haze-shift cast palette blood-cols]
-  (let [{:keys [dists hits sides]}                                     cast
+  (let [{:keys [dists hits sides wallxs]}                              cast
         {:keys [stbl ctbl sky-c floor-c door-shade-now door-code-now
                 boss-door-shade-now boss-door-code-now
                 sky-code-grad floor-code-grad
@@ -93,7 +114,15 @@
         top-edge                                                       (buf-mk)
         bot-edge                                                       (buf-mk)
         top-shadow                                                     (buf-mk)
-        bot-shadow                                                     (buf-mk)]
+        bot-shadow                                                     (buf-mk)
+        ;; Per-column wall-texture sampling state. `tex-u` is the
+        ;; texture column (0..63) from the ray's wall-hit fraction;
+        ;; `tex-level` is the 0..23 distance/side brightness used to fog
+        ;; the texture, or -1 to mark a cell that is NOT textured (door,
+        ;; boss door, or a blood-band column — those keep the flat
+        ;; `normal` shade so the red wash / nav glyphs stay clean).
+        tex-u                                                          (buf-mk)
+        tex-level                                                      (buf-mk)]
     (loop [col 0]
       (when (php/< col vw)
         (let [dist         (buf-get dists col)
@@ -120,6 +149,7 @@
               h            (buf-get hits col)]
           (buf-set tops col top)
           (buf-set bots col (php/+ top wall-h))
+          (buf-set tex-level col -1)            ; default: not textured
           (cond
             (php/=== 5 h)
             (do (buf-set normal      col boss-door-shade-now)
@@ -153,11 +183,20 @@
                 (buf-set top-edge   col (str "\e[48;5;" edge-code ";38;5;" sky-edge-c "m▀"))
                 (buf-set bot-edge   col (str "\e[48;5;" flr-edge-c ";38;5;" edge-code "m▀"))
                 (buf-set top-shadow col shd-bg)
-                (buf-set bot-shadow col shd-bg))))
+                (buf-set bot-shadow col shd-bg)
+                ;; Plain stone walls get the baked texture (unless blood
+                ;; is washing this column - then the flat red `normal`
+                ;; reads cleaner than a tinted texture). `idx` doubles as
+                ;; the texture fog level so depth + EW side-shading match
+                ;; the flat path exactly.
+                (when (not blood?)
+                  (buf-set tex-u     col (php/min 63 (php/intval (php/* (buf-get wallxs col) 64))))
+                  (buf-set tex-level col idx)))))
           (recur (php/+ col 1)))))
     {:tops tops :bots bots :normal normal
      :top-edge top-edge :bot-edge bot-edge
-     :top-shadow top-shadow :bot-shadow bot-shadow}))
+     :top-shadow top-shadow :bot-shadow bot-shadow
+     :tex-u tex-u :tex-level tex-level}))
 ;; =====================================================================
 ;; § Pulse cadences + near-death haze
 ;; =====================================================================
@@ -299,8 +338,9 @@
         ;; crisp walls. cast-frame still takes the factor so the
         ;; replication path stays available if ever needed.
         scale                              (render-scale vw vh)
-        {:keys [dists hits sides]}
+        {:keys [dists hits sides wallxs]}
         (cast-frame world vw scale)
+        tex-on?                            (wall-textures-enabled?)
         _                                  (when debug?
                                              (record-cast-ms!
                                               (php/* (php/- (php/microtime true) t-cast-start) 1000.0)))
@@ -408,9 +448,11 @@
          :top-edge          shades-top-edge
          :bot-edge          shades-bot-edge
          :top-shadow        shades-top-shadow
-         :bot-shadow        shades-bot-shadow}
+         :bot-shadow        shades-bot-shadow
+         :tex-u             shades-tex-u
+         :tex-level         shades-tex-level}
         (compute-wall-shades vw vh haze-shift
-                             {:dists dists :hits hits :sides sides}
+                             {:dists dists :hits hits :sides sides :wallxs wallxs}
                              {:stbl stbl :ctbl ctbl
                               :sky-c sky-c :floor-c floor-c
                               :door-shade-now door-shade-now
@@ -757,7 +799,23 @@
                               (php/=== row (php/- (buf-get bots col) 2))
                               (buf-get shades-bot-shadow col)
                               :else
-                              (buf-get shades-normal col))
+                              ;; Wall body: baked stone texture sampled by
+                              ;; (u = per-col wall-hit fraction, v = row
+                              ;; within the wall), fogged by the column's
+                              ;; shade level via tex-fade-table. tex-level
+                              ;; < 0 (door / boss / blood column, or
+                              ;; textures disabled) falls back to the flat
+                              ;; shade.
+                              (let [lvl (buf-get shades-tex-level col)]
+                                (if (and tex-on? (php/>= lvl 0))
+                                  (let [wtop (buf-get tops col)
+                                        wh   (php/max 1 (php/- (buf-get bots col) wtop))
+                                        tv   (php/min 63 (php/intdiv (php/* (php/- row wtop) 64) wh))
+                                        tc   (php/aget wall-tex-px
+                                                       (php/+ (php/* tv 64) (buf-get shades-tex-u col)))]
+                                    (php/aget bg-cell-cache
+                                              (php/aget (php/aget tex-fade-table lvl) tc)))
+                                  (buf-get shades-normal col))))
                   c         (if (and (php/< row visible-mh) (php/>= col mini-col0))
                               sky-row
                               (or (buf-get bp-trc (php/+ (php/* row vw) col))

--- a/tests/core/engine-test.phel
+++ b/tests/core/engine-test.phel
@@ -107,7 +107,23 @@
     (is (= 8 (php/count (:hits c))))
     (is (= 8 (php/count (:sides c))))
     (is (= 8 (php/count (:hxs c))))
-    (is (= 8 (php/count (:hys c))))))
+    (is (= 8 (php/count (:hys c))))
+    (is (= 8 (php/count (:wallxs c))))))
+
+(deftest test-cast-frame-wallx-is-texture-fraction
+  ;; :wallxs is the per-column wall-hit fraction (texture U), one entry
+  ;; per output column, each in [0, 1). The render layer scales it to a
+  ;; 0..63 texture column.
+  (let [w  (new-world chamber-grid (new-player 2.5 2.5 0.0))
+        c  (cast-frame w 16 1)
+        ws (:wallxs c)]
+    (is (= 16 (php/count ws)))
+    (loop [i 0]
+      (when (php/< i 16)
+        (let [u (php/aget ws i)]
+          (is (and (php/>= u 0.0) (php/< u 1.0))
+              "every wall-hit fraction is in [0, 1)"))
+        (recur (php/+ i 1))))))
 
 (deftest test-cast-frame-scale-2-fills-vw-from-half-rays
   ;; Perf-mode path: cast every 2nd column, replicate into the next.


### PR DESCRIPTION
## What

Plain walls rendered **flat grayscale**. They now sample the baked Freedoom **WALL70_2** stone flat (`wall_texture_data.phel`, previously unused) - real masonry detail.

| before (flat) | after (textured) |
|---|---|
| smooth gray gradient | stone blocks + mortar, distance-fogged |

## How

- **Raycaster** (`engine.phel`): `do-cast` now emits `:wallxs` - the per-column wall-hit fraction (texture U) from the raw perpendicular distance (frac of world-y on a vertical face, world-x on a horizontal face).
- **Render** (`main.phel`): each wall-body cell looks up the 64×64 texture at `(u = wallxs*64, v = row-within-wall*64/height)`, fogged by the column's 0..23 shade level through a **prebaked 24×256 fade LUT** (`tex-fade-table`) and resolved via a 256-entry `bg-cell-cache` - one nested `aget` per cell, **no per-cell `fade-256` or string alloc**.

## Cost

**~+2%** render time (120×30: 46.9→48.0ms, 180×40: 88.2→89.5ms, no-JIT local). The prebaked LUT makes texturing nearly free.

## Scope / safety

- Doors, boss door, and blood-wash columns stay **flat** (`tex-level = -1`) so nav cues + the red hit-wash read clean.
- Wall-top/bottom `▀` seams unchanged.
- `PHEL_DOOM_FLAT_WALLS=1` restores the old flat shading.
- Supersedes the marginal procedural-brick prototype (#178) - I'll close that.

## Tests / docs

- `:wallxs` length + [0,1) range pinned; parallel-arrays test extended. Suite green (1949). Verified visually (screenshot) + flat fallback.
- `docs/raycaster.md`, `rendering.md`, `features.md`, CHANGELOG updated.