### PR TITLE
fix(render): solid crosshair instead of faint dim glyph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 
 ### Fixed
 
+- Aiming crosshair no longer reads as a translucent smudge. The idle reticle used the faint/dim SGR attribute (`\e[..;2m`), which was barely visible against the busier half-block floor. It is now a solid bold bright-white `+` (bold bright-yellow on fire, paired with the existing one-row recoil jump) so it reads clearly on any background.
 - Wall/floor stone texture no longer shows colored confetti. The baked WALL70_2 flat carried colored seam columns, a corrupt top band, and scattered saturated specks; sampled across the floor (each cell hits a random texel) and walls they read as red/green/blue speckle on what should be neutral grey stone. The bake is now sanitized to a pure grayscale ramp (luminance-remapped, corrupt rows + border columns repaired), matching the grayscale-walls-so-enemies-pop design. Stone structure is preserved; only the stray colors are gone.
 - Horizontal FOV is now clamped at 100° on wide terminals (the widescreen sweet spot - roomy without warp). The ray spread widens naturally up to ~167 cols, then holds at 100° instead of bowing out toward 110°+ edge fisheye on ultrawide / fullscreen terminals; the extra columns add horizontal resolution. Narrower terminals are unchanged. Wall scale is untouched.
 

--- a/src/io/render/paint.phel
+++ b/src/io/render/paint.phel
@@ -87,7 +87,12 @@
   (let [firing? (php/> (or (get stats :fire-anim) 0.0) 0.0)
         ch-row  (php/+ (php/intdiv vh 2) (if firing? 0 1))
         ch-col  (php/+ (php/intdiv vw 2) 1)
-        ch-att  (if firing? "\e[97;1m" "\e[97;2m")]
+        ;; Idle: bold bright-white (NOT the old faint `2`, which read as a
+        ;; translucent smudge against the busy half-block floor). Firing:
+        ;; bold bright-yellow as a muzzle-kick flash, paired with the
+        ;; one-row jump above. center-bg keeps the underlying cell colour
+        ;; as the glyph's background so the reticle still sits in the scene.
+        ch-att  (if firing? "\e[93;1m" "\e[97;1m")]
     (buf-push parts
               (str "\e[" ch-row ";" ch-col "H" center-bg ch-att "+\e[0m")))
   parts)

--- a/tests/io/paint-test.phel
+++ b/tests/io/paint-test.phel
@@ -1,0 +1,23 @@
+(ns phel-doom-tests.io.paint-test
+  (:require phel.test :refer [deftest is])
+  (:require phel-doom.io.render.buffer :refer [buf-mk])
+  (:require phel-doom.io.render.paint :refer [paint-crosshair]))
+
+;; ---------------------------------------------------------------------
+;; Crosshair legibility. The reticle must be a SOLID glyph, never the old
+;; faint `\e[..;2m` (dim) attribute that read as a translucent smudge over
+;; the busy half-block floor. Idle = bold bright-white, firing = bold
+;; bright-yellow (muzzle-kick flash).
+;; ---------------------------------------------------------------------
+
+(defn- crosshair-str [stats]
+  (php/implode "" (paint-crosshair (buf-mk) stats 80 24 "\e[48;5;236m")))
+
+(deftest test-crosshair-idle-is-solid-white
+  (let [s (crosshair-str {:fire-anim 0.0})]
+    (is (php/str_contains s "\e[97;1m+") "idle reticle is bold bright-white")
+    (is (not (php/str_contains s ";2m")) "no faint/dim attribute")))
+
+(deftest test-crosshair-firing-flashes-yellow
+  (let [s (crosshair-str {:fire-anim 0.2})]
+    (is (php/str_contains s "\e[93;1m+") "firing reticle is bold bright-yellow")))


### PR DESCRIPTION
## Problem

The idle aiming reticle used the faint/dim SGR attribute (`\e[97;2m`). On the old flat floor it was fine, but the new half-block sub-pixel floor (#184) made the backdrop busier, so the dim `+` read as a translucent smudge - "seems odd" / nearly invisible.

## Fix

Drop the dim attribute:
- **Idle:** `\e[97;1m` - bold bright-white `+`
- **Firing:** `\e[93;1m` - bold bright-yellow flash (paired with the existing one-row recoil jump)

`center-bg` still tints the glyph's background with the underlying cell colour, so the reticle stays in the scene rather than becoming a hard UI box.

## Verify

Rendered via `local/shot.phel` -> headless: the `+` now reads as a crisp solid white glyph on the busy floor. New `tests/io/paint-test` pins the solid attribute and asserts no `;2m` (dim) remains; firing flashes yellow. `composer ci` green.