### PR TITLE
feat(render): textured amber doors via the wall-texture path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 
 ## [Unreleased]
 
+### Changed
+
+- Doors render as real textured doors. The old door face - one yellow/orange `▌` stripe per screen column with whole-cell edge bands - read as a striped curtain with a floating frame; doors now sample a baked procedural 64x64 amber metal door texture (rust border + frame, six vertical planks, horizontal mid rail) through the same path as the stone walls, so panels scale with perspective, fog with distance (floored so a door never fades to black, still haze-immune), and the door edges trace the sub-row diagonal seams. The door pulse breathes the texture's brightness on the same 4 rad/s beat instead of swapping stripe colours. The boss door keeps its flat pulsing red slab; seam accents moved to hue-true darken LUTs so the amber texels darken without hue shift (grayscale walls stay byte-identical).
+
 ## [0.13.0] - 2026-06-11
 
 ### Added

--- a/docs/rendering.md
+++ b/docs/rendering.md
@@ -66,7 +66,7 @@ shade-idx = clamp(0, 23,
 
 The gamma 0.6 curve brightens mid-range; the `+3` bonus for vertical faces reads as directional lighting. Walls, sky, and floor all index the same 24-step grayscale `shade-table` (no colour, no per-room tinting) so the place reads dark and neutral. One lookup per column; consecutive same-shade cells RLE-coalesce.
 
-Doors: `door-shade` (orange for unlocked, blue/red for keycards, bright red for boss-lock). Half-block edges mix door with sky/floor. Locked messages ("NEED BLUE KEY", "KILL THE BOSS") painted separately.
+Doors render as a baked procedural amber door texture (see "Textured doors" below); the boss door keeps its flat pulsing red `boss-door-shade` slab. Locked messages ("NEED BLUE KEY", "KILL THE BOSS") painted separately.
 
 ## Half-block edge anti-aliasing
 
@@ -79,11 +79,11 @@ Bottom: \e[48;5;<floor-at-row>;38;5;<wall>m▀    (floor BG, wall FG)
 
 Sky and floor codes are sampled from gradients at the seam row, not flat constants. Flat codes produced dark dots. `build-horizon-gradient-codes` and `build-themed-gradient-codes` pre-bake code-only twins of the string gradients per frame.
 
-These whole-cell edge bands now apply only to NON-textured columns (doors, boss door, blood-band, glyph-mode enemy columns, or with textures/subpixel off). Textured stone columns trace their wall top/bottom at sub-row precision instead - see the next section.
+These whole-cell edge bands now apply only to NON-textured columns (boss door, blood-band, glyph-mode enemy columns, or with textures/subpixel off). Textured columns - stone walls and doors alike - trace their wall top/bottom at sub-row precision instead - see the next section.
 
 ## Sub-row wall seams (diagonal wall edges)
 
-Textured, non-glyph-enemy columns place the wall top/bottom in SUB-rows (half a terminal row, the ▀ sub-pixel unit) via `build-wall-sub-bounds` and mix sky / wall / floor codes inside the boundary cells, so a receding wall's silhouette steps in half-row diagonals instead of whole-cell stairs - the wall/floor junction reads like the floor texture's own perspective diagonals instead of a bright staircase of edge cells. The seam carries a graduated dark border tracing the exact diagonal: the wall's bottom-most sub-row drops near-black (`seam-base-dark`), the sub-row above and the floor's first sub-row pull several steps darker (`seam-wall-dark`, `seam-floor-dark`), and a lighter lip marks the wall/sky limit (`seam-top-dark`). Interior wall cells keep a straight sample fast path; only the one or two boundary cells per column pay the per-sub-row resolution.
+Textured, non-glyph-enemy columns place the wall top/bottom in SUB-rows (half a terminal row, the ▀ sub-pixel unit) via `build-wall-sub-bounds` and mix sky / wall / floor codes inside the boundary cells, so a receding wall's silhouette steps in half-row diagonals instead of whole-cell stairs - the wall/floor junction reads like the floor texture's own perspective diagonals instead of a bright staircase of edge cells. The seam carries a graduated dark border tracing the exact diagonal: the wall's bottom-most sub-row drops near-black (`seam-darken-16`), the sub-row above and the floor's first sub-row pull several steps darker (`seam-darken-8`), and a lighter lip marks the wall/sky limit (`seam-darken-5`). The accents are hue-true darken LUTs, not plain code subtraction, so they work on the door texture's colour-cube texels too (see "Textured doors"). Interior wall cells keep a straight sample fast path; only the one or two boundary cells per column pay the per-sub-row resolution.
 
 The same mixer runs at both render scales: 2 sub-rows per cell at full detail, 4 per 2-terminal-row scene cell in pixel-doubled mode - the identical half-row absolute precision. At full detail it requires subpixel mode (`PHEL_DOOM_NO_SUBPIXEL=1` falls back to the whole-cell edge bands above). Costs ~15% render time at full detail (the per-cell mix-column checks), well inside the auto-calibration budget.
 
@@ -131,7 +131,18 @@ Consecutive same-color cells coalesce: one escape + N spaces (terminal repeats B
 
 Plain stone walls are sampled from the baked Freedoom flat `wall-tex` (WALL70_2, 64x64, in `wall_texture_data.phel`). Per wall-body cell: `u` = `wallxs[col] * 64` (the ray's wall-hit fraction from the cast), `v` = row-within-wall * 64 / wall-height. The texture code is fogged by the column's 0..23 shade level through `tex-fade-table` (a prebaked 24x256 fade LUT) and resolved to a ready cell via `bg-cell-cache` - one nested `aget`, no per-cell `fade-256` or string alloc, so texturing costs ~2% over flat shading.
 
-Doors, the boss door, and blood-band columns are NOT textured (`tex-level = -1`): they keep their flat shade so nav glyphs / the red hit-wash stay clean. Wall-top/bottom `▀` seams are unchanged. `PHEL_DOOM_FLAT_WALLS=1` forces the old flat-shaded stone.
+The boss door and blood-band columns are NOT textured (`tex-level = -1`): they keep their flat shade so the boss nav glyph / the red hit-wash stay clean. `PHEL_DOOM_FLAT_WALLS=1` forces the old flat-shaded stone (and the striped flat door).
+
+## Textured doors
+
+Door columns (unlocked + keycard-locked, map cells 2/3/4/9) run through the same texture path as the stone walls, sampling `door-tex-px` instead of `wall-tex-px` - `compute-wall-shades` stores the per-column texel array in a `tex-px` buffer, so the hot loops bind one extra aget and stay texture-agnostic. The texture is a procedural 64x64 amber metal door baked at load: dark rust border + red-rust frame ring, six vertical planks (alternating amber fills, highlight/shadow edges, dark grooves) split by a horizontal mid rail - the classic two-panel DOOM door silhouette, scaled by perspective like any texture.
+
+Door texels are xterm-256 colour-CUBE codes (not grayscale ramp), which two pieces of machinery must respect:
+
+- `tex-fade-table` fog already darkens cube codes hue-true via `fade-256`.
+- The sub-row seam accents darken through `seam-darken-16/-8/-5` LUTs (in `frame_math`) instead of plain `code - n` arithmetic: subtracting from a cube code jumps hue (amber 166 - 16 = green 150). For grayscale-ramp codes the LUTs reproduce the old subtraction exactly.
+
+Door fog is the wall formula with two nav-cue exceptions: the level floors at 8 (a door never fades to black) and ignores the near-death haze. The door pulse rides the fog level (`door-tex-boost`, +3 levels on the 4 rad/s beat) instead of swapping paint strings. Blood-band door columns keep the flat striped `door-shade` (the seam mixer's sky/floor codes are grayscale-only), as do glyph-enemy columns and all-flat fallback modes.
 
 ## Textured floor (floor-casting)
 

--- a/src/io/render/frame_math.phel
+++ b/src/io/render/frame_math.phel
@@ -58,6 +58,38 @@
         (recur (php/+ lvl 1))))
     outer))
 
+(defn- build-seam-darken
+  ;; 256-entry LUT darkening a colour code by `steps` grayscale-equivalent
+  ;; shade steps: grayscale-ramp codes subtract `steps` clamped at 232
+  ;; (exactly the old seam arithmetic), colour-cube codes fade toward
+  ;; black by steps/24 (hue-preserving — plain subtraction on a cube code
+  ;; jumps to a different hue, e.g. amber 166 - 16 = green 150).
+  [^int steps]
+  (let [a (php/array)]
+    (loop [c 0]
+      (when (php/< c 256)
+        (php/aset a c
+                  (if (php/>= c 232)
+                    (php/max 232 (php/- c steps))
+                    (fade-256 c (php// steps 24.0))))
+        (recur (php/+ c 1))))
+    a))
+
+(def seam-darken-16
+  "Seam-accent darken LUT, 16 shade steps: the wall's bottom-most sub-row
+   (near-black base line). See `build-seam-darken`."
+  (build-seam-darken 16))
+
+(def seam-darken-8
+  "Seam-accent darken LUT, 8 shade steps: second-to-bottom wall sub-row
+   and the floor's first sub-row past the seam."
+  (build-seam-darken 8))
+
+(def seam-darken-5
+  "Seam-accent darken LUT, 5 shade steps: the wall's top sub-row lip
+   against the sky."
+  (build-seam-darken 5))
+
 (def bg-cell-cache
   "256 pre-baked BG paint cells `\\e[48;5;<code>m ` (escape + one space),
    indexed by 256-colour code. The textured-wall path resolves a faded

--- a/src/io/render/main.phel
+++ b/src/io/render/main.phel
@@ -3,7 +3,7 @@
 (ns phel-doom.io.render.main
   (:require phel-doom.io.render.buffer :refer [buf-mk buf-set buf-get buf-push])
   (:require phel-doom.io.render.palette :refer [sky floor enemy-head enemy-body door-shade boss-door-shade sky-code floor-code door-code boss-door-code sprite-shadow heart-shade heart-shade-bright heart-glyph heart-glyph-bright armor-shade armor-shade-bright armor-glyph armor-glyph-bright armor-shard-shade armor-shard-shade-bright armor-shard-glyph armor-shard-glyph-bright ammo-shade ammo-shade-bright ammo-glyph ammo-glyph-bright berserk-shade berserk-shade-bright berserk-glyph berserk-glyph-bright invuln-shade invuln-shade-bright invuln-glyph invuln-glyph-bright soulsphere-shade soulsphere-shade-bright soulsphere-glyph soulsphere-glyph-bright backpack-shade backpack-shade-bright backpack-glyph backpack-glyph-bright shotgun-pickup-shade shotgun-pickup-bright shotgun-pickup-glyph shotgun-pickup-glyph-bright chaingun-pickup-shade chaingun-pickup-bright chaingun-pickup-glyph chaingun-pickup-glyph-bright bfg-pickup-shade bfg-pickup-bright bfg-pickup-glyph bfg-pickup-glyph-bright incinerator-pickup-shade incinerator-pickup-bright incinerator-pickup-glyph incinerator-pickup-glyph-bright rocket-pickup-shade rocket-pickup-bright rocket-pickup-glyph rocket-pickup-glyph-bright keycard-blue-shade keycard-blue-bright keycard-blue-glyph keycard-blue-glyph-bright keycard-red-shade keycard-red-bright keycard-red-glyph keycard-red-glyph-bright keycard-yellow-shade keycard-yellow-bright keycard-yellow-glyph keycard-yellow-glyph-bright char-aspect shade-table shade-code-table shade-table-blood shade-code-table-blood])
-  (:require phel-doom.io.render.frame-math :refer [enemy-shade-string enemy-textured-shade-string boss-col-paint aggro-distance enemy-aggro-head-string build-horizon-gradient build-themed-gradient build-horizon-gradient-codes build-themed-gradient-codes tex-fade-table bg-cell-cache halfblock build-sky-halfblock build-sky-codes-sub collect-enemy-projs layout pulse visuals-for-type enemy-front-visible-at?])
+  (:require phel-doom.io.render.frame-math :refer [enemy-shade-string enemy-textured-shade-string boss-col-paint aggro-distance enemy-aggro-head-string build-horizon-gradient build-themed-gradient build-horizon-gradient-codes build-themed-gradient-codes tex-fade-table bg-cell-cache halfblock build-sky-halfblock build-sky-codes-sub seam-darken-16 seam-darken-8 seam-darken-5 collect-enemy-projs layout pulse visuals-for-type enemy-front-visible-at?])
   (:require phel-doom.io.render.wall-texture-data :refer [wall-tex])
   (:require phel-doom.io.render.enemy-sprite :refer [sprite-for-type sprite-col-x sprite-subcol-x enemy-sprite-cell enemy-sprite-quad])
   (:require phel-doom.io.render.hud :refer [minimap-door minimap-door-pulse minimap-rows hud-debug-line hud-line-str help-menu-string settings-menu-string])
@@ -104,6 +104,48 @@
         (recur (php/+ i 1))))
     a))
 
+(def door-tex-px
+  "Procedural 64×64 amber metal door texture (flat row-major xterm-256
+   colour-cube codes), sampled by the same per-cell (u, v) path as the
+   stone walls. Layout: dark rust outer border (52) with a red-rust frame
+   ring (88) and four corner rivets (214); the body is six vertical planks
+   (alternating 166/172 fills, 214 left-edge highlight, 130 right-edge
+   shadow, 94 grooves) split by a horizontal mid rail — the classic
+   two-panel DOOM door silhouette. All codes live in the 16-231 colour
+   cube so `tex-fade-table` distance fog darkens them hue-true. Built
+   once at load; deterministic."
+  (let [a (php/array)]
+    (loop [v 0]
+      (when (php/< v 64)
+        (loop [u 0]
+          (when (php/< u 64)
+            (let [pu (php/% (php/- u 5) 9)
+                  pi (php/intdiv (php/- u 5) 9)
+                  c  (cond
+                       ;; outer border ring (52 = dark rust; 58 would be
+                       ;; olive and reads green against the amber body)
+                       (or (php/< u 2) (php/> u 61) (php/< v 2) (php/> v 61)) 52
+                       ;; corner rivets on the frame
+                       (and (or (php/=== u 3) (php/=== u 60))
+                            (or (php/=== v 3) (php/=== v 60)))                214
+                       ;; frame ring (red-rust, same family as the border:
+                       ;; 94 here reads olive next to the amber planks)
+                       (or (php/< u 5) (php/> u 58) (php/< v 5) (php/> v 58)) 88
+                       ;; horizontal mid rail + its lighter lips
+                       (and (php/>= v 30) (php/<= v 32))                      94
+                       (or (php/=== v 29) (php/=== v 33))                     130
+                       ;; vertical plank grooves + edge shading
+                       (php/>= pu 7)                                          94
+                       (php/=== pu 0)                                         214
+                       (php/=== pu 6)                                         130
+                       ;; plank fill, alternating warmth per plank
+                       (php/=== 0 (php/% pi 2))                               166
+                       :else                                                  172)]
+              (php/aset a (php/+ (php/* v 64) u) c))
+            (recur (php/+ u 1))))
+        (recur (php/+ v 1))))
+    a))
+
 (defn- wall-textures-enabled?
   "Textured walls are ON by default; PHEL_DOOM_FLAT_WALLS=1 forces the
    old flat-shaded stone (A/B compare, or taste). Resolved per frame."
@@ -150,12 +192,11 @@
         (recur (php/+ r 1))))
     arr))
 
-;; Pixel-doubled seam accent depths (grayscale steps; see the seam
-;; mixer in frame->string). NOTE: def- takes no docstring.
-(def- seam-base-dark 16)  ; wall's bottom-most sub-row: near-black base line
-(def- seam-wall-dark 8)   ; second-to-bottom wall sub-row
-(def- seam-floor-dark 8)  ; floor's first sub-row past the seam
-(def- seam-top-dark 5)    ; wall's top sub-row against the sky
+;; Seam accent depths live as hue-true darken LUTs in frame-math
+;; (seam-darken-16 / -8 / -5): base line 16 steps, wall shoulder +
+;; first floor sub-row 8, sky lip 5. LUTs (not plain subtraction)
+;; because door texels are colour-cube codes where `code - n` would
+;; jump hue instead of darkening.
 
 (def floor-darken
   "Shade steps the textured floor sits below a wall at the same distance.
@@ -241,8 +282,8 @@
 
    `cast`       ray-cast outputs {:dists :hits :sides}
    `palette`    {:stbl :ctbl :sky-c :floor-c :door-shade-now :door-code-now
-                 :sky-code-grad :floor-code-grad :blood-sky-code-grad
-                 :blood-floor-code-grad}
+                 :door-tex-boost :sky-code-grad :floor-code-grad
+                 :blood-sky-code-grad :blood-floor-code-grad}
    `blood-cols` per-col directional blood mask (from build-blood-cols)
    `haze-shift` int 0-23: how many shade-table steps to pull walls
                 toward black. Doors are kept bright as a nav cue.
@@ -253,6 +294,7 @@
   [vw vh haze-shift cast palette blood-cols ^float pd]
   (let [{:keys [dists hits sides wallxs]}                              cast
         {:keys [stbl ctbl sky-c floor-c door-shade-now door-code-now
+                door-tex-boost
                 boss-door-shade-now boss-door-code-now
                 sky-code-grad floor-code-grad
                 blood-sky-code-grad blood-floor-code-grad]}            palette
@@ -266,11 +308,14 @@
         ;; Per-column wall-texture sampling state. `tex-u` is the
         ;; texture column (0..63) from the ray's wall-hit fraction;
         ;; `tex-level` is the 0..23 distance/side brightness used to fog
-        ;; the texture, or -1 to mark a cell that is NOT textured (door,
-        ;; boss door, or a blood-band column — those keep the flat
-        ;; `normal` shade so the red wash / nav glyphs stay clean).
+        ;; the texture, or -1 to mark a cell that is NOT textured (boss
+        ;; door or a blood-band column — those keep the flat `normal`
+        ;; shade so the red wash / nav glyphs stay clean). `tex-px` is
+        ;; the texel array the column samples: the stone wall texture,
+        ;; or the amber door texture on door columns.
         tex-u                                                          (buf-mk)
-        tex-level                                                      (buf-mk)]
+        tex-level                                                      (buf-mk)
+        tex-px                                                         (buf-mk)]
     (loop [col 0]
       (when (php/< col vw)
         (let [dist         (buf-get dists col)
@@ -310,7 +355,23 @@
                 (buf-set top-edge    col (str "\e[48;5;" door-code-now ";38;5;" sky-edge-c "m▀"))
                 (buf-set bot-edge    col (str "\e[48;5;" flr-edge-c ";38;5;" door-code-now "m▀"))
                 (buf-set top-shadow  col door-shade-now)
-                (buf-set bot-shadow  col door-shade-now))
+                (buf-set bot-shadow  col door-shade-now)
+                ;; Textured door: same gamma distance fog + EW side
+                ;; shading as the stone walls, but floored at level 8
+                ;; (a door is the nav cue — it never fades to black)
+                ;; and immune to the near-death haze. The door pulse
+                ;; rides the fog level via `door-tex-boost` instead of
+                ;; swapping paint strings. Blood-band columns keep the
+                ;; flat striped door (the seam mixer's sky/floor codes
+                ;; are grayscale-only).
+                (when (not blood?)
+                  (let [didx (php/max 0
+                                      (php/min 23
+                                               (php/+ (php/intval (php/* (php/pow (php/- 1.0 (php/min 1.0 (php// dist max-depth))) 0.6) 23))
+                                                      (if (php/=== (buf-get sides col) 0) 3 0))))]
+                    (buf-set tex-u     col (php/min 63 (php/intval (php/* (buf-get wallxs col) 64))))
+                    (buf-set tex-level col (php/min 23 (php/+ (php/max 8 (php/min 21 didx)) door-tex-boost)))
+                    (buf-set tex-px    col door-tex-px))))
             :else
             (let [idx-raw (php/max 0
                                    (php/min 23
@@ -339,12 +400,13 @@
                 ;; the flat path exactly.
                 (when (not blood?)
                   (buf-set tex-u     col (php/min 63 (php/intval (php/* (buf-get wallxs col) 64))))
-                  (buf-set tex-level col idx)))))
+                  (buf-set tex-level col idx)
+                  (buf-set tex-px    col wall-tex-px)))))
           (recur (php/+ col 1)))))
     {:tops tops :bots bots :normal normal
      :top-edge top-edge :bot-edge bot-edge
      :top-shadow top-shadow :bot-shadow bot-shadow
-     :tex-u tex-u :tex-level tex-level}))
+     :tex-u tex-u :tex-level tex-level :tex-px tex-px}))
 ;; =====================================================================
 ;; § Pulse cadences + near-death haze
 ;; =====================================================================
@@ -724,13 +786,15 @@
          :top-shadow        shades-top-shadow
          :bot-shadow        shades-bot-shadow
          :tex-u             shades-tex-u
-         :tex-level         shades-tex-level}
+         :tex-level         shades-tex-level
+         :tex-px            shades-tex-px}
         (compute-wall-shades svw svh haze-shift
                              {:dists dists :hits hits :sides sides :wallxs wallxs}
                              {:stbl stbl :ctbl ctbl
                               :sky-c sky-c :floor-c floor-c
                               :door-shade-now door-shade-now
                               :door-code-now  door-code-now
+                              :door-tex-boost (if door-bright? 3 0)
                               :boss-door-shade-now boss-door-shade-now
                               :boss-door-code-now  boss-door-code-now
                               :sky-code-grad         sky-code-gradient
@@ -1263,16 +1327,17 @@
                           bs-sub (php/aget wsub-bot col)
                           whs    (php/max 1 (php/- bs-sub ts-sub))
                           u      (buf-get shades-tex-u col)
+                          tpx    (buf-get shades-tex-px col)
                           fade   (php/aget tex-fade-table (buf-get shades-tex-level col))
                           rel    (php/- s4 ts-sub)]
                       (if (if (php/> rel 0) (php/< (php/+ s4 3) (php/- bs-sub 2)) false)
                         (php/aset pack-reg 0
-                                  (php/+ (php/* (php/+ (php/* (php/+ (php/* (php/aget fade (php/aget wall-tex-px (php/+ (php/* (php/min 63 (php/intdiv (php/* rel 64) whs)) 64) u))) 256)
-                                                                     (php/aget fade (php/aget wall-tex-px (php/+ (php/* (php/min 63 (php/intdiv (php/* (php/+ rel 1) 64) whs)) 64) u))))
+                                  (php/+ (php/* (php/+ (php/* (php/+ (php/* (php/aget fade (php/aget tpx (php/+ (php/* (php/min 63 (php/intdiv (php/* rel 64) whs)) 64) u))) 256)
+                                                                     (php/aget fade (php/aget tpx (php/+ (php/* (php/min 63 (php/intdiv (php/* (php/+ rel 1) 64) whs)) 64) u))))
                                                               256)
-                                                       (php/aget fade (php/aget wall-tex-px (php/+ (php/* (php/min 63 (php/intdiv (php/* (php/+ rel 2) 64) whs)) 64) u))))
+                                                       (php/aget fade (php/aget tpx (php/+ (php/* (php/min 63 (php/intdiv (php/* (php/+ rel 2) 64) whs)) 64) u))))
                                                 256)
-                                         (php/aget fade (php/aget wall-tex-px (php/+ (php/* (php/min 63 (php/intdiv (php/* (php/+ rel 3) 64) whs)) 64) u)))))
+                                         (php/aget fade (php/aget tpx (php/+ (php/* (php/min 63 (php/intdiv (php/* (php/+ rel 3) 64) whs)) 64) u)))))
                         ;; Seam accents: graduated dark border tracing
                         ;; the exact wall/floor + wall/sky diagonals -
                         ;; near-black wall base sub-row, dark sub-row
@@ -1285,68 +1350,68 @@
                             (php/aset pack-reg 1 (php/aget sky-sub-codes s4))
                             (php/>= s4 bs-sub)
                             (php/aset pack-reg 1 (if (php/=== s4 bs-sub)
-                                                   (php/max 232 (php/- (floor-code-at s4 col) seam-floor-dark))
+                                                   (php/aget seam-darken-8 (floor-code-at s4 col))
                                                    (floor-code-at s4 col)))
                             :else
-                            (let [wc (php/aget fade (php/aget wall-tex-px (php/+ (php/* (php/min 63 (php/intdiv (php/* rel 64) whs)) 64) u)))]
+                            (let [wc (php/aget fade (php/aget tpx (php/+ (php/* (php/min 63 (php/intdiv (php/* rel 64) whs)) 64) u)))]
                               (php/aset pack-reg 1
                                         (if (php/>= s4 (php/- bs-sub 1))
-                                          (php/max 232 (php/- wc seam-base-dark))
+                                          (php/aget seam-darken-16 wc)
                                           (if (php/>= s4 (php/- bs-sub 2))
-                                            (php/max 232 (php/- wc seam-wall-dark))
+                                            (php/aget seam-darken-8 wc)
                                             (if (php/=== s4 ts-sub)
-                                              (php/max 232 (php/- wc seam-top-dark))
+                                              (php/aget seam-darken-5 wc)
                                               wc))))))
                           (cond
                             (php/< s4b ts-sub)
                             (php/aset pack-reg 2 (php/aget sky-sub-codes s4b))
                             (php/>= s4b bs-sub)
                             (php/aset pack-reg 2 (if (php/=== s4b bs-sub)
-                                                   (php/max 232 (php/- (floor-code-at s4b col) seam-floor-dark))
+                                                   (php/aget seam-darken-8 (floor-code-at s4b col))
                                                    (floor-code-at s4b col)))
                             :else
-                            (let [wc (php/aget fade (php/aget wall-tex-px (php/+ (php/* (php/min 63 (php/intdiv (php/* (php/+ rel 1) 64) whs)) 64) u)))]
+                            (let [wc (php/aget fade (php/aget tpx (php/+ (php/* (php/min 63 (php/intdiv (php/* (php/+ rel 1) 64) whs)) 64) u)))]
                               (php/aset pack-reg 2
                                         (if (php/>= s4b (php/- bs-sub 1))
-                                          (php/max 232 (php/- wc seam-base-dark))
+                                          (php/aget seam-darken-16 wc)
                                           (if (php/>= s4b (php/- bs-sub 2))
-                                            (php/max 232 (php/- wc seam-wall-dark))
+                                            (php/aget seam-darken-8 wc)
                                             (if (php/=== s4b ts-sub)
-                                              (php/max 232 (php/- wc seam-top-dark))
+                                              (php/aget seam-darken-5 wc)
                                               wc))))))
                           (cond
                             (php/< s4c ts-sub)
                             (php/aset pack-reg 3 (php/aget sky-sub-codes s4c))
                             (php/>= s4c bs-sub)
                             (php/aset pack-reg 3 (if (php/=== s4c bs-sub)
-                                                   (php/max 232 (php/- (floor-code-at s4c col) seam-floor-dark))
+                                                   (php/aget seam-darken-8 (floor-code-at s4c col))
                                                    (floor-code-at s4c col)))
                             :else
-                            (let [wc (php/aget fade (php/aget wall-tex-px (php/+ (php/* (php/min 63 (php/intdiv (php/* (php/+ rel 2) 64) whs)) 64) u)))]
+                            (let [wc (php/aget fade (php/aget tpx (php/+ (php/* (php/min 63 (php/intdiv (php/* (php/+ rel 2) 64) whs)) 64) u)))]
                               (php/aset pack-reg 3
                                         (if (php/>= s4c (php/- bs-sub 1))
-                                          (php/max 232 (php/- wc seam-base-dark))
+                                          (php/aget seam-darken-16 wc)
                                           (if (php/>= s4c (php/- bs-sub 2))
-                                            (php/max 232 (php/- wc seam-wall-dark))
+                                            (php/aget seam-darken-8 wc)
                                             (if (php/=== s4c ts-sub)
-                                              (php/max 232 (php/- wc seam-top-dark))
+                                              (php/aget seam-darken-5 wc)
                                               wc))))))
                           (cond
                             (php/< s4d ts-sub)
                             (php/aset pack-reg 4 (php/aget sky-sub-codes s4d))
                             (php/>= s4d bs-sub)
                             (php/aset pack-reg 4 (if (php/=== s4d bs-sub)
-                                                   (php/max 232 (php/- (floor-code-at s4d col) seam-floor-dark))
+                                                   (php/aget seam-darken-8 (floor-code-at s4d col))
                                                    (floor-code-at s4d col)))
                             :else
-                            (let [wc (php/aget fade (php/aget wall-tex-px (php/+ (php/* (php/min 63 (php/intdiv (php/* (php/+ rel 3) 64) whs)) 64) u)))]
+                            (let [wc (php/aget fade (php/aget tpx (php/+ (php/* (php/min 63 (php/intdiv (php/* (php/+ rel 3) 64) whs)) 64) u)))]
                               (php/aset pack-reg 4
                                         (if (php/>= s4d (php/- bs-sub 1))
-                                          (php/max 232 (php/- wc seam-base-dark))
+                                          (php/aget seam-darken-16 wc)
                                           (if (php/>= s4d (php/- bs-sub 2))
-                                            (php/max 232 (php/- wc seam-wall-dark))
+                                            (php/aget seam-darken-8 wc)
                                             (if (php/=== s4d ts-sub)
-                                              (php/max 232 (php/- wc seam-top-dark))
+                                              (php/aget seam-darken-5 wc)
                                               wc))))))
                           (php/aset pack-reg 0
                                     (php/+ (php/* (php/+ (php/* (php/+ (php/* (php/aget pack-reg 1) 256)
@@ -1658,23 +1723,26 @@
                           ;; (same mixer as the pixel-doubled emitter,
                           ;; sub-row codes via pack-reg slots 1-2).
                           ;; Non-mix textured columns keep the cell-bound
-                          ;; sampling; tex-level < 0 (door / boss / blood
+                          ;; sampling; tex-level < 0 (boss door / blood
                           ;; column, or textures disabled) falls back to
-                          ;; the flat shade.
+                          ;; the flat shade. Door columns sample the
+                          ;; amber door texture via the same path
+                          ;; (per-column texel array in shades-tex-px).
                           :else
                           (if mixw?
                             (let [ts-sub (php/aget wsub-top col)
                                   bs-sub (php/aget wsub-bot col)
                                   whs    (php/max 1 (php/- bs-sub ts-sub))
                                   u      (buf-get shades-tex-u col)
+                                  tpx    (buf-get shades-tex-px col)
                                   fade   (php/aget tex-fade-table (buf-get shades-tex-level col))
                                   s2     (php/* 2 row)
                                   s2b    (php/+ s2 1)
                                   rel    (php/- s2 ts-sub)]
                               (if (if (php/> rel 0) (php/< s2b (php/- bs-sub 2)) false)
                                 (php/aset cell-reg 0
-                                          (halfblock (php/aget fade (php/aget wall-tex-px (php/+ (php/* (php/min 63 (php/intdiv (php/* rel 64) whs)) 64) u)))
-                                                     (php/aget fade (php/aget wall-tex-px (php/+ (php/* (php/min 63 (php/intdiv (php/* (php/+ rel 1) 64) whs)) 64) u)))))
+                                          (halfblock (php/aget fade (php/aget tpx (php/+ (php/* (php/min 63 (php/intdiv (php/* rel 64) whs)) 64) u)))
+                                                     (php/aget fade (php/aget tpx (php/+ (php/* (php/min 63 (php/intdiv (php/* (php/+ rel 1) 64) whs)) 64) u)))))
                                 ;; Seam accents: graduated dark border
                                 ;; tracing the exact wall/floor + wall/sky
                                 ;; diagonals - near-black wall base
@@ -1687,34 +1755,34 @@
                                     (php/aset pack-reg 1 (php/aget sky-sub-codes s2))
                                     (php/>= s2 bs-sub)
                                     (php/aset pack-reg 1 (if (php/=== s2 bs-sub)
-                                                           (php/max 232 (php/- (floor-code-at s2 col) seam-floor-dark))
+                                                           (php/aget seam-darken-8 (floor-code-at s2 col))
                                                            (floor-code-at s2 col)))
                                     :else
-                                    (let [wc (php/aget fade (php/aget wall-tex-px (php/+ (php/* (php/min 63 (php/intdiv (php/* rel 64) whs)) 64) u)))]
+                                    (let [wc (php/aget fade (php/aget tpx (php/+ (php/* (php/min 63 (php/intdiv (php/* rel 64) whs)) 64) u)))]
                                       (php/aset pack-reg 1
                                                 (if (php/>= s2 (php/- bs-sub 1))
-                                                  (php/max 232 (php/- wc seam-base-dark))
+                                                  (php/aget seam-darken-16 wc)
                                                   (if (php/>= s2 (php/- bs-sub 2))
-                                                    (php/max 232 (php/- wc seam-wall-dark))
+                                                    (php/aget seam-darken-8 wc)
                                                     (if (php/=== s2 ts-sub)
-                                                      (php/max 232 (php/- wc seam-top-dark))
+                                                      (php/aget seam-darken-5 wc)
                                                       wc))))))
                                   (cond
                                     (php/< s2b ts-sub)
                                     (php/aset pack-reg 2 (php/aget sky-sub-codes s2b))
                                     (php/>= s2b bs-sub)
                                     (php/aset pack-reg 2 (if (php/=== s2b bs-sub)
-                                                           (php/max 232 (php/- (floor-code-at s2b col) seam-floor-dark))
+                                                           (php/aget seam-darken-8 (floor-code-at s2b col))
                                                            (floor-code-at s2b col)))
                                     :else
-                                    (let [wc (php/aget fade (php/aget wall-tex-px (php/+ (php/* (php/min 63 (php/intdiv (php/* (php/+ rel 1) 64) whs)) 64) u)))]
+                                    (let [wc (php/aget fade (php/aget tpx (php/+ (php/* (php/min 63 (php/intdiv (php/* (php/+ rel 1) 64) whs)) 64) u)))]
                                       (php/aset pack-reg 2
                                                 (if (php/>= s2b (php/- bs-sub 1))
-                                                  (php/max 232 (php/- wc seam-base-dark))
+                                                  (php/aget seam-darken-16 wc)
                                                   (if (php/>= s2b (php/- bs-sub 2))
-                                                    (php/max 232 (php/- wc seam-wall-dark))
+                                                    (php/aget seam-darken-8 wc)
                                                     (if (php/=== s2b ts-sub)
-                                                      (php/max 232 (php/- wc seam-top-dark))
+                                                      (php/aget seam-darken-5 wc)
                                                       wc))))))
                                   (php/aset cell-reg 0
                                             (halfblock (php/aget pack-reg 1) (php/aget pack-reg 2))))))
@@ -1726,16 +1794,17 @@
                                   ;; stacked into one ▀ cell.
                                   (let [wh   (php/max 1 (php/- bot top))
                                         u    (buf-get shades-tex-u col)
+                                        tpx  (buf-get shades-tex-px col)
                                         rel2 (php/* 2 (php/- row top))
                                         tvt  (php/min 63 (php/intdiv (php/* rel2 32) wh))
                                         tvb  (php/min 63 (php/intdiv (php/* (php/+ rel2 1) 32) wh))
                                         fade (php/aget tex-fade-table lvl)]
                                     (php/aset cell-reg 0
-                                              (halfblock (php/aget fade (php/aget wall-tex-px (php/+ (php/* tvt 64) u)))
-                                                         (php/aget fade (php/aget wall-tex-px (php/+ (php/* tvb 64) u))))))
+                                              (halfblock (php/aget fade (php/aget tpx (php/+ (php/* tvt 64) u)))
+                                                         (php/aget fade (php/aget tpx (php/+ (php/* tvb 64) u))))))
                                   (let [wh   (php/max 1 (php/- bot top))
                                         tv   (php/min 63 (php/intdiv (php/* (php/- row top) 64) wh))
-                                        tc   (php/aget wall-tex-px
+                                        tc   (php/aget (buf-get shades-tex-px col)
                                                        (php/+ (php/* tv 64) (buf-get shades-tex-u col)))
                                         fade (php/aget tex-fade-table lvl)]
                                     (php/aset cell-reg 0


### PR DESCRIPTION
## Summary

The 3D door face used to render as one yellow/orange `▌` stripe per screen column with whole-cell orange edge bands - at current render fidelity it read as a flickering striped curtain with a floating frame.

- Doors (unlocked + keycard-locked) now sample a baked procedural 64x64 amber metal door texture (dark rust border, red-rust frame ring, six vertical planks with highlight/shadow edges, horizontal mid rail) through the same path as the stone walls: panels scale with perspective, fog with distance, and door edges trace the sub-row diagonal seams
- `compute-wall-shades` stores a per-column texel array (`tex-px` buffer: stone or door texture); the hot loops bind one extra `aget` and stay texture-agnostic
- Door fog uses the wall gamma formula but floors at level 8 and ignores the near-death haze (a door is the nav cue - it never fades to black); the door pulse rides the fog level (+3 on the 4 rad/s beat) instead of swapping stripe colours
- Seam accents moved from `code - n` arithmetic to hue-true darken LUTs (`seam-darken-16/-8/-5` in `frame_math`): subtraction on a colour-cube code jumps hue (amber 166 - 16 = green 150); for grayscale codes the LUTs reproduce the old arithmetic exactly
- Boss door keeps its flat pulsing red slab; blood-band + glyph-enemy door columns and the flat-walls / no-subpixel fallbacks keep the striped door

## Verification

- `composer ci` green (format + lint + 2021 tests + build)
- 48-config frame-checksum matrix byte-identical to main (md5): proves the seam-LUT swap is a grayscale no-op; no harness scene faces a door
- Visual before/after at full detail and pixel-doubled: striped curtain -> framed two-panel amber door at both scales, diagonal seams at the door edges
- Bench vs main under identical load: delta within noise at every size (one extra aget per textured cell)

## Test plan

- [ ] `/play`: walk to an unlocked door - reads as a framed plank door, pulses gently, stays amber at distance
- [ ] Locked doors (blue/red/yellow) render the same texture; "NEED ... KEY" bump cue unchanged
- [ ] Boss door (L10) still the flat pulsing red slab
- [ ] `PHEL_DOOM_FLAT_WALLS=1` / `PHEL_DOOM_NO_SUBPIXEL=1` fall back cleanly