### PR TITLE
feat(render): FIND THE EXIT objective on plain-level intro (perf-neutral)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 
 ### Added
 
+- Every level states an objective on its intro splash: plain levels show **FIND THE EXIT** (orange, matching the compass exit arrow), alongside the existing **FIND THE \<COLOUR\> KEY** on locked levels and **KILL THE BOSS TO ESCAPE** on the boss arena. Overlay-only, no frame-speed cost.
 - End-screen run summary + letter rank: death/victory screens show **accuracy %** (connecting pulls / total pulls), **secrets** found/total, and a colour-coded **rank** S/A/B/C/D alongside kills/time/bests. Grade is `0.7*accuracy + 0.3*secrets-ratio` (a secret-less run is never penalised). New `:shots-fired` / `:shots-hit` counters accumulate across levels; grade + accuracy live in `core/format` (unit-tested).
 - End-screen summary also reports **damage taken** (HP lost across the run; armor-absorbed hits don't count) and a **per-weapon kill breakdown** (`by: chaingun 29  shotgun 8  pistol 5`, most-used first), via `:damage-taken` in `apply-hit` and `:kills-by-weapon` (`bump-weapon-kills`) carried across levels.
 - 8-way directional damage feedback: a hit paints a red arc on the screen edge the attacker came from - a centred bar for the four cardinals, an L at the corner for the four diagonals - so you read the exact incoming bearing during i-frames. New `:hurt-dir` octant (`attacker-octant`); the 4-way `:hurt-side` stays for blood-drip columns. Kept under reduced motion.

--- a/docs/features.md
+++ b/docs/features.md
@@ -55,7 +55,8 @@ See [monsters.md](monsters.md), [combat.md](combat.md).
 ## HUD + screens
 
 - Top-left strip: hearts + armor + GOD badge (dev). Row 2: level/monster count, kills, weapon, ammo, backpack tier, stamina bar, keycard, difficulty tag.
-- Compass top-center: facing letter yellow, locked level letter tints lock color.
+- Compass top-center: facing letter yellow; a quest-target letter tints toward the objective - the un-picked keycard (lock colour) on a locked level, or the exit door (orange) once the key is in hand / on a plain level.
+- Objective subtitle on the level-intro splash: `FIND THE <COLOUR> KEY` on locked levels, `KILL THE BOSS TO ESCAPE` on the boss arena, `FIND THE EXIT` (orange, matching the compass arrow) on plain levels - so every level states its goal.
 - Minimap (m toggle, default OFF): top-right, auto-scales <= 1/3 width on narrow terminals. Perf mode caps 40 cols.
 - F3 debug: frame-ms, cast/render split, bytes, RLE, mem, pos, angle, fps (off by default, zero overhead when off).
 - Ammo cues: pulsing `! LOW AMMO N !` when <= 3 rounds; dry-fire `CLICK` prompt.

--- a/src/io/render/paint.phel
+++ b/src/io/render/paint.phel
@@ -134,10 +134,11 @@
 
 (defn paint-intro-splash
   "Centred banner showing 'LEVEL N · NAME' while :intro-secs > 0.
-   On locked levels (L4 blue / L5 red / L7 yellow) appends a 'FIND THE <COLOUR>
-   KEY' subtitle so the player knows the door at the exit needs a
-   keycard before they go hunting for it. Subtitle SGR matches the
-   lock colour so the cue reads at a glance."
+   Appends an objective subtitle: 'FIND THE <COLOUR> KEY' on locked levels
+   (L4 blue / L5 red / L7 yellow), 'KILL THE BOSS TO ESCAPE' on the boss
+   level, and 'FIND THE EXIT' (orange, matching the compass exit arrow) on
+   plain levels - so the player always has a stated objective (issue #203).
+   Subtitle SGR matches the lock / exit colour so the cue reads at a glance."
   [parts stats vw vh]
   (when (php/> (or (get stats :intro-secs) 0.0) 0.0)
     (let [title    (str "LEVEL " (or (get stats :level) 1)
@@ -148,13 +149,16 @@
                      (php/=== lock :red)    "FIND THE RED KEY"
                      (php/=== lock :yellow) "FIND THE YELLOW KEY"
                      (php/=== lock :boss)   "KILL THE BOSS TO ESCAPE"
-                     :else                  nil)
+                     ;; Unlocked level: point the player at the exit (the
+                     ;; compass already tints the cardinal orange toward it).
+                     :else                  "FIND THE EXIT")
           sub-sgr  (cond
                      (php/=== lock :blue)   "\e[40;94;1m"
                      (php/=== lock :red)    "\e[40;91;1m"
                      (php/=== lock :yellow) "\e[40;93;1m"
                      (php/=== lock :boss)   "\e[40;38;5;196;1m"
-                     :else                  "\e[40;93;1m")
+                     ;; Orange to match the compass exit-door arrow (SGR 214).
+                     :else                  "\e[40;38;5;214;1m")
           ;; Box width sized to the longer of title / subtitle so
           ;; both lines fit symmetrically with the same 4-col pad.
           inner    (php/max (php/mb_strlen title)

--- a/tests/io/paint-test.phel
+++ b/tests/io/paint-test.phel
@@ -1,7 +1,7 @@
 (ns phel-doom-tests.io.paint-test
   (:require phel.test :refer [deftest is])
   (:require phel-doom.io.render.buffer :refer [buf-mk])
-  (:require phel-doom.io.render.paint :refer [paint-crosshair paint-door-face paint-game-info paint-compass paint-hearts-hud paint-hit-vignette]))
+  (:require phel-doom.io.render.paint :refer [paint-crosshair paint-door-face paint-game-info paint-compass paint-hearts-hud paint-hit-vignette paint-intro-splash]))
 
 ;; ---------------------------------------------------------------------
 ;; Crosshair legibility. The reticle must be a SOLID glyph, never the old
@@ -148,6 +148,20 @@
 
 (deftest test-hit-arc-not-bloody-no-paint
   (is (= "" (hit-vig-str 0 false)) "no i-frames -> nothing painted"))
+
+;; Objective subtitle (issue #203): the intro splash always states a goal.
+
+(defn- intro-str [lock]
+  (php/implode "" (paint-intro-splash (buf-mk)
+                                      {:intro-secs 1.0 :level 3 :level-name "the warrens" :door-lock lock}
+                                      80 24)))
+
+(deftest test-intro-unlocked-level-says-find-the-exit
+  (is (php/str_contains (intro-str nil) "FIND THE EXIT") "plain level points at the exit"))
+
+(deftest test-intro-locked-level-says-find-the-key
+  (is (php/str_contains (intro-str :blue) "FIND THE BLUE KEY") "locked level still names the key")
+  (is (not (php/str_contains (intro-str :blue) "FIND THE EXIT")) "key cue wins over exit on a locked level"))
 
 ;; ---------------------------------------------------------------------
 ;; Scene-coordinate painters carry a pixel-scale `sc`: their inputs live


### PR DESCRIPTION
## 📚 Description

The level-intro splash now states an objective on **every** level: plain levels show **FIND THE EXIT** (orange, matching the compass exit-door arrow), alongside the existing **FIND THE \<COLOUR\> KEY** (locked levels) and **KILL THE BOSS TO ESCAPE** (boss arena). Overlay-only, no frame-speed cost.

This addresses the **objective-waypoint** part (item 3) of #203 - the directional exit arrow on the compass was already implemented via `quest-target-hint`; this adds the matching text cue on plain levels. The navigable pause menu (item 2) and weapon-wheel (item 4) remain.

## 🔖 Changes

- `io/render/paint`: `paint-intro-splash` subtitle `:else` branch `nil` -> `FIND THE EXIT` (orange SGR 214); docstring refreshed.
- Tests pin unlocked (exit) vs locked (key wins) subtitle.
- Minimal single-branch change; no hot-loop touch (closures unchanged). Docs (features.md) + CHANGELOG.

Related to #203