### PR TITLE
test: pin combat immunity, sfx queue + difficulty mixed-spec scaling

### DIFF
--- a/tests/core/combat-test.phel
+++ b/tests/core/combat-test.phel
@@ -3,7 +3,7 @@
   (:require phel-doom.core.state :refer [new-world new-player max-lives])
   (:require phel-doom.core.enemy :refer [new-enemy])
   (:require phel-doom.core.combat
-            :refer [arm-berserk armory-reserve closest-attacker attacker-side attacker-octant berserk? berserk-damage-mul berserk-melee-mul berserk-mul-for berserk-seconds can-fire? apply-heat damage-step empty-click-seconds enemy-hit-damage hit-damage-for hit-player-at hit-stop-for hit-stop-tough-seconds hit-stop-boss-seconds invuln? invuln-seconds knockback mag-size pick-loot-weapon player-immune? reload reloading? roll-loot-kind tick-armory tick-shooting]))
+            :refer [arm-berserk armory-reserve closest-attacker attacker-side attacker-octant berserk? berserk-damage-mul berserk-melee-mul berserk-mul-for berserk-seconds can-fire? apply-heat damage-step empty-click-seconds enemy-hit-damage hit-damage-for hit-player-at hit-stop-for hit-stop-tough-seconds hit-stop-boss-seconds invuln? invuln-seconds knockback mag-size pick-loot-weapon player-immune? push-sfx reload reloading? roll-loot-kind tick-armory tick-shooting]))
 
 ;; ---------------------------------------------------------------------
 ;; closest-attacker: selection rule.
@@ -952,3 +952,19 @@
 (deftest test-player-immune-false-when-vulnerable
   (is (not (player-immune? {:iframes 0.0 :invuln-secs 0.0 :god? false}))
       "no i-frames, no invuln, no god -> hittable"))
+
+;; ---------------------------------------------------------------------
+;; push-sfx: the pure :sfx queue envelope. io (commands/play) drains it
+;; after the tick. Pin the {:name :vol} event shape, the nil-seed (or s
+;; []), and conj append order so a regression can't silently reorder or
+;; drop queued sounds.
+;; ---------------------------------------------------------------------
+
+(deftest test-push-sfx-appends-event-to-empty-queue
+  (is (= [{:name :hit :vol 1.0}] (:sfx (push-sfx {} :hit 1.0)))
+      "first event seeds the queue with one {:name :vol} map"))
+
+(deftest test-push-sfx-accumulates-in-order
+  (let [w (-> {} (push-sfx :hit 1.0) (push-sfx :kill 0.6))]
+    (is (= [{:name :hit :vol 1.0} {:name :kill :vol 0.6}] (:sfx w))
+        "events stay in enqueue order")))

--- a/tests/core/combat-test.phel
+++ b/tests/core/combat-test.phel
@@ -3,7 +3,7 @@
   (:require phel-doom.core.state :refer [new-world new-player max-lives])
   (:require phel-doom.core.enemy :refer [new-enemy])
   (:require phel-doom.core.combat
-            :refer [arm-berserk armory-reserve closest-attacker attacker-side attacker-octant berserk? berserk-damage-mul berserk-melee-mul berserk-mul-for berserk-seconds can-fire? apply-heat damage-step empty-click-seconds enemy-hit-damage hit-damage-for hit-player-at hit-stop-for hit-stop-tough-seconds hit-stop-boss-seconds invuln? invuln-seconds knockback mag-size pick-loot-weapon reload reloading? roll-loot-kind tick-armory tick-shooting]))
+            :refer [arm-berserk armory-reserve closest-attacker attacker-side attacker-octant berserk? berserk-damage-mul berserk-melee-mul berserk-mul-for berserk-seconds can-fire? apply-heat damage-step empty-click-seconds enemy-hit-damage hit-damage-for hit-player-at hit-stop-for hit-stop-tough-seconds hit-stop-boss-seconds invuln? invuln-seconds knockback mag-size pick-loot-weapon player-immune? reload reloading? roll-loot-kind tick-armory tick-shooting]))
 
 ;; ---------------------------------------------------------------------
 ;; closest-attacker: selection rule.
@@ -930,3 +930,25 @@
 (deftest test-hit-stop-boss-longer-freeze
   (is (= hit-stop-boss-seconds (hit-stop-for 10)))
   (is (= hit-stop-boss-seconds (hit-stop-for 50)) "L10 boss -> boss freeze"))
+
+;; ---------------------------------------------------------------------
+;; player-immune?: the three-way "this hit can't land" gate, shared by
+;; the contact path and core/projectile. Each test pins one branch with
+;; the other two off so a regression in any single condition is caught.
+;; ---------------------------------------------------------------------
+
+(deftest test-player-immune-true-with-iframes
+  (is (player-immune? {:iframes 0.5 :invuln-secs 0.0 :god? false})
+      "active i-frames block the hit"))
+
+(deftest test-player-immune-true-with-invuln
+  (is (player-immune? {:iframes 0.0 :invuln-secs 1.0 :god? false})
+      "invuln powerup blocks the hit"))
+
+(deftest test-player-immune-true-with-god
+  (is (player-immune? {:iframes 0.0 :invuln-secs 0.0 :god? true})
+      "god mode suppresses damage"))
+
+(deftest test-player-immune-false-when-vulnerable
+  (is (not (player-immune? {:iframes 0.0 :invuln-secs 0.0 :god? false}))
+      "no i-frames, no invuln, no god -> hittable"))

--- a/tests/core/difficulty-test.phel
+++ b/tests/core/difficulty-test.phel
@@ -1,6 +1,7 @@
 (ns phel-doom-tests.core.difficulty-test
   (:require phel.test :refer [deftest is])
-  (:require phel-doom.core.difficulty :refer [normalise scale-cfg spec-for]))
+  (:require phel-doom.core.difficulty :refer [normalise scale-cfg spec-for])
+  (:require phel-doom.core.enemies :refer [default-lives-for]))
 
 (deftest test-normalise-defaults-to-normal-on-nil
   (is (= :normal (normalise nil))))
@@ -60,3 +61,24 @@
   (let [cfg (scale-cfg {:chase 1.0 :enemy-lives 1 :enemies 1} :easy)]
     (is (= 1 (:enemies cfg)))
     (is (= 1 (:enemy-lives cfg)))))
+
+;; ---------------------------------------------------------------------
+;; scale-cfg, mixed-spec branch: when :enemies is a VECTOR of specs the
+;; hp-mul scales each spec's :lives but leaves :count alone (the author's
+;; roster is the design intent, not an auto-scaled knob). The int-:enemies
+;; branch is covered above; these pin the vector? path.
+;; ---------------------------------------------------------------------
+
+(deftest test-scale-cfg-mixed-spec-scales-lives-leaves-counts
+  ;; nightmare hp-mul 1.5: ceil(3 * 1.5) = 5; :count untouched.
+  (let [cfg  (scale-cfg {:chase 1.0 :enemies [{:type :caco :lives 3 :count 2}]} :nightmare)
+        spec (first (:enemies cfg))]
+    (is (= 5 (:lives spec)) "explicit :lives scaled by hp-mul")
+    (is (= 2 (:count spec)) "spec :count left as authored")))
+
+(deftest test-scale-cfg-mixed-spec-without-lives-uses-catalog-default
+  ;; No explicit :lives -> base is the type's catalog default-lives-for.
+  (let [cfg      (scale-cfg {:chase 1.0 :enemies [{:type :caco}]} :nightmare)
+        spec     (first (:enemies cfg))
+        expected (php/intval (php/ceil (php/* (default-lives-for :caco) 1.5)))]
+    (is (= expected (:lives spec)) "catalog HP scaled when spec omits :lives")))


### PR DESCRIPTION
## 📚 Description

Test-only coverage pass over pure `core/` logic that was exercised only indirectly. No behaviour change; suite green at 2221 (+9 assertions). First pass of an ongoing optimization loop.

## 🔖 Changes

- `combat`: pin `player-immune?` i-frame / invuln / god branches (one test per gate, others off).
- `combat`: pin `push-sfx` queue `{:name :vol}` shape, nil-seed, and conj append order.
- `difficulty`: cover `scale-cfg` mixed-spec (vector `:enemies`) path - HP scales per spec, `:count` left as authored; catalog `default-lives-for` fallback when `:lives` omitted.