### PR TITLE
fix: balance tuning - berserk 18s, eased critical heartbeat, doc drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 ### Changed
 
 - Berserk window trimmed from 20s to 18s: still long enough to chain two or three room clears, but the rage now ends with a touch of use-it-or-lose-it pressure instead of lingering passively.
+- Critical-HP heartbeat eased from 0.85s to 0.90s in the 3-4 heart tier: the first low-HP thump lands with a clearer percussive peak before accelerating into the 0.55s last-heart panic tier (last-heart tier unchanged).
 
 ## [0.14.0] - 2026-06-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 
 ## [Unreleased]
 
+### Changed
+
+- Berserk window trimmed from 20s to 18s: still long enough to chain two or three room clears, but the rage now ends with a touch of use-it-or-lose-it pressure instead of lingering passively.
+
 ## [0.14.0] - 2026-06-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,6 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 
 ## [Unreleased]
 
-### Changed
-
-- Berserk window trimmed from 20s to 18s: still long enough to chain two or three room clears, but the rage now ends with a touch of use-it-or-lose-it pressure instead of lingering passively.
-- Critical-HP heartbeat eased from 0.85s to 0.90s in the 3-4 heart tier: the first low-HP thump lands with a clearer percussive peak before accelerating into the 0.55s last-heart panic tier (last-heart tier unchanged).
-
 ## [0.14.0] - 2026-06-14
 
 ### Added

--- a/docs/combat.md
+++ b/docs/combat.md
@@ -155,7 +155,7 @@ High-burst tank-killer (issue #126): DOOM II's SSG. Reuses the shotgun `:spread?
 Berserk sphere (`Ω` glyph, 1-in-8 levels). Melee-biased, DOOM-style (issue #127): it is a "go punch everything" surge plus a full heal, not a flat all-weapon buff.
 
 1. `pickup-berserks` removes sphere, plays `:berserk` sfx, calls `arm-berserk`.
-2. `arm-berserk` stamps `:berserk-secs` to 20s (refresh, not stack) AND full-heals the player to `max-lives` (never lowering an over-cap soulsphere count).
+2. `arm-berserk` stamps `:berserk-secs` to 18s (refresh, not stack) AND full-heals the player to `max-lives` (never lowering an over-cap soulsphere count).
 3. `decay-timers` ticks down. While active, `berserk-mul-for` scales weapon damage by `damage-type`: `:melee` (the chainsaw) gets the big `berserk-melee-mul` (6), every ranged type gets the modest `berserk-damage-mul` (2). So berserk turns the chainsaw into a tank shredder while only mildly buffing guns.
 4. Render paints red pulsing border (suppressed by i-frames, which take priority).
 

--- a/docs/combat.md
+++ b/docs/combat.md
@@ -11,7 +11,7 @@ Hitscan + damage timing + i-frames. `src/core/combat.phel`. Pure: no side effect
 | `shot-knockback-dist` | 1.0 | Push distance per wounding hit |
 | `touch-damage-dist` | 0.7 | Contact damage range |
 | `iframe-seconds` | 1.0 | Post-hit invulnerability window |
-| `fire-anim-seconds` | 0.09 | Muzzle flash visibility |
+| `fire-anim-seconds` | 0.13 | Muzzle flash visibility |
 | `fx-ttl-seconds` | 0.7 | Blood splatter lifetime |
 | `flash-seconds` | 0.05 | White impact jolt |
 | `heat-per-shot` | 0.30 | Overheat per shot (dormant - no weapon overheats) |

--- a/docs/features.md
+++ b/docs/features.md
@@ -70,7 +70,7 @@ See [monsters.md](monsters.md), [combat.md](combat.md).
 
 Triggered on life drop or enemy proximity:
 
-- Heartbeat (last 2 hearts, <=4 HP): red edge vignette + low thump every 0.85s, accelerating to 0.55s in the last heart.
+- Heartbeat (last 2 hearts, <=4 HP): red edge vignette + low thump every 0.90s, accelerating to 0.55s in the last heart.
 - Lights flicker: brief scanline darken every 20-30s (calm), 6-12s in the last 2 hearts.
 - Jump-scare (enemy 3.5 units): magenta wide-eyed skull on face for 600ms.
 - Sudden silence (enemy 1.5 units): all sfx muted 400ms.

--- a/docs/features.md
+++ b/docs/features.md
@@ -19,7 +19,7 @@ See [rendering.md](rendering.md), [raycaster.md](raycaster.md), [performance.md]
 
 - 10 levels: L1 pure imps (tutorial), L2-L9 procgen mixed-type with a headline monster + secondaries (L2 demons, L3 cacos, L4 barons, L5 cybers, L6 spectres, L7 revenants, L8 archvile court, L9 the pinky brood), L10 hand-authored boss arena (cyber 50 HP + 2 imps, cap 1 alive)
 - Per-level wall, sky, floor palette
-- Pickups: hearts (heal one full heart; pool is 5 hearts / 10 HP), armor (cap 5, absorbs one whole hit), armor shards (+1 over-cap to 10), soulsphere (over-cap to 14 HP, decays), ammo boxes, berserk (20s 2x dmg), invuln (10s immune), stacking backpack (L2+, reserve tier per pickup)
+- Pickups: hearts (heal one full heart; pool is 5 hearts / 10 HP), armor (cap 5, absorbs one whole hit), armor shards (+1 over-cap to 10), soulsphere (over-cap to 14 HP, decays), ammo boxes, berserk (18s 2x dmg), invuln (10s immune), stacking backpack (L2+, reserve tier per pickup)
 - Keycards: L4 blue, L5 red, L7 yellow. Locked door pulses on bump without key. L10 boss door unlocks via synthetic :boss keycard after cyber kill. Compass tints facing letter in lock color.
 - Secrets: up to 2 per procgen level (L10 has hand-authored pair). Bump with F to reveal ammo + shard + rotating powerup. Skipped on locked levels.
 - Walk-into-door auto-advance. Pulsing minimap + bright 3D glyph.

--- a/docs/gameplay.md
+++ b/docs/gameplay.md
@@ -34,7 +34,7 @@ Terminal quirks (kitty, tmux): [input.md](input.md).
 - **armor shard**: plus 1 armor over cap 5, up to 10 total
 - **soulsphere**: boost to 7 lives (max 10), over-cap decays back over 5 seconds
 - **ammo box**: plus N to active weapon reserve
-- **berserk**: full heal plus 20s melee surge (chainsaw 6x, guns 2x)
+- **berserk**: full heal plus 18s melee surge (chainsaw 6x, guns 2x)
 - **invuln**: 10s damage immunity
 - **backpack**: increases reserve cap by one base (stacks 3 times)
 - **keycard**: blue unlocks L4 exit, red unlocks L5, yellow unlocks L7. L10 boss-locked

--- a/src/core/combat.phel
+++ b/src/core/combat.phel
@@ -197,7 +197,7 @@
   "Active window of the berserk powerup. While > 0 the player's
    weapon damage is multiplied by `berserk-damage-mul` and render
    paints a red rage tint on the viewport."
-  20.0)
+  18.0)
 
 (def berserk-damage-mul
   "Berserk damage multiplier for RANGED weapons (the default). Berserk is

--- a/src/core/physics.phel
+++ b/src/core/physics.phel
@@ -292,7 +292,7 @@
   (cond
     (php/<= lives 0) nil
     (php/<= lives 2) 0.55
-    (php/<= lives 4) 0.85
+    (php/<= lives 4) 0.90
     :else            nil))
 
 (defn- flicker-cooldown-bounds


### PR DESCRIPTION
## 📚 Description

Small balance + accuracy pass (review-gated; feel tweaks are proposals, not playtested). Suite green at 2212. Part of the ongoing optimization loop.

## 🔖 Changes

- `fix(combat)`: berserk window 20s -> 18s for use-it-or-lose-it tension (still chains 2-3 room clears). Docs synced in combat.md, features.md, gameplay.md.
- `fix(physics)`: critical-HP heartbeat eased 0.85s -> 0.90s in the 3-4 heart tier; last-heart 0.55s panic tier unchanged.
- `docs(combat)`: correct `fire-anim-seconds` tunables row to 0.13 (matched code; was stale 0.09).