### PR TITLE
feat(physics): muted deny click on locked-door bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,6 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 
 ## [Unreleased]
 
-### Added
-
-- Locked-door bump now plays a muted "denied" click (the dry-fire `:click` at half volume) so a blocked door reads by ear, not just the `NEED <COLOUR> KEY` hint. Rising-edge gated: holding into the door re-clicks at the ~1.5s hint cadence instead of spamming every frame. Enqueued from `physics/try-move`, drained like every other cue (gated on `:sound-on`).
-
 ## [0.14.0] - 2026-06-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 
 ## [Unreleased]
 
+### Added
+
+- Locked-door bump now plays a muted "denied" click (the dry-fire `:click` at half volume) so a blocked door reads by ear, not just the `NEED <COLOUR> KEY` hint. Rising-edge gated: holding into the door re-clicks at the ~1.5s hint cadence instead of spamming every frame. Enqueued from `physics/try-move`, drained like every other cue (gated on `:sound-on`).
+
 ## [0.14.0] - 2026-06-14
 
 ### Added

--- a/docs/audio.md
+++ b/docs/audio.md
@@ -8,6 +8,8 @@ One-shot SFX via `src/io/sound.phel` (shell-out) plus a background OST riff via 
 
 Combat enqueues events on the world's per-frame `:sfx` queue via `combat/push-sfx`: `:shoot`, `:shoot-shotgun`, `:shoot-chaingun`, `:shoot-chainsaw`, `:shoot-bfg`, `:shoot-incinerator`, `:shoot-rocket`, `:hit`, `:kill`, `:reload`, `:click`, `:door`, `:heartbeat`, `:berserk`, `:wound`.
 
+A locked-door bump also enqueues a muted `:click` (vol 0.5) as a "denied" cue, on the rising edge only (re-fires at the ~1.5s `NEED <COLOUR> KEY` hint cadence, not every frame). It is enqueued by `physics/try-move` directly (inlined, not via `push-sfx`) to avoid a `core/combat` <-> `core/physics` require cycle - `combat` already requires `physics/try-move`.
+
 This queue keeps `tick-world` pure: no `play-sfx!` calls in-tick. `commands/play` drains it after `tick-world` and emits each event, gated on `:sound-on`. The queue clears at frame start so events never replay. (Level-transition cues like door advance play directly in the outer loop, outside the pure tick.)
 
 Weapon-fire events play baked Freedoom (BSD) DMX reports (see "Weapon fire sounds" below). Everything else falls to the per-OS system map. macOS system map: Pop (pistol/kill), Blow (shotgun), Morse (chaingun), Purr (chainsaw), Glass (BFG), Frog (incinerator), Ping (rocket), Sosumi (player-hurt), Funk (reload), Tink (door/pickup), Submarine (wound), Bottle (heartbeat), Hero (berserk).

--- a/src/core/physics.phel
+++ b/src/core/physics.phel
@@ -68,8 +68,9 @@
    a wall OR a locked door without the matching keycard. When a
    bump is caused specifically by a missing keycard, arm
    :locked-door-bump-secs + record the colour so the render layer
-   can paint 'NEED <COLOUR> KEY' over the 3D view. Wall bumps are
-   silent — only the locked-door case is informational."
+   can paint 'NEED <COLOUR> KEY' over the 3D view, and enqueue a
+   muted `:click` deny cue on the :sfx queue. Wall bumps are silent —
+   only the locked-door case is informational."
   [world ^float dx ^float dy]
   (let [{:keys [grid player held-keys]} world
         nx                              (+ (:x player) dx)
@@ -84,9 +85,18 @@
       (let [need (missing-key-for grid held-keys ix iy)]
         (if (php/=== need nil)
           world
-          (assoc world
-                 :locked-door-bump-secs   locked-bump-secs
-                 :locked-door-bump-colour need))))))
+          ;; Rising-edge deny click: enqueue the muted `:click` only when
+          ;; the bump timer was not already armed, so holding into the door
+          ;; re-clicks at the ~1.5s hint cadence instead of every frame.
+          ;; Inlined (not push-sfx) to avoid a core/combat <-> physics
+          ;; require cycle — combat already requires physics/try-move.
+          (let [armed? (php/> (or (:locked-door-bump-secs world) 0.0) 0.0)
+                w      (assoc world
+                              :locked-door-bump-secs   locked-bump-secs
+                              :locked-door-bump-colour need)]
+            (if armed?
+              w
+              (update w :sfx (fn [s] (conj (or s []) {:name :click :vol 0.5}))))))))))
 
 (defn- counter-on? [moves slot]
   (php/> (get moves slot) 0))

--- a/tests/core/physics-test.phel
+++ b/tests/core/physics-test.phel
@@ -76,6 +76,20 @@
     (is (= 0.0 (or (:locked-door-bump-secs w) 0.0)))
     (is (php/=== nil (:locked-door-bump-colour w)))))
 
+(deftest test-try-move-locked-door-enqueues-one-deny-click
+  ;; First bump from a non-armed state plays the muted deny click.
+  (let [w (try-move blue-door-world 1.0 0.0)]
+    (is (= [{:name :click :vol 0.5}] (:sfx w)))))
+
+(deftest test-try-move-locked-door-hold-does-not-respam-click
+  ;; While the bump timer is still armed (player holding into the door)
+  ;; no new click is enqueued — the click re-fires only after the timer
+  ;; decays, at the HUD-hint cadence, not every frame.
+  (let [w1 (try-move blue-door-world 1.0 0.0)
+        w2 (try-move (assoc w1 :sfx []) 1.0 0.0)]
+    (is (= [] (or (:sfx w2) [])))
+    (is (php/> (:locked-door-bump-secs w2) 0.0) "stays armed")))
+
 ;; ---------------------------------------------------------------------
 ;; apply-physics: counters drive movement, decay each frame.
 ;; ---------------------------------------------------------------------


### PR DESCRIPTION
## 📚 Description

A locked-door bump arms the `NEED <COLOUR> KEY` HUD hint but was silent. Now it also plays a muted "denied" click so a blocked door reads by ear. Suite green at 2215 (+3 assertions). Part of the ongoing optimization loop.

## 🔖 Changes

- `physics/try-move`: enqueue the dry-fire `:click` at 0.5 vol on a missing-key bump. Rising-edge gated on `:locked-door-bump-secs` so holding into the door re-clicks at the ~1.5s hint cadence, not every frame.
- Inlined the `:sfx` append (not `push-sfx`) to avoid a `core/combat` <-> `core/physics` require cycle - combat already requires `physics/try-move`. core/ stays pure; `commands/play` drains it gated on `:sound-on`.
- Tests: first bump enqueues exactly one click; held bump enqueues none. Docs: audio.md event tags + CHANGELOG.