### PR TITLE
ref: code-quality cleanup - blink cond, kitty decoders, dead read-key

### DIFF
--- a/src/glue/controls.phel
+++ b/src/glue/controls.phel
@@ -191,6 +191,18 @@
           (press-slot w1 :sprint)
           w1)))))
 
+(defn- kitty-mods
+  "Decode an optional kitty mods capture: empty / nil means no modifiers (0).
+   Kitty encodes modifiers as a bitfield + 1; bit 0 = SHIFT (sprint arming)."
+  [raw]
+  (if (or (nil? raw) (= raw "")) 0 (php/intval raw)))
+
+(defn- kitty-event
+  "Decode an optional kitty event-type capture: empty / nil means a press (1).
+   Event types: 1 = press, 2 = repeat, 3 = release."
+  [raw]
+  (if (or (nil? raw) (= raw "")) 1 (php/intval raw)))
+
 (defn- apply-kitty-events
   "Scan `keys` for kitty CSI-u sequences and fold them into `world`.
    Returns [world-after-events leftover-string]; leftover-string is
@@ -213,13 +225,8 @@
         (if (php/>= i n)
           [w (php/preg_replace re "" keys)]
           (let [code  (php/intval (php/aget codes-arr i))
-                mraw  (php/aget mods-arr i)
-                mods  (if (or (nil? mraw) (= mraw "")) 0 (php/intval mraw))
-                evraw (php/aget ev-arr i)
-                ;; Missing :event capture means press (event-type 1).
-                event (if (or (nil? evraw) (= evraw ""))
-                        1
-                        (php/intval evraw))]
+                mods  (kitty-mods (php/aget mods-arr i))
+                event (kitty-event (php/aget ev-arr i))]
             (recur (php/+ i 1) (handle-kitty-event w code event mods))))))))
 
 (def arrow-letter->slot
@@ -252,12 +259,8 @@
         (if (php/>= i n)
           [w (php/preg_replace re "" keys)]
           (let [letter (php/aget letters i)
-                mraw   (php/aget mods-arr i)
-                mods   (if (or (nil? mraw) (= mraw "")) 0 (php/intval mraw))
-                evraw  (php/aget ev-arr i)
-                event  (if (or (nil? evraw) (= evraw ""))
-                         1
-                         (php/intval evraw))
+                mods   (kitty-mods (php/aget mods-arr i))
+                event  (kitty-event (php/aget ev-arr i))
                 slot   (get arrow-letter->slot letter)]
             (recur (php/+ i 1)
                    (cond

--- a/src/io/input.phel
+++ b/src/io/input.phel
@@ -43,14 +43,6 @@
   (print "\e[?25h\e[?7h\e[?1049l")
   (php/exec "stty sane"))
 
-(defn read-key
-  "Read one key from STDIN. Returns the character or nil if nothing pending."
-  []
-  (let [s (php/fread php/STDIN 1)]
-    (if (or (= s false) (= s ""))
-      nil
-      s)))
-
 (defn drain-keys
   "Drain all pending input bytes as a raw string (possibly empty). Lets
    a held key apply its motion multiple times per frame instead of being

--- a/src/io/render/paint.phel
+++ b/src/io/render/paint.phel
@@ -903,9 +903,9 @@
         ;; High-contrast (#200): empty heart pips in plain white instead
         ;; of the dim grey (90) that disappears on washed-out terminals.
         empty-sgr (if (get stats :high-contrast?) "\e[40;97m" "\e[40;90m")
-        blink     (cond (and bloody? (pulse t 8.0)) "\e[1m"
-                        bloody?                     "\e[2m"
-                        :else                       "\e[1m")]
+        ;; Dim only during the off-phase of the pulse while bloody; bright
+        ;; otherwise (healthy, or the on-phase of a bloody pulse).
+        blink     (if (and bloody? (not (pulse t 8.0))) "\e[2m" "\e[1m")]
     (buf-push parts
               (str "\e[1;1H\e[40m" blink "\e[91m"
                    (php/str_repeat "♥ " full)


### PR DESCRIPTION
## 📚 Description

Three small, behaviour-preserving cleanups surfaced + adversarially verified by the optimization loop's round-2 discovery. Suite green at 2212 (no test edits needed). Each commit is independent.

## 🔖 Changes

- `ref(render)`: hearts-HUD `blink` was a 3-clause `cond` whose first and `:else` branches were identical (`\e[1m`); collapse to one `if` that dims only during the off-phase of a bloody pulse. Truth-table identical, `pulse` short-circuit preserved.
- `ref(controls)`: extract `kitty-mods` / `kitty-event` private decoders; the empty/nil-default parse was inlined four times across `apply-kitty-events` + `apply-kitty-arrow-events`. Covered end-to-end by controls-test.
- `ref(input)`: remove dead `read-key` (zero callers repo-wide; `drain-keys` superseded it).