### PR TITLE
feat(render): READY flash when reload cooldown completes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,6 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 
 ## [Unreleased]
 
-### Added
-
-- Reload-ready cue: a one-shot bright-green ` READY! ` flash appears when a reload finishes (the gun is hot again), at the reload-reminder row for 0.30s. Stamped in `tick-world` on the `:reload-cooldown` `>0 -> <=0` edge, painted as a pure overlay (`paint-reload-ready`) mirroring the SAVED/LOADED flash; suppressed on viewports under 9 rows.
-
 ## [0.14.0] - 2026-06-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 
 ## [Unreleased]
 
+### Added
+
+- Reload-ready cue: a one-shot bright-green ` READY! ` flash appears when a reload finishes (the gun is hot again), at the reload-reminder row for 0.30s. Stamped in `tick-world` on the `:reload-cooldown` `>0 -> <=0` edge, painted as a pure overlay (`paint-reload-ready`) mirroring the SAVED/LOADED flash; suppressed on viewports under 9 rows.
+
 ## [0.14.0] - 2026-06-14
 
 ### Added

--- a/docs/combat.md
+++ b/docs/combat.md
@@ -35,6 +35,8 @@ Empty trigger pulls → `empty-trigger-pull`: arm `:empty-click-secs` (0.8s), pl
 
 The periodic `press R to RELOAD` nag is gated by the pure `reload-reminder-visible?` (`io/render.phel`). It arms on the remaining-mag **fraction** (`<= reload-reminder-frac`, 0.3) rather than an absolute count, so a 10-round pistol and a 4-round shotgun both nag at "nearly empty". Single-round mags (BFG, chainsaw: `mag-size <= 1`) reload every shot by design, so the nag is suppressed entirely. It is also suppressed while reloading, when the reserve is dry, during the dry-fire CLICK, and on viewports under 9 rows.
 
+When the reload finishes (the `:reload-cooldown` `>0 -> <=0` edge, detected in `tick-world` since `damage-step`'s `decay-timers` is the sole site that ticks it), a one-shot bright-green ` READY! ` cue flashes at the same row for `reload-ready-flash-seconds` (0.30s) so the gun-hot-again moment reads. Pure overlay (`paint-reload-ready`), driven by the `:reload-ready-secs` timer, suppressed on viewports under 9 rows.
+
 Fresh run starts with 30 reserve (3 mags); cap 50. Pickups refill (see [`level-system.md`](level-system.md)).
 
 ## Kill loot

--- a/src/commands/play.phel
+++ b/src/commands/play.phel
@@ -514,6 +514,11 @@
          :door 1.0)
         world))))
 
+(def reload-ready-flash-seconds
+  "How long the ' READY! ' HUD cue holds after a reload cooldown
+   finishes (the gun goes hot again)."
+  0.30)
+
 (defn tick-world
   "Pure one-frame state transition. `keys` is the drained input string,
    `dt` is seconds since the previous tick, `edges` is the rising-edge
@@ -604,7 +609,15 @@
             w5c  (tick-armory w5b)
             w6   (tick-shooting w5c (:fire edges) (:fire-held edges))
             w7   (damage-step   w6 dt)
-            w8   (tick-heartbeat w7 dt)
+            ;; READY flash: damage-step's decay-timers is the sole site
+            ;; that ticks :reload-cooldown. If it crossed from >0 to <=0
+            ;; this frame the reload just finished and the gun is hot
+            ;; again, so stamp the one-shot ' READY! ' HUD cue.
+            w7b  (if (and (php/> (or (:reload-cooldown w6) 0.0) 0.0)
+                          (php/<= (or (:reload-cooldown w7) 0.0) 0.0))
+                   (assoc w7 :reload-ready-secs reload-ready-flash-seconds)
+                   w7)
+            w8   (tick-heartbeat w7b dt)
             w9   (tick-flicker  w8 dt)
             w10  (tick-scare    w9 dt)
             w11  (tick-blood-drops w10 dt)
@@ -613,8 +626,10 @@
             ;; Decay the F5/F9 save/load HUD cue (set in game-loop after
             ;; the tick).
             w13b (update w13 :save-flash-secs
+                         (fn [s] (php/max 0.0 (php/- (or s 0.0) dt))))
+            w13c (update w13b :reload-ready-secs
                          (fn [s] (php/max 0.0 (php/- (or s 0.0) dt))))]
-        (advance-game-time w13b dt)))))
+        (advance-game-time w13c dt)))))
 
 ;; =====================================================================
 ;; § Per-frame IO + stats
@@ -710,6 +725,7 @@
    :enemy                (or (:enemy world) :imp)
    :save-flash-secs      (or (:save-flash-secs world) 0.0)
    :save-flash-msg       (:save-flash-msg world)
+   :reload-ready-secs    (or (:reload-ready-secs world) 0.0)
    ;; Settings page (issue #107): the pause overlay paints the box from
    ;; these. The page IS the pause screen, so the render layer keys off
    ;; :paused; the cursor + values ride along here.

--- a/src/io/render/main.phel
+++ b/src/io/render/main.phel
@@ -7,7 +7,7 @@
   (:require phel-doom.io.render.wall-texture-data :refer [wall-tex])
   (:require phel-doom.io.render.enemy-sprite :refer [sprite-for-type-lod sprite-fade sprite-fade-index sprite-col-x sprite-subcol-x enemy-sprite-cell enemy-sprite-quad])
   (:require phel-doom.io.render.hud :refer [minimap-door minimap-door-pulse minimap-rows minimap-frame hud-debug-line hud-line-str help-menu-string settings-menu-string])
-  (:require phel-doom.io.render.paint :refer [paint-face-overlay paint-crosshair paint-intro-splash paint-locked-bump paint-door-face paint-blood-drops paint-rear-warning paint-low-ammo paint-reload-reminder paint-save-flash paint-game-info paint-berserk-badge paint-invuln-badge paint-empty-click paint-flicker paint-heartbeat-vignette paint-hit-vignette paint-berserk-tint paint-heat-bar paint-kill-streak paint-compass paint-enemy-hp-flashes paint-hearts-hud paint-pistol-hud paint-weapon-hud paint-blood-fx-into paint-pickups-into paint-projectiles-into paint-tracers-into build-blood-cols])
+  (:require phel-doom.io.render.paint :refer [paint-face-overlay paint-crosshair paint-intro-splash paint-locked-bump paint-door-face paint-blood-drops paint-rear-warning paint-low-ammo paint-reload-reminder paint-save-flash paint-reload-ready paint-game-info paint-berserk-badge paint-invuln-badge paint-empty-click paint-flicker paint-heartbeat-vignette paint-hit-vignette paint-berserk-tint paint-heat-bar paint-kill-streak paint-compass paint-enemy-hp-flashes paint-hearts-hud paint-pistol-hud paint-weapon-hud paint-blood-fx-into paint-pickups-into paint-projectiles-into paint-tracers-into build-blood-cols])
   (:require phel-doom.core.engine :refer [cast-frame max-depth proj-dist])
   (:require phel-doom.core.perf :refer [render-scale])
   (:require phel-doom.core.format :refer [format-duration])
@@ -1936,19 +1936,20 @@
             p19         (paint-reload-reminder    p18 stats vw vh)
             p19b        (paint-locked-bump        p19 stats vw vh)
             p19c        (paint-enemy-hp-flashes   p19b world vw vh)
-            p20         (paint-save-flash         p19c stats vw vh)]
+            p20         (paint-save-flash         p19c stats vw vh)
+            p20b        (paint-reload-ready       p20 stats vw vh)]
         ;; Pause (P) IS the settings page: freezing the game and the
         ;; options live in one overlay so there's only one layer to
         ;; learn. The H info panel can still sit on top of it (player
         ;; paused, then pressed H); it paints last so it wins.
         (when (and (get stats :paused) (not (get stats :help?)))
-          (buf-push p20 (settings-menu-string vw vh
-                                              (get stats :settings)
-                                              (get stats :settings-cursor)
-                                              "↑↓ws move  ←→ad change  p resume")))
+          (buf-push p20b (settings-menu-string vw vh
+                                               (get stats :settings)
+                                               (get stats :settings-cursor)
+                                               "↑↓ws move  ←→ad change  p resume")))
         (when (get stats :help?)
-          (buf-push p20 (help-menu-string vw vh stats)))
-        (php/implode "" p20)))))
+          (buf-push p20b (help-menu-string vw vh stats)))
+        (php/implode "" p20b)))))
 ;; =====================================================================
 ;; § IO entry points
 ;; =====================================================================

--- a/src/io/render/paint.phel
+++ b/src/io/render/paint.phel
@@ -384,6 +384,22 @@
         (buf-push parts (str "\e[3;" col "H" label)))))
   parts)
 
+(defn paint-reload-ready
+  "Brief centred ' READY! ' cue when the reload cooldown finishes and the
+   gun is hot again - bright green, at the reload-reminder row so it reads
+   as that nag's resolution. Drives off the one-shot `:reload-ready-secs`
+   timer (stamped in tick-world on the reload-cooldown >0 -> <=0 edge)."
+  [parts stats vw vh]
+  (let [secs (or (get stats :reload-ready-secs) 0.0)]
+    (when (and (php/> secs 0.0) (php/>= vh 9))
+      (let [text  " READY! "
+            label (str "\e[40;92;1m" text "\e[0m")
+            col   (php/max 1 (php/- (php/intdiv vw 2)
+                                    (php/intdiv (php/strlen text) 2)))
+            row   (php/max 3 (php/- vh 8))]
+        (buf-push parts (str "\e[" row ";" col "H" label)))))
+  parts)
+
 (def stamina-bar-cells
   "Width of the STA bar in cells. 10 is wide enough to read the pool
    level at a glance without crowding the HUD strip on narrow

--- a/tests/commands/play-test.phel
+++ b/tests/commands/play-test.phel
@@ -241,3 +241,21 @@
   (is (= false (resumed-pause? {:paused false} {:paused true}))  "opening is not a resume")
   (is (= false (resumed-pause? {:paused true}  {:paused true}))  "still paused")
   (is (= false (resumed-pause? {:paused false} {:paused false})) "never paused"))
+
+;; READY flash (reload-ready-secs): tick-world stamps the one-shot cue on
+;; the frame the reload cooldown crosses from >0 to <=0. damage-step's
+;; decay-timers is the sole site that ticks :reload-cooldown.
+
+(deftest test-tick-world-reload-completion-arms-ready-flash
+  (let [w' (tick-world (assoc (new-world open-grid (new-player 5.0 5.0 0.0))
+                              :reload-cooldown 0.01)
+                       "" 0.05 no-edges)]
+    (is (php/> (or (:reload-ready-secs w') 0.0) 0.0)
+        "reload finishing this frame arms the READY flash")))
+
+(deftest test-tick-world-reload-in-progress-does-not-arm-ready-flash
+  (let [w' (tick-world (assoc (new-world open-grid (new-player 5.0 5.0 0.0))
+                              :reload-cooldown 1.0)
+                       "" 0.016 no-edges)]
+    (is (= 0.0 (or (:reload-ready-secs w') 0.0))
+        "a mid-reload frame does not arm the flash")))

--- a/tests/io/paint-test.phel
+++ b/tests/io/paint-test.phel
@@ -1,7 +1,7 @@
 (ns phel-doom-tests.io.paint-test
   (:require phel.test :refer [deftest is])
   (:require phel-doom.io.render.buffer :refer [buf-mk])
-  (:require phel-doom.io.render.paint :refer [paint-crosshair paint-door-face paint-game-info paint-compass paint-hearts-hud paint-hit-vignette paint-intro-splash]))
+  (:require phel-doom.io.render.paint :refer [paint-crosshair paint-door-face paint-game-info paint-compass paint-hearts-hud paint-hit-vignette paint-intro-splash paint-reload-ready]))
 
 ;; ---------------------------------------------------------------------
 ;; Crosshair legibility. The reticle must be a SOLID glyph, never the old
@@ -185,3 +185,23 @@
 (deftest test-door-face-pixel-doubled-coords
   ;; Same scene cell, terminal coords doubled: row 8, col 2*3+1 = 7.
   (is (php/str_contains (door-face-str 2) "\e[8;7H")))
+
+;; Reload-ready READY flash: a one-shot bright-green cue when the reload
+;; cooldown finishes (gun hot again). Drives off :reload-ready-secs,
+;; stamped in tick-world on the reload-cooldown >0 -> <=0 edge.
+
+(defn- reload-ready-str [stats vh]
+  (php/implode "" (paint-reload-ready (buf-mk) stats 80 vh)))
+
+(deftest test-reload-ready-flash-shows-when-armed
+  (let [s (reload-ready-str {:reload-ready-secs 0.30} 24)]
+    (is (php/str_contains s "READY!")      "active timer paints the READY cue")
+    (is (php/str_contains s "\e[40;92;1m") "bright-green chip")))
+
+(deftest test-reload-ready-flash-hidden-when-zero
+  (is (= "" (reload-ready-str {:reload-ready-secs 0.0} 24))
+      "no cue once the timer has elapsed"))
+
+(deftest test-reload-ready-flash-hidden-on-tiny-viewport
+  (is (= "" (reload-ready-str {:reload-ready-secs 0.30} 8))
+      "suppressed under 9 rows"))


### PR DESCRIPTION
## 📚 Description

The reload cooldown finishing (gun hot again) had no feedback. Add a one-shot bright-green ` READY! ` flash, mirroring the existing SAVED/LOADED save-flash pattern. Suite green at 2218 (+6 assertions). Part of the ongoing optimization loop (round-2 verified item).

## 🔖 Changes

- `tick-world` (play.phel): detect the `:reload-cooldown` `>0 -> <=0` edge across `damage-step` (its `decay-timers` is the sole site that ticks the timer) and stamp `:reload-ready-secs` (0.30s); decay it each frame beside `:save-flash-secs`; expose it in `frame-stats`.
- `paint-reload-ready` (paint.phel): pure overlay, bright-green chip at the reload-reminder row, guarded to viewports >= 9 rows; threaded into the render pipeline after `paint-save-flash`.
- Tests: tick-world transition arms / steady-state does not; paint emits on armed, nothing on zero / tiny viewport. Docs: combat.md + CHANGELOG.