### PR TITLE
fix(settings): persist all 9 settings fields across launches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,15 +11,19 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 
 ### Added
 
-- Navigable pause menu (issue #203): `p` opens a Resume / Settings / Restart / Quit menu (up/down move, enter or space selects). Settings opens the options sub-page (enter/space/`p` back); Restart restarts the run from level 1 with a fresh seed; Quit exits. Paints only when paused, so the 3D loop is untouched.
-- Colorblind-safe minimap palette (issue #200): a `Colorblind` setting (`none` / `deuteran` / `protan` / `tritan`) remaps the keycard and door markers - the only minimap glyphs told apart by colour alone - to a brightness-plus-hue CVD-safe triad (red-green: sky-blue/orange/white; blue-yellow: blue/red/white), a key and its door sharing one code. Persisted; overlay-only, no hot-path cost.
+- Navigable pause menu (issue #203): `p` opens a Resume / Settings / Restart / Quit menu (up/down move, enter or space selects). Settings opens the options sub-page (enter/space/`p` back); Restart restarts from level 1 with a fresh seed; Quit exits. Paints only when paused, so the 3D loop is untouched.
+- Colorblind-safe minimap palette (issue #200): a `Colorblind` setting (`none` / `deuteran` / `protan` / `tritan`) remaps keycard and door markers - the only minimap glyphs told apart by colour alone - to a brightness-plus-hue CVD-safe triad (red-green: sky-blue/orange/white; blue-yellow: blue/red/white), a key and its door sharing one code. Overlay-only, no hot-path cost.
 - Reload-ready cue: a one-shot bright-green ` READY! ` flash at the reload-reminder row when a reload finishes.
-- Locked-door deny click: bumping a locked door without its key plays a muted click (rising-edge, at the ~1.5s `NEED <COLOUR> KEY` hint cadence) so a blocked door reads by ear.
+- Locked-door deny click: bumping a locked door without its key plays a muted click (at the ~1.5s `NEED <COLOUR> KEY` hint cadence) so a blocked door reads by ear.
 
 ### Changed
 
-- Berserk window trimmed from 20s to 18s: enough to chain two or three room clears, but the rage now ends with use-it-or-lose-it pressure.
-- Critical-HP heartbeat eased from 0.85s to 0.90s in the 3-4 heart tier for a clearer first thump; the last-heart 0.55s panic tier is unchanged.
+- Berserk window trimmed 20s to 18s: still chains two or three room clears, but ends with use-it-or-lose-it pressure.
+- Critical-HP heartbeat eased 0.85s to 0.90s in the 3-4 heart tier for a clearer first thump; the last-heart 0.55s panic tier is unchanged.
+
+### Fixed
+
+- Settings persistence dropped 5 of 9 fields: crosshair, run timer, reduced motion, high contrast and colorblind were never written to the settings JSON and reset to defaults on every launch (only music, SFX, minimap and difficulty survived). All nine now round-trip; enum fields save as their bare keyword name and a malformed value heals to its default on load.
 
 ## [0.14.0] - 2026-06-14
 

--- a/src/io/settings.phel
+++ b/src/io/settings.phel
@@ -9,8 +9,8 @@
 ;; the game from starting — it just falls back to defaults).
 ;;
 ;; The pure shape + validation lives in core/settings (coerce-settings);
-;; this layer only reads / writes the file and converts the difficulty
-;; keyword to / from its JSON string form.
+;; this layer only reads / writes the file and converts the enum fields
+;; (difficulty / crosshair / colorblind) to / from their JSON string form.
 ;; ---------------------------------------------------------------------
 
 (defn- settings-path []
@@ -22,9 +22,10 @@
 
 (defn load-settings
   "Read the persisted settings file, returning the coerced defaults
-   when it's missing or malformed. Difficulty is stored as a string and
-   keyword-ised on the way in; coerce-settings clamps + validates the
-   whole map so the result is always complete and safe to apply."
+   when it's missing or malformed. Enum fields (difficulty / crosshair /
+   colorblind) are stored as strings and keyword-ised on the way in;
+   coerce-settings clamps + validates the whole map so the result is
+   always complete and safe to apply."
   []
   (let [path (settings-path)]
     (if (php/file_exists path)
@@ -34,26 +35,36 @@
           (let [data (php/json_decode content true)]
             (if (php/is_array data)
               (coerce-settings
-               {:music      (read-from data "music"   (:music default-settings))
-                :sfx        (read-from data "sfx"      (:sfx default-settings))
-                :minimap    (read-from data "minimap"  (:minimap default-settings))
-                :difficulty (keyword (read-from data "difficulty" "normal"))})
+               {:music          (read-from data "music"   (:music default-settings))
+                :sfx            (read-from data "sfx"      (:sfx default-settings))
+                :minimap        (read-from data "minimap"  (:minimap default-settings))
+                :difficulty     (keyword (read-from data "difficulty"     "normal"))
+                :crosshair      (keyword (read-from data "crosshair"      "cross"))
+                :timer          (read-from data "timer"          (:timer default-settings))
+                :reduced-motion (read-from data "reduced-motion" (:reduced-motion default-settings))
+                :high-contrast  (read-from data "high-contrast"  (:high-contrast default-settings))
+                :colorblind     (keyword (read-from data "colorblind"     "none"))})
               (coerce-settings default-settings)))))
       (coerce-settings default-settings))))
 
 (defn save-settings!
-  "Write `settings` back to the JSON file. Difficulty is stored as its
-   bare keyword name (\"normal\", not \":normal\"). Returns the settings
-   so callers can thread it. Swallows write failures."
+  "Write `settings` back to the JSON file. Enum fields are stored as
+   their bare keyword name (\"normal\", not \":normal\"). Returns the
+   settings so callers can thread it. Swallows write failures."
   [settings]
   ;; Re-coerce defensively: save-settings! is public, so a caller could
   ;; hand it a partial / out-of-range map. Clamping here keeps the file
   ;; on disk always valid, matching what load-settings will accept back.
   (let [s   (coerce-settings settings)
         arr (php/array)]
-    (php/aset arr "music"      (:music s))
-    (php/aset arr "sfx"        (:sfx s))
-    (php/aset arr "minimap"    (:minimap s))
-    (php/aset arr "difficulty" (name (:difficulty s)))
+    (php/aset arr "music"          (:music s))
+    (php/aset arr "sfx"            (:sfx s))
+    (php/aset arr "minimap"        (:minimap s))
+    (php/aset arr "difficulty"     (name (:difficulty s)))
+    (php/aset arr "crosshair"      (name (:crosshair s)))
+    (php/aset arr "timer"          (:timer s))
+    (php/aset arr "reduced-motion" (:reduced-motion s))
+    (php/aset arr "high-contrast"  (:high-contrast s))
+    (php/aset arr "colorblind"     (name (:colorblind s)))
     (php/file_put_contents (settings-path) (php/json_encode arr))
     s))

--- a/tests/io/settings-test.phel
+++ b/tests/io/settings-test.phel
@@ -1,0 +1,83 @@
+(ns phel-doom-tests.io.settings-test
+  (:require phel.test :refer [deftest is])
+  (:require phel-doom.core.settings :as core)
+  (:require phel-doom.io.settings :refer [load-settings save-settings!]))
+
+;; Round-trip tests run against an isolated temp $HOME so they never
+;; touch the user's real ~/.phel-doom-settings.json. settings-path reads
+;; $HOME on every call, so swapping the env var redirects load + save.
+
+(defn- with-temp-home [f]
+  (let [prev (php/getenv "HOME")
+        tmp  (str (php/sys_get_temp_dir) "/" (php/uniqid "phel-doom-settings-test-"))
+        file (str tmp "/.phel-doom-settings.json")]
+    (php/mkdir tmp 0777 true)
+    (php/putenv (str "HOME=" tmp))
+    (try
+      (f)
+      (finally
+        (php/putenv (str "HOME=" prev))
+        (when (php/file_exists file) (php/unlink file))
+        (php/rmdir tmp)))))
+
+(deftest test-missing-file-returns-coerced-defaults
+  (with-temp-home
+   (fn []
+      ;; No file written yet -> defaults.
+     (let [loaded (load-settings)]
+       (is (= (core/coerce-settings core/default-settings) loaded))))))
+
+(deftest test-round-trips-all-nine-settings
+  (with-temp-home
+   (fn []
+      ;; A non-default value for every field, so a dropped key fails loud.
+     (let [custom (-> core/default-settings
+                      (core/adjust :music 2)          ; 60 -> 80
+                      (core/adjust :sfx -3)           ; 90 -> 60
+                      (core/adjust :minimap 1)        ; -> true
+                      (core/adjust :difficulty 2)     ; normal -> nightmare
+                      (core/adjust :crosshair 2)      ; cross -> open
+                      (core/adjust :timer 1)          ; -> true
+                      (core/adjust :reduced-motion 1) ; -> true
+                      (core/adjust :high-contrast 1)  ; -> true
+                      (core/adjust :colorblind 1))]   ; none -> deuteran
+       (save-settings! custom)
+       (let [loaded (load-settings)]
+         (is (= (:music custom)          (:music loaded))          "music")
+         (is (= (:sfx custom)            (:sfx loaded))            "sfx")
+         (is (= (:minimap custom)        (:minimap loaded))        "minimap")
+         (is (= (:difficulty custom)     (:difficulty loaded))     "difficulty")
+         (is (= (:crosshair custom)      (:crosshair loaded))      "crosshair")
+         (is (= (:timer custom)          (:timer loaded))          "timer")
+         (is (= (:reduced-motion custom) (:reduced-motion loaded)) "reduced-motion")
+         (is (= (:high-contrast custom)  (:high-contrast loaded))  "high-contrast")
+         (is (= (:colorblind custom)     (:colorblind loaded))     "colorblind"))))))
+
+(deftest test-enum-fields-stored-as-keywords-after-load
+  (with-temp-home
+   (fn []
+     (save-settings! (-> core/default-settings
+                         (core/adjust :crosshair 1)
+                         (core/adjust :colorblind 2)))
+     (let [loaded (load-settings)]
+        ;; Loaded enums must be keywords (not raw "dot"/"protan" strings).
+       (is (= :dot (:crosshair loaded)))
+       (is (= :protan (:colorblind loaded)))))))
+
+(deftest test-malformed-enum-on-disk-coerces-to-default
+  (with-temp-home
+   (fn []
+      ;; Hand-write a file with a bogus enum value; load must heal it.
+     (let [path (str (php/getenv "HOME") "/.phel-doom-settings.json")]
+       (php/file_put_contents
+        path
+        (php/json_encode
+         (let [a (php/array)]
+           (php/aset a "crosshair" "bogus")
+           (php/aset a "colorblind" "weird")
+           (php/aset a "difficulty" "impossible")
+           a))))
+     (let [loaded (load-settings)]
+       (is (= :cross  (:crosshair loaded)))
+       (is (= :none   (:colorblind loaded)))
+       (is (= :normal (:difficulty loaded)))))))


### PR DESCRIPTION
## What

Settings persistence only wrote **4 of 9** fields to `~/.phel-doom-settings.json` (`music`, `sfx`, `minimap`, `difficulty`). The other five - **crosshair**, **run timer**, **reduced motion**, **high contrast**, **colorblind** - were never persisted, so they silently reset to defaults on every launch.

They worked mid-session (consumed in the HUD/render path), but never survived a restart. No test covered the round-trip, so it slipped through.

The 0.14.0 changelog even claimed crosshair/run-timer "persist to the settings JSON" and colorblind was "Persisted" - this PR makes those claims true.

## How

- `save-settings!` writes all nine fields; enum fields (`difficulty` / `crosshair` / `colorblind`) stored as their bare keyword name.
- `load-settings` reads all nine; enums keyword-ised on the way in, malformed values heal to their default via `coerce-settings`.
- Stale docstrings updated.

## Tests

New `tests/io/settings-test.phel` (isolated temp `$HOME`, never touches the real file):
- round-trips all 9 fields
- enum fields load back as keywords, not raw strings
- malformed enum on disk coerces to default
- missing file returns coerced defaults

Full suite: 2291 pass, format clean.

Closes #N/A (discovered during a menu/settings verification pass).