### PR TITLE
chore(deps): track phel dev-main, migrate argv to *argv*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
   "prefer-stable": true,
   "require": {
     "php": ">=8.4",
-    "phel-lang/phel-lang": "^0.44",
+    "phel-lang/phel-lang": "dev-main",
     "symfony/console": "^7.4"
   },
   "require-dev": {

--- a/src/main.phel
+++ b/src/main.phel
@@ -12,4 +12,4 @@
     :commands [play-command demo-command]}))
 
 (when-not *build-mode*
-  (php/exit (cli/run app (cli/argv argv))))
+  (php/exit (cli/run app (cli/argv *argv*))))


### PR DESCRIPTION
## 📚 Description

Bump `phel-lang/phel-lang` to `dev-main` (`0e032f0`) to get the latest Phel features (native-int arithmetic fast path, ^:pure inlining, bug fixes). The bump carries one breaking change: Phel removed the bare `argv` CLI-args var in favor of the earmuffed `*argv*`, so `main.phel` is updated to keep the build resolving.

## 🔖 Changes

- `composer.json`: `phel-lang/phel-lang` `^0.44` → `dev-main`
- `main.phel`: `argv` → `*argv*` (#2494 breaking)
- Verified: format + lint + 2291 tests + build green; game renders + runs

## ⚡ Free speedup (no code change)

The new native-int fast path (#2458/#2459) covers `+ - * / < =` **and `quot/rem/mod`**; #2460 drops the per-op `apply` round-trip on arithmetic + `bit-*` (~1.8-8x / ~26%). This makes every **native** numeric helper in warm per-frame code faster automatically: `mod` in render fade/scanline, `pos?`/`zero?`/`max` in combat/enemy/AI, native `+` in physics step. Captured just by bumping the version - no rewrite.

## 🧪 Hot-loop note

The tightest 4800-cell DDA/paint loop already uses `php/` interop, untouched. Measured native Phel arithmetic vs interop on dev-main: 100x slower (33.4s vs 0.33s, 3M ops) - so the fast path does NOT change the deepest loop, and converting interop→native would regress. engine/render carry zero native arithmetic. Only actionable hot-loop edit left (per-row `(mod r 2)` → `(php/& r 1)`) is marginal + risks floor-vs-trunc semantics; skipped.