### PR TITLE
ref(render): extract project-height projection primitive

### DIFF
--- a/docs/raycaster.md
+++ b/docs/raycaster.md
@@ -75,6 +75,21 @@ FOV is clamped at `fov-max-deg` (100°, the widescreen sweet spot - roomy withou
 
 Edge rays travel further than central rays to reach the same wall plane. Multiply by `cos(offset)` to project onto the player's forward axis. One multiply per column; without it: barrel distortion.
 
+## Projection primitive
+
+`src/core/projection.phel` holds the pure vertical-projection kernel shared by the wall paths (and, ahead, variable floor/ceiling heights, pitch, eye-height):
+
+```phel
+(wall-px num dist)                 ; projected pixel height of a num-unit
+                                   ; surface at distance dist
+(project-height pd vh dist eye-z z); screen row (float) where world height
+                                   ; z lands
+```
+
+- `wall-px num dist` = `num / ((max 0.3 dist) * char-aspect)`. `num` is `proj-dist` for a one-unit wall, or `n * proj-dist` for an n-sub-row half-block slice. The 0.3 floor stops a surface in the player's own cell projecting to an infinite slice. Both the cell-resolution wall path (`compute-wall-shades`) and the half-block sub-pixel path (`build-wall-sub-bounds`) call it, so they agree to the last bit.
+- `project-height pd vh dist eye-z z` = `vh/2 - (z - eye-z) * (wall-px pd dist)`. The horizon (z = eye-z) sits at `vh/2`; points above the eye rise, below sink. Today's flat wall is the special case `eye-z = 0.5` with `z = 1` (top) and `z = 0` (bottom). Variable heights pass other `z`; look up/down and jump/crouch pass other `eye-z`.
+- `char-aspect` (2.0) lives here too, as the canonical projection constant alongside `proj-dist`, so the kernel stays pure `core/` with no `io/` dependency.
+
 ## Performance
 
 DDA averages ~5-8 cell crossings per ray instead of ~35 fixed steps. Hot loop uses direct PHP ops (`php/+`, `php/<`) and `:pgrid` (nested PHP array).

--- a/src/core/engine.phel
+++ b/src/core/engine.phel
@@ -22,7 +22,9 @@
 (def proj-dist
   "Horizontal projection distance in screen cells. Wall heights are
    `proj-dist / (dist * char-aspect)`, so this controls how big walls
-   look at a given world distance. The horizontal FOV emerges as
+   look at a given world distance. (`char-aspect` and the shared
+   `wall-px` / `project-height` kernel live in `core.projection`.) The
+   horizontal FOV emerges as
    `2 * atan(viewport-width / 2 / proj-dist)` — wider terminals show
    more of the world without changing wall scale."
   70.0)

--- a/src/core/projection.phel
+++ b/src/core/projection.phel
@@ -1,0 +1,49 @@
+(ns phel-doom.core.projection)
+
+;; ---------------------------------------------------------------------
+;; Pure vertical-projection kernel. Maps a world height + perpendicular
+;; distance to a screen row. Today's flat world only ever projects a
+;; one-unit wall (floor z=0, ceiling z=1) centred on the horizon, but the
+;; general form below is what variable floor / ceiling heights, pitch,
+;; and eye-height build on (see docs/raycaster.md).
+;;
+;; Lives in core/ (not io/render) so the math is pure + unit-testable and
+;; the renderer, sprite projection, and future height-aware casting all
+;; share ONE definition of "how tall does this look".
+;; ---------------------------------------------------------------------
+
+(def char-aspect
+  "Character cell aspect ratio: a terminal cell is ~twice as tall as it
+   is wide, so every vertical projection divides by this to stop walls /
+   sprites stretching. Canonical projection constant, sibling of
+   engine/proj-dist. (Relocated here from io/render/palette so the pure
+   primitives below need no io dependency.)"
+  2.0)
+
+(defn wall-px
+  "Projected pixel height of a `num`-unit-tall surface at perpendicular
+   distance `dist`. `num` is the height numerator: `proj-dist` for a
+   one-unit wall, or `n * proj-dist` for an n-sub-row slice. Distance is
+   floored at 0.3 so a surface in the player's own cell can't project to
+   infinity. This is the shared kernel behind the cell-resolution wall
+   path, the half-block sub-pixel path, and (later) variable-height
+   casting, so all three agree to the last bit."
+  [^float num ^float dist]
+  (php// num (php/* (php/max 0.3 dist) char-aspect)))
+
+(defn project-height
+  "Screen row (float, 0 = top of viewport) where world height `z`
+   projects, given the wall-height numerator `pd`, viewport height `vh`,
+   perpendicular distance `dist`, and camera eye height `eye-z`. The
+   horizon (z = eye-z) sits at vh/2; points above the eye rise toward row
+   0, points below sink, and apparent displacement falls off with
+   distance via `wall-px`.
+
+   Today's flat-world wall is the special case eye-z=0.5 with z=1 (top of
+   a one-unit wall) and z=0 (bottom):
+     (project-height pd vh dist 0.5 1.0) ; => wall top row
+     (project-height pd vh dist 0.5 0.0) ; => wall bottom row
+   Variable floor / ceiling heights and look up/down pass other z / eye-z."
+  [^float pd ^int vh ^float dist ^float eye-z ^float z]
+  (php/- (php// vh 2.0)
+         (php/* (php/- z eye-z) (wall-px pd dist))))

--- a/src/io/render/frame_math.phel
+++ b/src/io/render/frame_math.phel
@@ -2,9 +2,10 @@
 ;; enemy projection, visibility tests. Pure helpers.
 (ns phel-doom.io.render.frame-math
   (:require phel-doom.io.render.buffer :refer [buf-mk buf-set buf-get])
-  (:require phel-doom.io.render.palette :refer [char-aspect base-hud-rows code-r code-g code-b nearest-256])
+  (:require phel-doom.io.render.palette :refer [base-hud-rows code-r code-g code-b nearest-256])
   (:require phel-doom.core.enemies :refer [enemy-types])
-  (:require phel-doom.core.engine :refer [proj-dist]))
+  (:require phel-doom.core.engine :refer [proj-dist])
+  (:require phel-doom.core.projection :refer [char-aspect]))
 
 (defn- hud-rows-for
   "Number of HUD rows to reserve at the bottom of the viewport. The

--- a/src/io/render/main.phel
+++ b/src/io/render/main.phel
@@ -2,13 +2,14 @@
 ;; perf snapshot, and the end / menu screens.
 (ns phel-doom.io.render.main
   (:require phel-doom.io.render.buffer :refer [buf-mk buf-set buf-get buf-push])
-  (:require phel-doom.io.render.palette :refer [sky floor enemy-head enemy-body door-shade boss-door-shade sky-code floor-code door-code boss-door-code sprite-shadow heart-shade heart-shade-bright heart-glyph heart-glyph-bright armor-shade armor-shade-bright armor-glyph armor-glyph-bright armor-shard-shade armor-shard-shade-bright armor-shard-glyph armor-shard-glyph-bright ammo-shade ammo-shade-bright ammo-glyph ammo-glyph-bright berserk-shade berserk-shade-bright berserk-glyph berserk-glyph-bright invuln-shade invuln-shade-bright invuln-glyph invuln-glyph-bright soulsphere-shade soulsphere-shade-bright soulsphere-glyph soulsphere-glyph-bright backpack-shade backpack-shade-bright backpack-glyph backpack-glyph-bright shotgun-pickup-shade shotgun-pickup-bright shotgun-pickup-glyph shotgun-pickup-glyph-bright chaingun-pickup-shade chaingun-pickup-bright chaingun-pickup-glyph chaingun-pickup-glyph-bright bfg-pickup-shade bfg-pickup-bright bfg-pickup-glyph bfg-pickup-glyph-bright incinerator-pickup-shade incinerator-pickup-bright incinerator-pickup-glyph incinerator-pickup-glyph-bright rocket-pickup-shade rocket-pickup-bright rocket-pickup-glyph rocket-pickup-glyph-bright keycard-blue-shade keycard-blue-bright keycard-blue-glyph keycard-blue-glyph-bright keycard-red-shade keycard-red-bright keycard-red-glyph keycard-red-glyph-bright keycard-yellow-shade keycard-yellow-bright keycard-yellow-glyph keycard-yellow-glyph-bright char-aspect shade-table shade-code-table shade-table-blood shade-code-table-blood])
+  (:require phel-doom.io.render.palette :refer [sky floor enemy-head enemy-body door-shade boss-door-shade sky-code floor-code door-code boss-door-code sprite-shadow heart-shade heart-shade-bright heart-glyph heart-glyph-bright armor-shade armor-shade-bright armor-glyph armor-glyph-bright armor-shard-shade armor-shard-shade-bright armor-shard-glyph armor-shard-glyph-bright ammo-shade ammo-shade-bright ammo-glyph ammo-glyph-bright berserk-shade berserk-shade-bright berserk-glyph berserk-glyph-bright invuln-shade invuln-shade-bright invuln-glyph invuln-glyph-bright soulsphere-shade soulsphere-shade-bright soulsphere-glyph soulsphere-glyph-bright backpack-shade backpack-shade-bright backpack-glyph backpack-glyph-bright shotgun-pickup-shade shotgun-pickup-bright shotgun-pickup-glyph shotgun-pickup-glyph-bright chaingun-pickup-shade chaingun-pickup-bright chaingun-pickup-glyph chaingun-pickup-glyph-bright bfg-pickup-shade bfg-pickup-bright bfg-pickup-glyph bfg-pickup-glyph-bright incinerator-pickup-shade incinerator-pickup-bright incinerator-pickup-glyph incinerator-pickup-glyph-bright rocket-pickup-shade rocket-pickup-bright rocket-pickup-glyph rocket-pickup-glyph-bright keycard-blue-shade keycard-blue-bright keycard-blue-glyph keycard-blue-glyph-bright keycard-red-shade keycard-red-bright keycard-red-glyph keycard-red-glyph-bright keycard-yellow-shade keycard-yellow-bright keycard-yellow-glyph keycard-yellow-glyph-bright shade-table shade-code-table shade-table-blood shade-code-table-blood])
   (:require phel-doom.io.render.frame-math :refer [enemy-shade-string enemy-textured-shade-string boss-col-paint aggro-distance enemy-aggro-head-string build-horizon-gradient build-themed-gradient build-horizon-gradient-codes build-themed-gradient-codes tex-fade-table bg-cell-cache halfblock build-sky-halfblock build-sky-codes-sub seam-darken-16 seam-darken-8 seam-darken-5 collect-enemy-projs layout pulse visuals-for-type enemy-front-visible-at?])
   (:require phel-doom.io.render.wall-texture-data :refer [wall-tex])
   (:require phel-doom.io.render.enemy-sprite :refer [sprite-for-type-lod sprite-fade sprite-fade-index sprite-col-x sprite-subcol-x enemy-sprite-cell enemy-sprite-quad])
   (:require phel-doom.io.render.hud :refer [minimap-door minimap-door-pulse minimap-rows minimap-frame hud-debug-line hud-line-str help-menu-string settings-menu-string pause-menu-string])
   (:require phel-doom.io.render.paint :refer [paint-face-overlay paint-crosshair paint-intro-splash paint-locked-bump paint-door-face paint-blood-drops paint-rear-warning paint-low-ammo paint-reload-reminder paint-save-flash paint-reload-ready paint-game-info paint-berserk-badge paint-invuln-badge paint-empty-click paint-flicker paint-heartbeat-vignette paint-hit-vignette paint-berserk-tint paint-heat-bar paint-kill-streak paint-compass paint-enemy-hp-flashes paint-hearts-hud paint-pistol-hud paint-weapon-hud paint-blood-fx-into paint-pickups-into paint-projectiles-into paint-tracers-into build-blood-cols])
   (:require phel-doom.core.engine :refer [cast-frame max-depth proj-dist])
+  (:require phel-doom.core.projection :refer [char-aspect wall-px])
   (:require phel-doom.core.perf :refer [render-scale])
   (:require phel-doom.core.format :refer [format-duration])
   (:require phel-doom.core.version :refer [version]))
@@ -319,8 +320,7 @@
     (loop [col 0]
       (when (php/< col vw)
         (let [dist         (buf-get dists col)
-              wall-h       (php/min vh (php/intval
-                                        (php// pd (php/* (php/max 0.3 dist) char-aspect))))
+              wall-h       (php/min vh (php/intval (wall-px pd dist)))
               top          (php/intdiv (php/- vh wall-h) 2)
               blood?       (php/> (buf-get blood-cols col) 0.4)
               stbl-l       (if blood? shade-table-blood stbl)
@@ -490,9 +490,7 @@
     (loop [c 0]
       (when (php/< c svw)
         (let [dist (buf-get dists c)
-              whs  (php/min cap
-                            (php/intval (php// (php/* nf pd)
-                                               (php/* (php/max 0.3 dist) char-aspect))))
+              whs  (php/min cap (php/intval (wall-px (php/* nf pd) dist)))
               t    (php/intdiv (php/- cap whs) 2)
               b    (php/+ t whs)
               mix? (and tex-on?

--- a/src/io/render/palette.phel
+++ b/src/io/render/palette.phel
@@ -334,7 +334,6 @@
 (def keycard-yellow-glyph-bright
   "Pulse frame: yellow keycard ⚿ in dark (16) FG on the bright yellow BG."
   "\e[48;5;184;38;5;16;1m⚿")
-(def char-aspect 2.0)
 (def base-hud-rows 1)
 
 (def shade-table

--- a/tests/core/projection-test.phel
+++ b/tests/core/projection-test.phel
@@ -1,0 +1,63 @@
+(ns phel-doom-tests.core.projection-test
+  (:require phel.test :refer [deftest is])
+  (:require phel-doom.core.projection :refer [wall-px project-height]))
+
+;; ---------------------------------------------------------------------
+;; wall-px: the shared projection kernel. num / ((max 0.3 dist) * 2.0).
+;; ---------------------------------------------------------------------
+
+(deftest wall-px-unit-distance
+  ;; 70 / (1.0 * 2.0) = 35
+  (is (= 35.0 (wall-px 70.0 1.0))))
+
+(deftest wall-px-distance-floor
+  ;; dist below 0.3 clamps to 0.3, so a surface in the player's own cell
+  ;; can't blow up to an infinite slice.
+  (is (= (wall-px 70.0 0.3) (wall-px 70.0 0.05)))
+  (is (= (wall-px 70.0 0.3) (wall-px 70.0 0.0))))
+
+(deftest wall-px-monotonic-in-distance
+  ;; Farther away looks shorter.
+  (is (php/> (wall-px 70.0 1.0) (wall-px 70.0 2.0)))
+  (is (php/> (wall-px 70.0 2.0) (wall-px 70.0 4.0))))
+
+;; ---------------------------------------------------------------------
+;; project-height: world height -> screen row.
+;; ---------------------------------------------------------------------
+
+(deftest project-height-horizon-at-eye
+  ;; z == eye-z lands exactly on the horizon (vh/2) at any distance.
+  (is (= 15.0 (project-height 70.0 30 1.0 0.5 0.5)))
+  (is (= 15.0 (project-height 70.0 30 9.9 0.5 0.5))))
+
+(deftest project-height-wall-centred-on-horizon
+  ;; A one-unit wall (z=1 top, z=0 bottom) straddles the horizon
+  ;; symmetrically: midpoint is exactly vh/2.
+  (let [top (project-height 70.0 30 2.0 0.5 1.0)
+        bot (project-height 70.0 30 2.0 0.5 0.0)]
+    (is (= 15.0 (php// (php/+ top bot) 2.0)) "midpoint on horizon")
+    (is (php/< top 15.0) "top above horizon")
+    (is (php/> bot 15.0) "bottom below horizon")))
+
+(deftest project-height-nearer-is-taller
+  ;; Closer wall top projects higher up the screen (smaller row).
+  (is (php/< (project-height 70.0 30 1.0 0.5 1.0)
+             (project-height 70.0 30 4.0 0.5 1.0))))
+
+(deftest project-height-raising-eye-sinks-world-point
+  ;; Looking from a higher eye pushes a fixed world height DOWN the
+  ;; screen (larger row) - the basis for stepping onto a platform.
+  (is (php/> (project-height 70.0 30 2.0 0.8 1.0)
+             (project-height 70.0 30 2.0 0.3 1.0))))
+
+(deftest project-height-reconciles-with-wall-pipeline
+  ;; Contract: project-height at z=1 / z=0 (eye 0.5) agrees with the
+  ;; integer top/bot the renderer derives from wall-px, on an even-gap
+  ;; case (dist 2.5 -> wall-h 14, gap 16). Confirms both the cell-res
+  ;; wall path and the general primitive share one kernel.
+  (let [pd     70.0 vh     30 dist   2.5
+        wall-h (php/min vh (php/intval (wall-px pd dist)))
+        top    (php/intdiv (php/- vh wall-h) 2)
+        bot    (php/+ top wall-h)]
+    (is (= top (php/intval (php/round (project-height pd vh dist 0.5 1.0)))))
+    (is (= bot (php/intval (php/round (project-height pd vh dist 0.5 0.0)))))))

--- a/tests/io/render-cache-test.phel
+++ b/tests/io/render-cache-test.phel
@@ -42,6 +42,17 @@
   (is (not= (frame->string world stats 80 24)
             (frame->string world stats 160 44))))
 
+(deftest test-frame-bytes-pinned
+  ;; Golden hash: the exact rendered bytes for a fixed world + stats at
+  ;; several viewports (full detail + pixel-doubled). Any unintended
+  ;; pixel change - e.g. a regression in the vertical-projection kernel -
+  ;; flips a hash and fails loudly. Update the constants DELIBERATELY when
+  ;; output is meant to change.
+  (is (= "a68ddd13b2b7506dfd866e82008144b0" (php/md5 (frame->string world stats 120 30))))
+  (is (= "03abeff32bc5cc3df68f46ce1efcd0db" (php/md5 (frame->string world stats 80 24))))
+  (is (= "a8e3e4211a844d3f7b2e473a4d6b4f0f" (php/md5 (frame->string world stats 160 44))))
+  (is (= "959148793da9868ff84b9fb4158db77a" (php/md5 (frame->string world (assoc stats :px2? true) 120 30)))))
+
 ;; ---------------------------------------------------------------------
 ;; Half-block sub-pixel cell cache (halfblock). Two distinct codes pack
 ;; into a ▀ with top fg / bottom bg; equal codes collapse to a single-


### PR DESCRIPTION
## 📚 Description

Linchpin refactor for the vertical-levels epic (#229). Extracts the inline vertical wall-projection math into a pure `core/projection` module so variable floor/ceiling heights, pitch, and eye-height can build on one shared, tested definition of "how tall does this look". No behaviour change: render output is byte-identical, proven by a new frame md5 golden test.

## 🔖 Changes

- New pure `core/projection`: `wall-px` (shared `num/((max 0.3 dist)*char-aspect)` kernel) + `project-height` (general world-height -> screen-row).
- Relocate `char-aspect` from `io/render/palette` to `core/projection` (no io dependency in the kernel).
- `compute-wall-shades` + `build-wall-sub-bounds` now call `wall-px`.
- Tests: `projection-test` (8 cases) + pinned `test-frame-bytes-pinned` golden; all 2309 green.

Closes #230