### PR TITLE
feat(render): look up/down (camera pitch)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 
 ## [Unreleased]
 
+### Added
+
+- Look up/down camera pitch (issue #231): `t` tilts the view up, `g` tilts it down (hold to keep pitching, clamps at the extremes - no wrap). It is a pure vertical shear of the horizon (no extra rays): walls, the sky/floor split, floor-cast and enemy sprites all slide together by an integer row offset capped at +/-0.4 of the viewport height. `:pitch` is stored on the player as a fraction in [-1, 1]; a level gaze renders byte-for-byte identically to before.
+
 ## [0.15.0] - 2026-06-16
 
 ### Added

--- a/docs/input.md
+++ b/docs/input.md
@@ -28,9 +28,13 @@ Arrows arrive as 3-byte CSI: `\e[A` up, `\e[B` down, `\e[C` right, `\e[D` left. 
 
 ## Movement slots
 
-`key->slot` maps: `w`/`^` to `:fwd`, `s`/`_` to `:back`, `a` to `:strafe-left`, `d` to `:strafe-right`, arrows to turn, `x` to `:sprint`.
+`key->slot` maps: `w`/`^` to `:fwd`, `s`/`_` to `:back`, `a` to `:strafe-left`, `d` to `:strafe-right`, arrows to turn, `x` to `:sprint`, `t` to `:pitch-up`, `g` to `:pitch-down`.
 
 Each byte refreshes its slot's counter on `world[:moves]`. Physics only reads the counters. See [state.md](state.md).
+
+## Look up/down (pitch)
+
+Hold **`t`** to look up, **`g`** to look down. Picked off the WASD home cluster and otherwise unbound (no collision with move/turn/sprint, weapons 1-7, or the one-shot action keys). They refresh the `:pitch-up` / `:pitch-down` move slots; physics shears the player's `:pitch` fraction (clamped to [-1, 1], no wrap) via the same counter path as turning. `pitch-hold-frames` = 3 (~50ms), so the camera halts quickly on release like turning rather than gliding. Under kitty the keys arrive as codepoints 116 (`t`) / 103 (`g`) and work the same. The shear is a pure render offset (see [raycaster.md](raycaster.md)); a level gaze (`:pitch` 0) renders identically to no pitch at all.
 
 ## Sprint
 
@@ -49,6 +53,7 @@ Per byte, counter is set to its hold value; each frame physics decrements by 1. 
 
 - `move-hold-frames` = 18 (~300ms at 60 fps): bridges OS initial-key-repeat delay (250-500ms). Avoids stutter on press. Trade-off: ~300ms post-release glide on non-kitty terminals. Kitty release events (event type 3) override with instant clear.
 - `turn-hold-frames` = 3 (~50ms at 60 fps): quick halt for aiming.
+- `pitch-hold-frames` = 3 (~50ms at 60 fps): same quick halt for look up/down (`t`/`g`), so the camera stops on release instead of drifting.
 
 ## Kitty keyboard protocol
 

--- a/docs/raycaster.md
+++ b/docs/raycaster.md
@@ -84,11 +84,27 @@ Edge rays travel further than central rays to reach the same wall plane. Multipl
                                    ; surface at distance dist
 (project-height pd vh dist eye-z z); screen row (float) where world height
                                    ; z lands
+(pitch-rows pitch vh)              ; integer horizon shear (scene rows) for
+                                   ; a look up/down fraction
 ```
 
 - `wall-px num dist` = `num / ((max 0.3 dist) * char-aspect)`. `num` is `proj-dist` for a one-unit wall, or `n * proj-dist` for an n-sub-row half-block slice. The 0.3 floor stops a surface in the player's own cell projecting to an infinite slice. Both the cell-resolution wall path (`compute-wall-shades`) and the half-block sub-pixel path (`build-wall-sub-bounds`) call it, so they agree to the last bit.
-- `project-height pd vh dist eye-z z` = `vh/2 - (z - eye-z) * (wall-px pd dist)`. The horizon (z = eye-z) sits at `vh/2`; points above the eye rise, below sink. Today's flat wall is the special case `eye-z = 0.5` with `z = 1` (top) and `z = 0` (bottom). Variable heights pass other `z`; look up/down and jump/crouch pass other `eye-z`.
+- `project-height pd vh dist eye-z z` = `vh/2 - (z - eye-z) * (wall-px pd dist)`. The horizon (z = eye-z) sits at `vh/2`; points above the eye rise, below sink. Today's flat wall is the special case `eye-z = 0.5` with `z = 1` (top) and `z = 0` (bottom). Variable heights pass other `z`; jump/crouch pass other `eye-z`.
 - `char-aspect` (2.0) lives here too, as the canonical projection constant alongside `proj-dist`, so the kernel stays pure `core/` with no `io/` dependency.
+
+## Look up/down (pitch): horizon shear
+
+Looking up/down is a pure **vertical shear of the horizon**, not a re-projection: it costs no extra rays. The player carries `:pitch`, a fraction in `[-1, 1]` (1 = full up, -1 = full down, clamped by `state/clamp-pitch`, no wrap). `pitch-rows pitch vh` = `round(pitch * pitch-cap * vh)` turns it into an **integer scene-row offset** `pr`, where `pitch-cap` = 0.4, so the horizon travels at most +/-0.4 of the viewport height. Positive pitch (look up) yields positive `pr`, sliding the horizon DOWN the screen (more sky), negative slides it up.
+
+`frame->string` computes `pr` once and adds it to every site that centres on `vh/2`, so the whole scene shears as one rigid band:
+
+- wall tops in `compute-wall-shades` (`top = (vh - wall-h)/2 + pr`; `bot` derives from `top`)
+- the sub-row seam bounds in `build-wall-sub-bounds` (`+ pr*n`, n sub-rows per scene cell)
+- the floor-cast distance tables `build-floor-dperp` / `build-floor-dperp-sub` (horizon `vh/2 + pr`, sub-row `vh + 2*pr`)
+- the sky/floor gradients and their code twins in `frame-math` (each gradient builder takes an optional `horizon-offset`; the gradient cache keys on `(vh, pr)`)
+- enemy sprite anchors (the billboard top + the face / HP-flash overlays add the same `pr` so sprites stay pinned to their feet)
+
+The crosshair stays fixed (it is a weapon sight, not part of the world). Because every offset is **additive and 0 at `pitch = 0`**, a level gaze renders byte-for-byte identically to the no-pitch path (pinned by `render-cache-test/test-frame-bytes-pinned`).
 
 ## Performance
 

--- a/src/core/physics.phel
+++ b/src/core/physics.phel
@@ -1,6 +1,6 @@
 (ns phel-doom.core.physics
   (:require phel-doom.core.rng :as rng)
-  (:require phel-doom.core.state   :refer [max-stamina move-player turn-player])
+  (:require phel-doom.core.state   :refer [max-stamina move-player turn-player clamp-pitch])
   (:require phel-doom.core.map     :refer [missing-key-for passable? wall?])
   (:require phel-doom.core.weapons :refer [weapon-spec]))
 
@@ -31,6 +31,13 @@
 (def turn-speed
   "Radians per second of sustained rotation."
   2.0)
+
+(def pitch-speed
+  "Look up/down fraction per second of sustained pitch. `:pitch` lives
+   in [-1, 1] (clamp-pitch), so at 1.2/s a held look-up key travels from
+   level to full-up in just under a second - brisk enough to feel
+   responsive without overshooting the clamp on a single key blip."
+  1.2)
 
 (def sprint-multiplier
   "Speed multiplier applied to longitudinal + lateral motion while the
@@ -136,6 +143,12 @@
   (php/- (contribution moves :turn-right turn-speed dt)
          (contribution moves :turn-left  turn-speed dt)))
 
+(defn- pitch-delta [moves ^float dt]
+  ;; Look UP adds to `:pitch` (horizon shears down); look down subtracts.
+  ;; Same `contribution` helper the yaw path uses, just on the pitch slots.
+  (php/- (contribution moves :pitch-up   pitch-speed dt)
+         (contribution moves :pitch-down pitch-speed dt)))
+
 (defn- longitudinal-delta [world ^float dt]
   (let [moves (:moves world)
         sf    (sprint-factor world)
@@ -156,6 +169,12 @@
   (if (php/=== turn-by 0.0)
     world
     (turn-player world turn-by)))
+
+(defn- apply-pitch [world ^float pitch-by]
+  (if (php/=== pitch-by 0.0)
+    world
+    (update-in world [:player :pitch]
+               (fn [p] (clamp-pitch (php/+ (or p 0.0) pitch-by))))))
 
 (defn- apply-translation [world ^float long-d ^float lat-d]
   (if (and (php/=== long-d 0.0) (php/=== lat-d 0.0))
@@ -183,7 +202,9 @@
             :strafe-right (decay-counter (:strafe-right m))
             :turn-left    (decay-counter (:turn-left m))
             :turn-right   (decay-counter (:turn-right m))
-            :sprint       (decay-counter (or (:sprint m) 0))})))
+            :sprint       (decay-counter (or (:sprint m) 0))
+            :pitch-up     (decay-counter (or (:pitch-up m) 0))
+            :pitch-down   (decay-counter (or (:pitch-down m) 0))})))
 
 (defn- any-movement-on? [world]
   (let [m (:moves world)]
@@ -193,16 +214,19 @@
         (counter-on? m :strafe-right))))
 
 (defn apply-physics
-  "Per-frame: rotate, then translate using the new heading, then
-   decay every counter by one frame. Translation deltas read both
-   `:moves` AND the sprint state (via sprint-factor) so sprint
-   intent x stamina > 0 x not-blocked yields a 1.6x boost."
+  "Per-frame: rotate, shear the look up/down pitch, then translate using
+   the new heading, then decay every counter by one frame. Translation
+   deltas read both `:moves` AND the sprint state (via sprint-factor) so
+   sprint intent x stamina > 0 x not-blocked yields a 1.6x boost. Pitch
+   is a pure camera shear (no effect on translation), clamped by
+   `clamp-pitch`."
   [world ^float dt]
-  (let [moves  (:moves world)
-        turned (apply-rotation world (turn-delta moves dt))
-        walked (apply-translation turned
-                                  (longitudinal-delta turned dt)
-                                  (lateral-delta turned dt))]
+  (let [moves   (:moves world)
+        turned  (apply-rotation world (turn-delta moves dt))
+        pitched (apply-pitch turned (pitch-delta moves dt))
+        walked  (apply-translation pitched
+                                   (longitudinal-delta pitched dt)
+                                   (lateral-delta pitched dt))]
     (decay-move-counters walked)))
 
 (defn tick-stamina

--- a/src/core/projection.phel
+++ b/src/core/projection.phel
@@ -47,3 +47,29 @@
   [^float pd ^int vh ^float dist ^float eye-z ^float z]
   (php/- (php// vh 2.0)
          (php/* (php/- z eye-z) (wall-px pd dist))))
+
+(def pitch-cap
+  "Fraction of the viewport height the horizon may shear by at full
+   pitch. `pitch-rows` multiplies the normalised `:pitch` (in [-1, 1])
+   by this and `vh`, so the horizon can travel at most ±0.4·vh rows up
+   or down the screen. Kept below 0.5 so a full look-up still leaves the
+   wall band on screen rather than scrolling the scene entirely past the
+   viewport edge."
+  0.4)
+
+(defn pitch-rows
+  "Integer scene-row offset the horizon shears by for a normalised
+   camera `pitch` in [-1.0, 1.0] (1 = full up, -1 = full down) at
+   viewport height `vh`. `pitch = 0` returns 0 so the default view is
+   byte-identical to the no-pitch renderer; the magnitude is capped at
+   `±pitch-cap·vh` rows.
+
+   POSITIVE pitch (looking UP) shears the horizon DOWN the screen
+   (larger row numbers): walls + floor slide down and more sky shows.
+   This is the sign every horizon=vh/2 render site adds to its centre,
+   so wall tops/centres and the sky/floor split all move together.
+     (pitch-rows 0.0 30) ; => 0   (no shear, default view)
+     (pitch-rows 1.0 30) ; => 12  (full look-up, horizon down 12 rows)
+     (pitch-rows -1.0 30); => -12 (full look-down, horizon up 12 rows)"
+  [^float pitch ^int vh]
+  (php/intval (php/round (php/* pitch (php/* pitch-cap vh)))))

--- a/src/core/state.phel
+++ b/src/core/state.phel
@@ -2,9 +2,27 @@
   (:require phel-doom.core.weapons :refer [initial-weapon-state]))
 
 (defn new-player
-  "Create a player record with floating-point position and angle in radians."
+  "Create a player record with floating-point position and angle in
+   radians. `:pitch` is the look up/down shear as a normalised fraction
+   in [-1.0, 1.0] (0 = level, 1 = full up, -1 = full down); fresh
+   players spawn looking level so the default view is unchanged."
   [x y angle]
-  {:x x :y y :angle angle})
+  {:x x :y y :angle angle :pitch 0.0})
+
+(def max-pitch
+  "Hard cap on the absolute value of the player's `:pitch` look
+   up/down fraction. The view shears by at most `±projection/pitch-cap`
+   of the viewport height at the cap; physics clamps to this via
+   `clamp-pitch` so looking up/down saturates instead of wrapping."
+  1.0)
+
+(defn clamp-pitch
+  "Clamp a look up/down `:pitch` fraction into [-max-pitch, max-pitch]
+   so the camera saturates at the extremes (no wrap, no NaN)."
+  [p]
+  ;; Phel doesn't emit unary `php/-` as negation (see engine.phel), so
+  ;; the lower bound is built via 0 - max-pitch.
+  (php/max (php/- 0 max-pitch) (php/min max-pitch p)))
 
 (def max-lives
   "Hard cap on the player's HP pool, in half-heart units: 10 HP drawn as
@@ -200,7 +218,9 @@
                 :strafe-right 0
                 :turn-left    0
                 :turn-right   0
-                :sprint       0}})
+                :sprint       0
+                :pitch-up     0
+                :pitch-down   0}})
 
 (defn gain-life
   "Heal one full heart (2 HP), capped at max-lives. Heart pickups grant

--- a/src/glue/controls.phel
+++ b/src/glue/controls.phel
@@ -41,19 +41,29 @@
    release, which the HUD bar exposes as a phantom drain."
   3)
 
+(def pitch-hold-frames
+  "Frames a look up/down direction (T / G) stays active after each input
+   byte. Short, like turn-hold-frames, so the camera pitch halts within
+   ~50ms of releasing the key (no terminal key-release on the legacy
+   path) instead of drifting on for the full move-hold bridge."
+  3)
+
 (def key->slot
   "Map a single-byte input to the direction-counter slot it activates.
    Arrow-key escape sequences are normalised to ^ _ < > before lookup
    so they slot in alongside WASD. `x` arms the sprint slot — the
    legacy / non-kitty fallback for terminals that don't expose SHIFT
-   modifier bits via CSI-u."
+   modifier bits via CSI-u. `t` / `g` shear the camera look up / down
+   (pitch) — picked off the WASD home cluster and otherwise unbound."
   {"^" :fwd    "w" :fwd
    "_" :back   "s" :back
    "<" :turn-left
    ">" :turn-right
    "a" :strafe-left
    "d" :strafe-right
-   "x" :sprint})
+   "x" :sprint
+   "t" :pitch-up
+   "g" :pitch-down})
 
 (def shift-key->slot
   "Capital-letter equivalents of `key->slot` movement keys. In cooked
@@ -71,11 +81,17 @@
   "Slots that use turn-hold-frames instead of move-hold-frames."
   #{:turn-left :turn-right})
 
+(def pitch-slots
+  "Slots that use pitch-hold-frames (look up/down) instead of
+   move-hold-frames."
+  #{:pitch-up :pitch-down})
+
 (defn- hold-frames-for [slot]
   (cond
-    (turn-slots slot) turn-hold-frames
-    (= slot :sprint)  sprint-hold-frames
-    :else             move-hold-frames))
+    (turn-slots slot)  turn-hold-frames
+    (pitch-slots slot) pitch-hold-frames
+    (= slot :sprint)   sprint-hold-frames
+    :else              move-hold-frames))
 
 (defn refresh-move
   "If `byte` maps to a direction slot, refresh that slot's counter on
@@ -136,14 +152,16 @@
 
 (def ascii->slot
   "ASCII codepoint -> direction-counter slot. WASD movement, ←→ turn
-   (kitty reports left-arrow as 57351, right as 57349), and 'x' (120)
-   as the legacy sprint key — works under kitty too without needing
-   the SHIFT modifier bit."
+   (kitty reports left-arrow as 57351, right as 57349), 'x' (120) as the
+   legacy sprint key, and 't' (116) / 'g' (103) as look up / down (pitch)
+   — all work under kitty too without needing the SHIFT modifier bit."
   {119 :fwd
    115 :back
    97 :strafe-left
    100 :strafe-right
    120 :sprint
+   116 :pitch-up
+   103 :pitch-down
    57351 :turn-left
    57349 :turn-right})
 

--- a/src/io/render/frame_math.phel
+++ b/src/io/render/frame_math.phel
@@ -203,10 +203,16 @@
    pair is row-constant (gradient depends only on the row), so the inner
    loop still RLE-coalesces each sky row into a single run. `ctbl` is the
    shade-code-table (bare numeric code strings); the sub-row index runs
-   over 2·vh with the horizon at vh."
-  [^int vh ctbl]
-  (let [arr     (buf-mk)
-        horizon vh
+   over 2·vh with the horizon at vh. Optional `horizon-offset` (scene
+   rows, default 0) shears the horizon for look up/down: it shifts the
+   sub-row horizon by `2·offset` so the sky tracks the pitched wall band."
+  [^int vh ctbl & [horizon-offset]]
+  (let [pr      (or horizon-offset 0)
+        arr     (buf-mk)
+        ;; Sub-row horizon: vh at level pitch, sheared by pr*2 (two
+        ;; sub-rows per scene row) so the sky band tracks the same
+        ;; pitched horizon as the wall sub-bounds and floor-cast.
+        horizon (php/+ vh (php/* pr 2))
         max-d   (php/max 1 vh)
         code-at (fn [^int s]
                   (let [idx (php/max 0
@@ -228,10 +234,15 @@
    horizon at sub-row vh — the same curve `build-sky-halfblock` packs
    into ▀ cells, left unpacked so the pixel-doubled renderer can paint
    sub-row `2r` on the upper output row and `2r+1` on the lower as two
-   solid cells (full vertical sky smoothness at pixel scale 2)."
-  [^int vh ctbl]
-  (let [arr     (php/array)
-        horizon vh
+   solid cells (full vertical sky smoothness at pixel scale 2). Optional
+   `horizon-offset` (scene rows, default 0) shears the horizon by
+   `2·offset` sub-rows for look up/down."
+  [^int vh ctbl & [horizon-offset]]
+  (let [pr      (or horizon-offset 0)
+        arr     (php/array)
+        ;; Sub-row horizon at vh, sheared by pr*2 (two sub-rows per scene
+        ;; row) - same pitched horizon the half-block sky packs.
+        horizon (php/+ vh (php/* pr 2))
         max-d   (php/max 1 vh)
         sub     (php/* 2 vh)]
     (loop [s 0]
@@ -333,11 +344,18 @@
    height. Maps each row to a shade-table index based on distance
    from the horizon line (vh/2): closer to the horizon = darker
    (atmospheric haze). Used for both sky AND floor since after a
-   distance the eye stops distinguishing them anyway."
-  [^int vh tbl]
-  (let [arr     (buf-mk)
-        horizon (php/intdiv vh 2)
-        max-d   (php/max 1 horizon)]
+   distance the eye stops distinguishing them anyway. Optional
+   `horizon-offset` (scene rows, default 0) shears the horizon for look
+   up/down while keeping the gradient span fixed, so pr=0 is unchanged."
+  [^int vh tbl & [horizon-offset]]
+  (let [pr      (or horizon-offset 0)
+        arr     (buf-mk)
+        ;; Horizon line sheared by `pr` scene rows for look up/down; the
+        ;; normalisation span (max-d) keeps the unshifted half-height so
+        ;; the gradient just translates (pr=0 => identical bytes).
+        base    (php/intdiv vh 2)
+        horizon (php/+ base pr)
+        max-d   (php/max 1 base)]
     (loop [r 0]
       (when (php/< r vh)
         (let [idx (php/max 0
@@ -356,11 +374,15 @@
    toward black at the horizon via fade-256. When `stripe?` is true,
    every other row pulls one extra fade step so floors show subtle
    horizontal banding (tile lines). One pass over vh rows per frame;
-   vh is small (~30-40) so the cost is negligible."
-  [^int vh ^int base-code stripe?]
-  (let [arr     (buf-mk)
-        horizon (php/intdiv vh 2)
-        max-d   (php/max 1 horizon)]
+   vh is small (~30-40) so the cost is negligible. Optional
+   `horizon-offset` (scene rows, default 0) shears the horizon for look
+   up/down; pr=0 leaves output unchanged."
+  [^int vh ^int base-code stripe? & [horizon-offset]]
+  (let [pr      (or horizon-offset 0)
+        arr     (buf-mk)
+        base    (php/intdiv vh 2)
+        horizon (php/+ base pr)
+        max-d   (php/max 1 base)]
     (loop [r 0]
       (when (php/< r vh)
         (let [t     (php// (php/abs (php/- r horizon)) max-d)
@@ -378,11 +400,15 @@
    code strings (e.g. \"240\") instead of full SGR paint cells.
    Used to sample the sky gradient code at a specific row so the ▀
    half-block edge cell can blend the exact sky shade of that row
-   into the top-half FG, eliminating the flat-236 seam artifact."
-  [^int vh ctbl]
-  (let [arr     (buf-mk)
-        horizon (php/intdiv vh 2)
-        max-d   (php/max 1 horizon)]
+   into the top-half FG, eliminating the flat-236 seam artifact.
+   Optional `horizon-offset` (scene rows, default 0) shears the horizon
+   for look up/down; pr=0 leaves output unchanged."
+  [^int vh ctbl & [horizon-offset]]
+  (let [pr      (or horizon-offset 0)
+        arr     (buf-mk)
+        base    (php/intdiv vh 2)
+        horizon (php/+ base pr)
+        max-d   (php/max 1 base)]
     (loop [r 0]
       (when (php/< r vh)
         (let [idx (php/max 0
@@ -400,11 +426,15 @@
    code strings (e.g. \"237\") instead of full SGR paint cells.
    Used to sample the floor gradient code at a specific row so the ▀
    half-block edge cell can blend the exact floor shade of that row
-   into the bottom-half BG, eliminating the flat floor-code seam."
-  [^int vh ^int base-code stripe?]
-  (let [arr     (buf-mk)
-        horizon (php/intdiv vh 2)
-        max-d   (php/max 1 horizon)]
+   into the bottom-half BG, eliminating the flat floor-code seam.
+   Optional `horizon-offset` (scene rows, default 0) shears the horizon
+   for look up/down; pr=0 leaves output unchanged."
+  [^int vh ^int base-code stripe? & [horizon-offset]]
+  (let [pr      (or horizon-offset 0)
+        arr     (buf-mk)
+        base    (php/intdiv vh 2)
+        horizon (php/+ base pr)
+        max-d   (php/max 1 base)]
     (loop [r 0]
       (when (php/< r vh)
         (let [t     (php// (php/abs (php/- r horizon)) max-d)

--- a/src/io/render/main.phel
+++ b/src/io/render/main.phel
@@ -9,7 +9,7 @@
   (:require phel-doom.io.render.hud :refer [minimap-door minimap-door-pulse minimap-rows minimap-frame hud-debug-line hud-line-str help-menu-string settings-menu-string pause-menu-string])
   (:require phel-doom.io.render.paint :refer [paint-face-overlay paint-crosshair paint-intro-splash paint-locked-bump paint-door-face paint-blood-drops paint-rear-warning paint-low-ammo paint-reload-reminder paint-save-flash paint-reload-ready paint-game-info paint-berserk-badge paint-invuln-badge paint-empty-click paint-flicker paint-heartbeat-vignette paint-hit-vignette paint-berserk-tint paint-heat-bar paint-kill-streak paint-compass paint-enemy-hp-flashes paint-hearts-hud paint-pistol-hud paint-weapon-hud paint-blood-fx-into paint-pickups-into paint-projectiles-into paint-tracers-into build-blood-cols])
   (:require phel-doom.core.engine :refer [cast-frame max-depth proj-dist])
-  (:require phel-doom.core.projection :refer [char-aspect wall-px])
+  (:require phel-doom.core.projection :refer [char-aspect wall-px pitch-rows])
   (:require phel-doom.core.perf :refer [render-scale])
   (:require phel-doom.core.format :refer [format-duration])
   (:require phel-doom.core.version :refer [version]))
@@ -180,10 +180,14 @@
   "Per-row perpendicular ground distance for floor-casting. Row centres
    below the horizon (`vh/2`) map to `floor-cast-k / (row+0.5 - vh/2)`,
    clamped to `max-depth`. Rows at/above the horizon get `max-depth`
-   (never sampled as floor — walls/sky cover them). One pass over vh."
-  [^int vh]
-  (let [arr    (php/array)
-        center (php/* 0.5 vh)]
+   (never sampled as floor — walls/sky cover them). One pass over vh.
+   `pr` (scene rows, default 0) shears the horizon down/up for look
+   up/down so the floor plane tracks the pitched wall band; pr=0 keeps
+   the table identical."
+  [^int vh & [pr-arg]]
+  (let [pr     (or pr-arg 0)
+        arr    (php/array)
+        center (php/+ (php/* 0.5 vh) pr)]
     (loop [r 0]
       (when (php/< r vh)
         (let [p (php/- (php/+ r 0.5) center)]
@@ -236,11 +240,15 @@
    projection numerator for ONE sub-row of drop (`floor-cast-k-sub`,
    sub-row = half a terminal row). The pixel-doubled renderer passes
    `vh` = 2x its scene height so the table covers its 4-per-scene-row
-   sub-pixel space - the same sub-pixel density as full detail."
-  [^int vh ^float k]
-  (let [arr    (php/array)
+   sub-pixel space - the same sub-pixel density as full detail. `pr`
+   (SCENE rows, default 0) shears the sub-row horizon by `2·pr` for look
+   up/down so the floor tracks the pitched wall sub-bounds; pr=0 keeps
+   the table identical."
+  [^int vh ^float k & [pr-arg]]
+  (let [pr     (or pr-arg 0)
+        arr    (php/array)
         sub    (php/* 2 vh)
-        center (php/* 1.0 vh)]
+        center (php/+ (php/* 1.0 vh) (php/* pr 2))]
     (loop [s 0]
       (when (php/< s sub)
         (let [p (php/- (php/+ s 0.5) center)]
@@ -291,8 +299,12 @@
    `pd`         wall-height projection numerator: `proj-dist` at full
                 detail, half of it in pixel-doubled mode (scene rows are
                 two terminal rows tall, so heights halve to keep the
-                same on-screen wall size)."
-  [vw vh haze-shift cast palette blood-cols ^float pd]
+                same on-screen wall size).
+   `pr`         look up/down horizon shear in scene rows (default 0):
+                added to every wall top so the whole wall band slides
+                down (look up) / up (look down) with the sky/floor
+                split. pr=0 keeps the shading byte-identical."
+  [vw vh haze-shift cast palette blood-cols ^float pd & [pr-arg]]
   (let [{:keys [dists hits sides wallxs]}                              cast
         {:keys [stbl ctbl sky-c floor-c door-shade-now door-code-now
                 door-tex-boost
@@ -316,12 +328,13 @@
         ;; or the amber door texture on door columns.
         tex-u                                                          (buf-mk)
         tex-level                                                      (buf-mk)
-        tex-px                                                         (buf-mk)]
+        tex-px                                                         (buf-mk)
+        pr                                                             (or pr-arg 0)]
     (loop [col 0]
       (when (php/< col vw)
         (let [dist         (buf-get dists col)
               wall-h       (php/min vh (php/intval (wall-px pd dist)))
-              top          (php/intdiv (php/- vh wall-h) 2)
+              top          (php/+ (php/intdiv (php/- vh wall-h) 2) pr)
               blood?       (php/> (buf-get blood-cols col) 0.4)
               stbl-l       (if blood? shade-table-blood stbl)
               ctbl-l       (if blood? shade-code-table-blood ctbl)
@@ -456,7 +469,7 @@
 ;; Input-determined cache — same vh always yields the same arrays — so
 ;; it preserves frame->string's referential transparency, same as the
 ;; engine's offset-cache.
-(def- gradient-cache (atom {:vh -1}))
+(def- gradient-cache (atom {:vh -1 :pr 0}))
 
 (defn- build-wall-sub-bounds
   "Per-column seam data for the sub-row wall mixers, all
@@ -478,20 +491,27 @@
    non-mixing columns. NOTE: the fallbacks copy tops/bots BEFORE the
    enemy zone pass mutates them, so consumers must only trust sky-lim /
    floor-from on mix columns (mix columns are never glyph-enemy
-   columns, whose tops/bots the zone pass rewrites)."
-  [dists tex-levels emask tops bots ^bool sprites-on ^bool tex-on? ^int svw ^int svh ^float pd ^int n]
-  (let [ts  (php/array)
+   columns, whose tops/bots the zone pass rewrites). `pr` (scene rows,
+   default 0) shears the sub-row band by `pr*n` for look up/down so the
+   seam tracks the cell-res tops; pr=0 keeps the bounds identical."
+  [dists tex-levels emask tops bots ^bool sprites-on ^bool tex-on? ^int svw ^int svh ^float pd ^int n & [pr-arg]]
+  (let [pr  (or pr-arg 0)
+        ts  (php/array)
         bs  (php/array)
         mx  (php/array)
         sl  (php/array)
         ff  (php/array)
         nf  (php/* 1.0 n)
-        cap (php/* n svh)]
+        cap (php/* n svh)
+        ;; Look up/down: shear the sub-row wall band by `pr` SCENE rows =
+        ;; `pr*n` sub-rows (n per scene cell), matching the cell-res tops
+        ;; from compute-wall-shades so the half-row seam tracks the band.
+        prn (php/* pr n)]
     (loop [c 0]
       (when (php/< c svw)
         (let [dist (buf-get dists c)
               whs  (php/min cap (php/intval (wall-px (php/* nf pd) dist)))
-              t    (php/intdiv (php/- cap whs) 2)
+              t    (php/+ (php/intdiv (php/- cap whs) 2) prn)
               b    (php/+ t whs)
               mix? (and tex-on?
                         (php/>= (buf-get tex-levels c) 0)
@@ -533,22 +553,28 @@
     {:dists d :hits h :sides s :wallxs w :floordxs fx :floordys fy}))
 
 (defn- frame-gradients
-  "Memoized sky/floor gradient bundle for viewport height `vh`. Returns
-   a map of the 6 gradient arrays (normal + blood, shade + code twins),
-   rebuilding only on a vh change. Blood variants are always built here;
-   the caller still gates their USE on the live `bloody?` flag."
-  [^int vh]
-  (let [c @gradient-cache]
-    (if (php/=== vh (:vh c))
+  "Memoized sky/floor gradient bundle for viewport height `vh` and look
+   up/down shear `pr` (scene rows, default 0). Returns a map of the 6
+   gradient arrays (normal + blood, shade + code twins), rebuilding only
+   when `vh` OR `pr` changes (resize / pitch). Blood variants are always
+   built here; the caller still gates their USE on the live `bloody?`
+   flag. Keying on `pr` keeps the bundle input-determined (same vh + pr
+   => same arrays), preserving frame->string's referential transparency;
+   pr=0 reproduces the pre-pitch bundle byte-for-byte."
+  [^int vh & [pr-arg]]
+  (let [pr (or pr-arg 0)
+        c  @gradient-cache]
+    (if (and (php/=== vh (:vh c)) (php/=== pr (:pr c)))
       c
       (let [bundle {:vh             vh
-                    :sky            (build-horizon-gradient vh shade-table)
-                    :sky-hb         (build-sky-halfblock vh shade-code-table)
-                    :floor          (build-themed-gradient vh 239 true)
-                    :sky-code       (build-horizon-gradient-codes vh shade-code-table)
-                    :floor-code     (build-themed-gradient-codes vh 239 true)
-                    :blood-sky      (build-horizon-gradient vh shade-table-blood)
-                    :blood-sky-code (build-horizon-gradient-codes vh shade-code-table-blood)}]
+                    :pr             pr
+                    :sky            (build-horizon-gradient vh shade-table pr)
+                    :sky-hb         (build-sky-halfblock vh shade-code-table pr)
+                    :floor          (build-themed-gradient vh 239 true pr)
+                    :sky-code       (build-horizon-gradient-codes vh shade-code-table pr)
+                    :floor-code     (build-themed-gradient-codes vh 239 true pr)
+                    :blood-sky      (build-horizon-gradient vh shade-table-blood pr)
+                    :blood-sky-code (build-horizon-gradient-codes vh shade-code-table-blood pr)}]
         (reset! gradient-cache bundle)
         bundle))))
 
@@ -573,6 +599,24 @@
         px-sc                              (if px2? 2 1)
         svw                                (if px2? (php/intdiv (php/+ vw 1) 2) vw)
         svh                                (if px2? (php/intdiv (php/+ vh 1) 2) vh)
+        ;; Look up/down camera pitch -> integer horizon shear in SCENE
+        ;; rows. Computed once; threaded into every horizon=svh/2 site
+        ;; (wall tops, sub-row seam bounds, floor-cast tables, sky/floor
+        ;; gradients, sprite anchors) so the whole scene shears together.
+        ;; pr=0 (default, no pitch) leaves every site at its original
+        ;; centre, so the render is byte-identical to the no-pitch path.
+        ;; POSITIVE pitch (look up) => POSITIVE pr => band slides DOWN.
+        pr                                 (pitch-rows (or (:pitch (:player world)) 0.0) svh)
+        ;; Sub-row twin: the half-block sky / floor-cast tables index at
+        ;; 2 sub-rows per SCENE row at full detail and 2 per PASSED-vh row
+        ;; in px2 (where the table is built at 2·svh). They scale `pr` by
+        ;; 2 internally, so a px2 scene-row shift needs 2·pr handed in to
+        ;; land 4 sub-rows per scene cell - matching the n=4 wall bounds.
+        pr-sub                             (if px2? (php/* 2 pr) pr)
+        ;; Full-resolution pitch shear (rows): the HP-flash overlay floats
+        ;; at terminal resolution (vh, not svh), so it tracks the sprite
+        ;; head using the vh-scaled offset.
+        pr-full                            (pitch-rows (or (:pitch (:player world)) 0.0) vh)
         bloody?                            (php/> (or (get stats :iframes) 0.0) 0.0)
         ;; Walls + sky + floor are ALL pure grayscale: enemy colours
         ;; pop against neutral stonework, and far walls fade toward
@@ -584,7 +628,7 @@
         ;; SCENE height (see frame-gradients); the per-frame rebuild is
         ;; gone. In pixel-doubled mode every scene-side consumer keys off
         ;; svh, so the memo stays single-keyed and stable across frames.
-        grads                              (frame-gradients svh)
+        grads                              (frame-gradients svh pr)
         sky-gradient                       (:sky grads)
         ;; Half-block sky: per-row ▀ cell stacking two sub-rows of the
         ;; horizon gradient (2× vertical smoothness). Row-constant, so it
@@ -597,7 +641,7 @@
         ;; the full-detail seam mixer blends the code at a wall-top
         ;; boundary sub-row into its ▀ cell. Sized to the path's
         ;; sub-row space (4 per scene cell in px2, 2 per cell in px1).
-        sky-sub-codes                      (build-sky-codes-sub (if px2? (php/* 2 svh) svh) shade-code-table)
+        sky-sub-codes                      (build-sky-codes-sub (if px2? (php/* 2 svh) svh) shade-code-table pr-sub)
         ;; Floor: same grey gradient with subtle tile banding (odd
         ;; rows one fade step darker).
         floor-gradient                     (:floor grads)
@@ -671,9 +715,9 @@
         ;; res arrays drive the legacy single-texel floor; the sub arrays
         ;; (2× vertical) drive the half-block floor.
         {:x pfx :y pfy}                    (:player world)
-        floor-dperp                        (build-floor-dperp svh)
+        floor-dperp                        (build-floor-dperp svh pr)
         floor-level                        (build-floor-level floor-dperp svh)
-        floor-dperp-sub                    (build-floor-dperp-sub (if px2? (php/* 2 svh) svh) floor-cast-k-sub)
+        floor-dperp-sub                    (build-floor-dperp-sub (if px2? (php/* 2 svh) svh) floor-cast-k-sub pr-sub)
         floor-level-sub                    (build-floor-level-sub floor-dperp-sub (if px2? (php/* 2 svh) svh))
         _                                  (when debug?
                                              (record-cast-ms!
@@ -800,7 +844,8 @@
                               :blood-sky-code-grad   blood-sky-code-gradient
                               :blood-floor-code-grad blood-floor-code-gradient}
                              blood-cols
-                             scene-pd)
+                             scene-pd
+                             pr)
         ;; Enemy sprite zone boundaries (head/body/legs). For each
         ;; column carrying an enemy:
         ;;   row in [tops, mids)   -> head
@@ -935,7 +980,7 @@
                    ;; darkening) rather than level 8 (65%), keeping its
                    ;; shading bands visible against dark stone.
               sfade     (php/aget sprite-fade (sprite-fade-index body-fade))]
-          (let [e-top (php/intdiv (php/- svh h) 2)]
+          (let [e-top (php/+ (php/intdiv (php/- svh h) 2) pr)]
             (let [e-bot         (php/+ e-top h)
                   e-mid         (php/+ e-top (php/intdiv h 3))
                   e-lower       (php/+ e-top (php/intdiv (php/* h 2) 3))
@@ -1035,7 +1080,7 @@
               h      (php/min svh (php/intval (php/* sc
                                                      (php// scene-pd
                                                             (php/* (php/max 0.5 d) char-aspect)))))
-              e-bot  (php/+ (php/intdiv (php/- svh h) 2) h)
+              e-bot  (php/+ (php/intdiv (php/- svh h) 2) pr h)
               c-from (php/max 0 (php/- col hw))
               c-to   (php/min (php/- svw 1) (php/+ col hw))]
           (when (php/< e-bot svh)
@@ -1181,7 +1226,8 @@
                                                      sprites-on
                                                      (if px2? tex-on? (if subpixel? tex-on? false))
                                                      svw svh scene-pd
-                                                     (if px2? 4 2))
+                                                     (if px2? 4 2)
+                                                     pr)
           wsub-top            (php/aget wsub 0)
           wsub-bot            (php/aget wsub 1)
           wsub-mix            (php/aget wsub 2)
@@ -1908,7 +1954,7 @@
             ;; Face glyph (blinking eyes) is a glyph-era tell; the
             ;; Freedoom sprites already show a face, so skip it in sprite mode.
             p1          (if sprites-on parts
-                            (paint-face-overlay parts world stats svw svh dists edists face-phase px-sc))
+                            (paint-face-overlay parts world stats svw svh dists edists face-phase px-sc pr))
             p3          (paint-door-face          p1 stats svw svh hits tops bots px-sc)
             p4          (paint-crosshair          p3 stats vw vh center-bg)
             p5          (paint-intro-splash       p4 stats vw vh)
@@ -1933,7 +1979,7 @@
             p18         (paint-empty-click        p17 stats vw vh)
             p19         (paint-reload-reminder    p18 stats vw vh)
             p19b        (paint-locked-bump        p19 stats vw vh)
-            p19c        (paint-enemy-hp-flashes   p19b world vw vh)
+            p19c        (paint-enemy-hp-flashes   p19b world vw vh pr-full)
             p20         (paint-save-flash         p19c stats vw vh)
             p20b        (paint-reload-ready       p20 stats vw vh)]
         ;; Pause (P) IS the settings page: freezing the game and the

--- a/src/io/render/paint.phel
+++ b/src/io/render/paint.phel
@@ -50,11 +50,17 @@
 
    `sc` is the render pixel scale: `vw`/`vh`/`dists`/`edists` live in
    SCENE cells, so the emitted terminal coordinates multiply by `sc`
-   (1 = full detail, identity; 2 = pixel-doubled scene)."
-  [parts world stats vw vh dists edists face-phase ^int sc]
+   (1 = full detail, identity; 2 = pixel-doubled scene).
+
+   `pr` (scene rows, default 0) is the look up/down horizon shear: the
+   sprite body shifts by `pr` in the base frame, so the face glyph adds
+   the same `pr` to stay pinned to the head. pr=0 keeps the overlay
+   exactly where it was."
+  [parts world stats vw vh dists edists face-phase ^int sc & [pr-arg]]
   ;; Reduced-motion: drop the one-shot jump-scare glyph swap (a sudden
   ;; flash); the resting / attack faces still animate on their own beat.
-  (let [scare? (and (php/> (or (get stats :scare-secs) 0.0) 0.0)
+  (let [pr     (or pr-arg 0)
+        scare? (and (php/> (or (get stats :scare-secs) 0.0) 0.0)
                     (not (get stats :reduced-motion?)))]
     (doseq [proj (collect-enemy-projs (:enemies world) (:player world) vw)]
       (let [col         (:col proj)
@@ -73,7 +79,7 @@
                    (php/< col vw)
                    (enemy-front-visible-at? d col dists edists))
           (let [h        (sprite-h vh d 1.0)
-                face-row (php/+ (php/intdiv (php/- vh h) 2) (php/intdiv h 6))]
+                face-row (php/+ (php/intdiv (php/- vh h) 2) (php/intdiv h 6) pr)]
             (when (and (php/>= face-row 1) (php/<= face-row vh))
               (buf-push parts
                         (str "\e[" (php/* sc face-row) ";"
@@ -873,9 +879,11 @@
    enemies and 1-HP enemies (where any hit is a kill anyway, so the
    number would always be 0 the moment it appeared). Bright yellow
    on a dark BG so the digit reads against any sprite zone behind
-   it."
-  [parts world vw vh]
-  (let [player (:player world)]
+   it. `pr` (rows, default 0) is the look up/down horizon shear at full
+   resolution, added so the digit tracks the pitched sprite head."
+  [parts world vw vh & [pr-arg]]
+  (let [pr     (or pr-arg 0)
+        player (:player world)]
     (doseq [e (:enemies world)]
       (when (and e
                  (:alive e)
@@ -887,7 +895,7 @@
             (let [col (:col proj)
                   d   (:dist proj)
                   h   (sprite-h vh d 1.0)
-                  row (php/max 1 (php/- (php/intdiv (php/- vh h) 2) 1))]
+                  row (php/max 1 (php/+ (php/- (php/intdiv (php/- vh h) 2) 1) pr))]
               (when (and (php/>= col 1) (php/<= col vw))
                 (buf-push parts
                           (str "\e[" row ";" col "H\e[40;38;5;226;1m"

--- a/tests/core/physics-test.phel
+++ b/tests/core/physics-test.phel
@@ -152,6 +152,49 @@
     (is (= (:y p0) (:y p1)))
     (is (= (:angle p0) (:angle p1)))))
 
+;; ---------------------------------------------------------------------
+;; apply-pitch (via apply-physics): :pitch-up / :pitch-down counters
+;; shear the look up/down fraction, clamped, with no effect on position.
+;; ---------------------------------------------------------------------
+
+(deftest test-apply-physics-look-up-raises-pitch
+  ;; Look-up adds to :pitch (positive); the counter decays one frame.
+  (let [w0 (assoc-in empty-world [:moves :pitch-up] 3)
+        w1 (apply-physics w0 0.1)]
+    (is (php/> (:pitch (:player w1)) 0.0))
+    (is (= 2 (:pitch-up (:moves w1))))))
+
+(deftest test-apply-physics-look-down-lowers-pitch
+  (let [w0 (assoc-in empty-world [:moves :pitch-down] 3)
+        w1 (apply-physics w0 0.1)]
+    (is (php/< (:pitch (:player w1)) 0.0))
+    (is (= 2 (:pitch-down (:moves w1))))))
+
+(deftest test-apply-physics-pitch-clamps-and-does-not-wrap
+  ;; Hold look-up across many frames: pitch saturates at +1.0, never
+  ;; exceeds the cap or flips sign.
+  (let [w0 (assoc-in empty-world [:moves :pitch-up] 1)
+        wn (loop [w w0 i 0]
+             (if (php/< i 200)
+               (recur (apply-physics (assoc-in w [:moves :pitch-up] 1) 0.1)
+                      (php/+ i 1))
+               w))]
+    (is (= 1.0 (:pitch (:player wn))))))
+
+(deftest test-apply-physics-pitch-does-not-move-player
+  ;; Pitch is a pure camera shear: looking up/down leaves x/y/angle put.
+  (let [p0 (:player empty-world)
+        w1 (apply-physics (assoc-in empty-world [:moves :pitch-up] 3) 0.1)
+        p1 (:player w1)]
+    (is (= (:x p0) (:x p1)))
+    (is (= (:y p0) (:y p1)))
+    (is (= (:angle p0) (:angle p1)))))
+
+(deftest test-apply-physics-no-pitch-counter-leaves-pitch-level
+  ;; Default (no pitch keys held): pitch stays 0.0 - the byte-identical
+  ;; render contract.
+  (is (= 0.0 (:pitch (:player (apply-physics empty-world 0.1))))))
+
 (deftest test-apply-physics-wall-blocks-but-counter-still-decays
   ;; dt large enough that the requested move overshoots the open cell
   ;; (1,1) into the wall at (2,1). Player stays put, counter still

--- a/tests/core/projection-test.phel
+++ b/tests/core/projection-test.phel
@@ -1,6 +1,6 @@
 (ns phel-doom-tests.core.projection-test
   (:require phel.test :refer [deftest is])
-  (:require phel-doom.core.projection :refer [wall-px project-height]))
+  (:require phel-doom.core.projection :refer [wall-px project-height pitch-rows pitch-cap]))
 
 ;; ---------------------------------------------------------------------
 ;; wall-px: the shared projection kernel. num / ((max 0.3 dist) * 2.0).
@@ -61,3 +61,46 @@
         bot    (php/+ top wall-h)]
     (is (= top (php/intval (php/round (project-height pd vh dist 0.5 1.0)))))
     (is (= bot (php/intval (php/round (project-height pd vh dist 0.5 0.0)))))))
+
+;; ---------------------------------------------------------------------
+;; pitch-rows: normalised look up/down fraction -> integer horizon shear.
+;; ---------------------------------------------------------------------
+
+(deftest pitch-rows-zero-is-zero
+  ;; The byte-identical contract: no pitch shears the horizon by nothing
+  ;; at every viewport height.
+  (is (= 0 (pitch-rows 0.0 30)))
+  (is (= 0 (pitch-rows 0.0 24)))
+  (is (= 0 (pitch-rows 0.0 44))))
+
+(deftest pitch-rows-positive-looks-up-shears-down
+  ;; POSITIVE pitch (look up) shears the horizon DOWN the screen, i.e.
+  ;; toward larger row numbers, so the offset is positive.
+  (is (php/> (pitch-rows 1.0 30) 0))
+  (is (php/> (pitch-rows 0.5 30) 0)))
+
+(deftest pitch-rows-negative-looks-down-shears-up
+  ;; NEGATIVE pitch (look down) shears the horizon UP (smaller rows).
+  (is (php/< (pitch-rows -1.0 30) 0))
+  (is (php/< (pitch-rows -0.5 30) 0)))
+
+(deftest pitch-rows-sign-is-antisymmetric
+  ;; Equal-and-opposite pitch gives equal-and-opposite shear.
+  (is (= (php/- 0 (pitch-rows 0.7 30)) (pitch-rows -0.7 30))))
+
+(deftest pitch-rows-magnitude-grows-with-pitch
+  ;; Looking further up shears the horizon further down.
+  (is (php/> (pitch-rows 1.0 30) (pitch-rows 0.5 30)))
+  (is (php/> (pitch-rows 0.5 30) (pitch-rows 0.25 30))))
+
+(deftest pitch-rows-caps-at-pitch-cap-fraction
+  ;; Full pitch shears by exactly round(pitch-cap * vh) rows - the
+  ;; documented ceiling (0.4 * 30 = 12).
+  (is (= (php/intval (php/round (php/* pitch-cap 30))) (pitch-rows 1.0 30)))
+  (is (= (php/- 0 (php/intval (php/round (php/* pitch-cap 30)))) (pitch-rows -1.0 30))))
+
+(deftest pitch-rows-returns-int
+  ;; Always an integer scene-row offset (round, not float), so it can
+  ;; index gradient arrays / add to integer wall tops cleanly.
+  (is (php/is_int (pitch-rows 0.37 30)))
+  (is (php/is_int (pitch-rows -0.81 44))))

--- a/tests/core/state-test.phel
+++ b/tests/core/state-test.phel
@@ -8,7 +8,7 @@
                                          gain-life gain-soulsphere decay-soul-overcap
                                          max-armor max-backpacks max-lives
                                          armor-shard-cap soul-overcap-decay-secs
-                                         soulsphere-cap]))
+                                         soulsphere-cap clamp-pitch max-pitch]))
 
 (def grid [[1 1 1] [1 0 1] [1 1 1]])
 
@@ -17,6 +17,20 @@
     (is (= 1.0 (:x p)))
     (is (= 2.0 (:y p)))
     (is (= 0.5 (:angle p)))))
+
+(deftest test-new-player-spawns-level-pitch
+  ;; Fresh players look level so the default view is byte-identical.
+  (is (= 0.0 (:pitch (new-player 1.0 2.0 0.5)))))
+
+(deftest test-clamp-pitch-passes-through-in-range
+  (is (= 0.0 (clamp-pitch 0.0)))
+  (is (= 0.5 (clamp-pitch 0.5)))
+  (is (= -0.5 (clamp-pitch -0.5))))
+
+(deftest test-clamp-pitch-saturates-at-the-cap
+  ;; No wrap: over-range looks-up / looks-down stick at ±max-pitch.
+  (is (= max-pitch (clamp-pitch 3.0)))
+  (is (= (php/- 0 max-pitch) (clamp-pitch -3.0))))
 
 (deftest test-new-world-records-dimensions
   (let [w (new-world grid (new-player 1.0 1.0 0.0))]

--- a/tests/glue/controls-test.phel
+++ b/tests/glue/controls-test.phel
@@ -2,7 +2,7 @@
   (:require phel.test :refer [deftest is])
   (:require phel-doom.glue.controls
             :refer [key-states refresh-from-keys rising-edges initial-key-snapshot
-                    nav-deltas]))
+                    nav-deltas refresh-move]))
 
 (def blank-moves
   {:fwd          0
@@ -11,7 +11,9 @@
    :strafe-right 0
    :turn-left    0
    :turn-right   0
-   :sprint       0})
+   :sprint       0
+   :pitch-up     0
+   :pitch-down   0})
 
 (def blank-world
   {:moves blank-moves})
@@ -280,6 +282,50 @@
   ;; release feels instant.
   (let [w' (refresh-from-keys blank-world "x")]
     (is (php/<= (:sprint (:moves w')) 5))))
+
+;; ---------------------------------------------------------------------
+;; Look up/down (pitch): 't' arms :pitch-up, 'g' arms :pitch-down. Both
+;; legacy single-byte and kitty CSI-u (codepoints 116 / 103) paths.
+;; ---------------------------------------------------------------------
+
+(deftest test-t-byte-refreshes-pitch-up-slot
+  (let [w' (refresh-from-keys blank-world "t")]
+    (is (php/> (:pitch-up   (:moves w')) 0))
+    (is (= 0   (:pitch-down (:moves w'))))))
+
+(deftest test-g-byte-refreshes-pitch-down-slot
+  (let [w' (refresh-from-keys blank-world "g")]
+    (is (php/> (:pitch-down (:moves w')) 0))
+    (is (= 0   (:pitch-up   (:moves w'))))))
+
+(deftest test-refresh-move-maps-t-to-pitch-up
+  ;; Direct slot-map check, mirroring the blank-moves style: the byte
+  ;; lands in exactly the :pitch-up slot, nothing else.
+  (let [w' (refresh-move blank-world "t")]
+    (is (php/> (:pitch-up (:moves w')) 0))
+    (is (= (assoc blank-moves :pitch-up (:pitch-up (:moves w')))
+           (:moves w')))))
+
+(deftest test-refresh-move-maps-g-to-pitch-down
+  (let [w' (refresh-move blank-world "g")]
+    (is (php/> (:pitch-down (:moves w')) 0))
+    (is (= (assoc blank-moves :pitch-down (:pitch-down (:moves w')))
+           (:moves w')))))
+
+(deftest test-t-still-works-under-kitty-as-codepoint-116
+  ;; Under kitty, 't' arrives wrapped as \e[116u. Must still hit :pitch-up.
+  (let [w' (refresh-from-keys blank-world "\e[116u")]
+    (is (php/> (:pitch-up (:moves w')) 0))))
+
+(deftest test-g-still-works-under-kitty-as-codepoint-103
+  (let [w' (refresh-from-keys blank-world "\e[103u")]
+    (is (php/> (:pitch-down (:moves w')) 0))))
+
+(deftest test-pitch-slot-uses-short-hold-frames
+  ;; Pitch halts fast (like turn), not the long move-hold bridge, so the
+  ;; camera doesn't keep drifting after the key is released.
+  (let [w' (refresh-from-keys blank-world "t")]
+    (is (php/<= (:pitch-up (:moves w')) 5))))
 
 ;; ---------------------------------------------------------------------
 ;; Capital WASD: legacy fallback so SHIFT+WASD sprints on terminals

--- a/tests/io/render-cache-test.phel
+++ b/tests/io/render-cache-test.phel
@@ -54,6 +54,48 @@
   (is (= "959148793da9868ff84b9fb4158db77a" (php/md5 (frame->string world (assoc stats :px2? true) 120 30)))))
 
 ;; ---------------------------------------------------------------------
+;; Camera pitch (look up/down, issue #231): a vertical horizon shear.
+;; pitch=0 must reproduce the unpitched frame byte-for-byte; positive
+;; pitch (look up) shears the wall/floor band DOWN the screen so the top
+;; rows show more (RLE-friendly) sky, and negative pitch (look down)
+;; pulls the textured floor up into the top rows.
+;; ---------------------------------------------------------------------
+
+(defn- pitched [^float p]
+  (frame->string (assoc-in world [:player :pitch] p) stats 120 30))
+
+(defn- top-row-segments
+  "ANSI-segment count across the top 12 scene rows as a horizon-position
+   proxy: sky rows coalesce into a couple of runs (few segments); wall /
+   textured-floor rows carry many. Fewer => more sky on top."
+  [^float p]
+  (let [rows (php/explode "\n" (pitched p))]
+    (loop [i 0 c 0]
+      (if (php/< i 12)
+        (recur (php/+ i 1)
+               (php/+ c (php/- (php/count (php/explode "\e[" (php/aget rows i))) 1)))
+        c))))
+
+(deftest test-pitch-zero-matches-unpitched-frame
+  ;; The byte-identical contract at the frame level: an explicit
+  ;; :pitch 0.0 renders exactly like the world with no pitch shear.
+  (is (= (frame->string world stats 120 30) (pitched 0.0))))
+
+(deftest test-pitch-changes-the-frame
+  (is (not= (pitched 0.0) (pitched 0.8)))
+  (is (not= (pitched 0.0) (pitched -0.8))))
+
+(deftest test-look-up-shears-horizon-down
+  ;; Looking UP (positive pitch) slides the wall band DOWN, so the top
+  ;; rows are more sky than at level gaze, which is in turn more sky than
+  ;; looking DOWN (where the floor is pulled up into view). Directional
+  ;; proof that wall tops / the sky-floor split move with +pitch.
+  (is (php/< (top-row-segments 0.8) (top-row-segments 0.0))
+      "look up => more sky on top than level")
+  (is (php/< (top-row-segments 0.0) (top-row-segments -0.8))
+      "look down => less sky on top than level"))
+
+;; ---------------------------------------------------------------------
 ;; Half-block sub-pixel cell cache (halfblock). Two distinct codes pack
 ;; into a ▀ with top fg / bottom bg; equal codes collapse to a single-
 ;; colour BG cell (fewer bytes, RLE-friendly). The memo must return a


### PR DESCRIPTION
## 📚 Description

Adds a camera pitch (look up/down) to the raycaster, part of the vertical-levels epic (#229). Implemented as a vertical horizon shear: the player's `:pitch` (a [-1,1] fraction) converts to an integer row offset that is added to every horizon site (walls, sub-walls, floor-cast, sky/floor gradients, sprites + grounding shadows), so the whole scene tilts together with no seam tear. Crosshair stays fixed as a weapon sight. `pitch = 0` is byte-identical (golden frame hashes unchanged).

## 🔖 Changes

- New `pitch-rows` (pure, in `core/projection`); `:pitch` + `clamp-pitch` in state; `apply-pitch` mirrors yaw in physics (no wrap).
- Keys: `t` look up, `g` look down (legacy + kitty), short hold-frames.
- Render threads the offset through wall/floor/sky/sprite projection; grounding shadow + face/HP overlays follow the sprite.
- Tests: +45 (pitch-rows, clamp, physics, controls, directional render); golden byte-identity preserved. `docs/input.md`, `docs/raycaster.md`, CHANGELOG updated.

Closes #231