### PR TITLE
feat(controls): look up/down on arrow keys (replace t/g)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 
 ### Added
 
-- Look up/down camera pitch (issue #231): `t` tilts the view up, `g` tilts it down (hold to keep pitching, clamps at the extremes - no wrap). It is a pure vertical shear of the horizon (no extra rays): walls, the sky/floor split, floor-cast and enemy sprites all slide together by an integer row offset capped at +/-0.4 of the viewport height. `:pitch` is stored on the player as a fraction in [-1, 1]; a level gaze renders byte-for-byte identically to before.
+- Look up/down camera pitch (issues #231, #240): the ↑ / ↓ arrow keys tilt the view up / down (hold to keep pitching, clamps at the extremes - no wrap). It is a pure vertical shear of the horizon (no extra rays): walls, the sky/floor split, floor-cast and enemy sprites all slide together by an integer row offset capped at +/-0.4 of the viewport height. `:pitch` is stored on the player as a fraction in [-1, 1]; a level gaze renders byte-for-byte identically to before.
 
 ## [0.15.0] - 2026-06-16
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ Override tag: `DOCKER_IMG=mytag make docker-build`. Host PHP is the inner loop; 
 
 | Key            | Action                  |
 |---|---|
-| `w` `a` `s` `d` / arrows | Move / turn    |
+| `w` `a` `s` `d`         | Move / strafe           |
+| `←` `→` / `↑` `↓`       | Turn / look up, down    |
 | `SHIFT`        | Sprint                  |
 | `space` / `r`  | Fire / reload           |
 | `1`...`8`      | Switch weapon           |

--- a/docs/gameplay.md
+++ b/docs/gameplay.md
@@ -6,9 +6,10 @@ Full controls, pickups, weapons, and CLI flags. The README has the short version
 
 | Key | Action |
 |---|---|
-| `w` / `s` / ↑↓ | Forward / back |
+| `w` / `s` | Forward / back |
 | `a` / `d` | Strafe left / right |
 | `←` / `→` | Turn left / right |
+| `↑` / `↓` | Look up / down |
 | `SHIFT` / `x` | Sprint (1.6x speed) |
 | `e` | About-face (180 degrees) |
 | `space` | Fire (hold to spray auto-fire) |

--- a/docs/input.md
+++ b/docs/input.md
@@ -24,17 +24,17 @@ Kitty-enabled terminals (kitty, WezTerm, Ghostty, Alacritty >= 0.13, iTerm2 >= 3
 
 ## Arrow keys
 
-Arrows arrive as 3-byte CSI: `\e[A` up, `\e[B` down, `\e[C` right, `\e[D` left. Normalised to `^` `_` `>` `<` before byte-walk so they map to direction slots identically to WASD.
+Arrows arrive as 3-byte CSI: `\e[A` up, `\e[B` down, `\e[C` right, `\e[D` left. Normalised to `^` `_` `>` `<` before byte-walk. Up/down (`^`/`_`) look up/down (pitch); left/right (`<`/`>`) turn. Forward/back movement is WASD (`w`/`s`).
 
 ## Movement slots
 
-`key->slot` maps: `w`/`^` to `:fwd`, `s`/`_` to `:back`, `a` to `:strafe-left`, `d` to `:strafe-right`, arrows to turn, `x` to `:sprint`, `t` to `:pitch-up`, `g` to `:pitch-down`.
+`key->slot` maps: `w` to `:fwd`, `s` to `:back`, `a` to `:strafe-left`, `d` to `:strafe-right`, `^`/`_` (up/down arrows) to `:pitch-up`/`:pitch-down`, `<`/`>` (left/right arrows) to turn, `x` to `:sprint`.
 
 Each byte refreshes its slot's counter on `world[:moves]`. Physics only reads the counters. See [state.md](state.md).
 
 ## Look up/down (pitch)
 
-Hold **`t`** to look up, **`g`** to look down. Picked off the WASD home cluster and otherwise unbound (no collision with move/turn/sprint, weapons 1-7, or the one-shot action keys). They refresh the `:pitch-up` / `:pitch-down` move slots; physics shears the player's `:pitch` fraction (clamped to [-1, 1], no wrap) via the same counter path as turning. `pitch-hold-frames` = 3 (~50ms), so the camera halts quickly on release like turning rather than gliding. Under kitty the keys arrive as codepoints 116 (`t`) / 103 (`g`) and work the same. The shear is a pure render offset (see [raycaster.md](raycaster.md)); a level gaze (`:pitch` 0) renders identically to no pitch at all.
+Hold **↑** to look up, **↓** to look down. The arrow keys form a camera cluster (←/→ turn, ↑/↓ look) while WASD handles movement. They refresh the `:pitch-up` / `:pitch-down` move slots; physics shears the player's `:pitch` fraction (clamped to [-1, 1], no wrap) via the same counter path as turning. `pitch-hold-frames` = 3 (~50ms), so the camera halts quickly on release like turning rather than gliding. The up/down arrows reach pitch on every encoding: legacy CSI/SS3 (`\e[A`/`\eOA`, normalised to `^`/`_`) and kitty-enhanced (`\e[1;..A`/`B`). The shear is a pure render offset (see [raycaster.md](raycaster.md)); a level gaze (`:pitch` 0) renders identically to no pitch at all.
 
 ## Sprint
 
@@ -53,7 +53,7 @@ Per byte, counter is set to its hold value; each frame physics decrements by 1. 
 
 - `move-hold-frames` = 18 (~300ms at 60 fps): bridges OS initial-key-repeat delay (250-500ms). Avoids stutter on press. Trade-off: ~300ms post-release glide on non-kitty terminals. Kitty release events (event type 3) override with instant clear.
 - `turn-hold-frames` = 3 (~50ms at 60 fps): quick halt for aiming.
-- `pitch-hold-frames` = 3 (~50ms at 60 fps): same quick halt for look up/down (`t`/`g`), so the camera stops on release instead of drifting.
+- `pitch-hold-frames` = 3 (~50ms at 60 fps): same quick halt for look up/down (↑/↓ arrows), so the camera stops on release instead of drifting.
 
 ## Kitty keyboard protocol
 

--- a/src/glue/controls.phel
+++ b/src/glue/controls.phel
@@ -13,7 +13,7 @@
 ;; =====================================================================
 
 (def move-hold-frames
-  "Frames a movement direction (W/S/A/D + ↑/↓ arrows) stays active
+  "Frames a movement direction (W/S/A/D) stays active
    after each input byte. Sized to bridge the OS initial-key-repeat
    delay (~250-500ms on macOS/Linux): without this, the first byte
    arrives, motion runs for a few frames, then stops dead until the
@@ -42,28 +42,28 @@
   3)
 
 (def pitch-hold-frames
-  "Frames a look up/down direction (T / G) stays active after each input
-   byte. Short, like turn-hold-frames, so the camera pitch halts within
-   ~50ms of releasing the key (no terminal key-release on the legacy
-   path) instead of drifting on for the full move-hold bridge."
+  "Frames a look up/down direction (↑/↓ arrows) stays active after each
+   input byte. Short, like turn-hold-frames, so the camera pitch halts
+   within ~50ms of releasing the key (no terminal key-release on the
+   legacy path) instead of drifting on for the full move-hold bridge."
   3)
 
 (def key->slot
   "Map a single-byte input to the direction-counter slot it activates.
-   Arrow-key escape sequences are normalised to ^ _ < > before lookup
-   so they slot in alongside WASD. `x` arms the sprint slot — the
-   legacy / non-kitty fallback for terminals that don't expose SHIFT
-   modifier bits via CSI-u. `t` / `g` shear the camera look up / down
-   (pitch) — picked off the WASD home cluster and otherwise unbound."
-  {"^" :fwd    "w" :fwd
-   "_" :back   "s" :back
+   Arrow-key escape sequences are normalised to ^ _ < > before lookup:
+   ↑/↓ (^/_) shear the camera look up/down (pitch), ←/→ (</>) turn, and
+   forward/back are WASD's w/s. `x` arms the sprint slot — the legacy /
+   non-kitty fallback for terminals that don't expose SHIFT modifier
+   bits via CSI-u."
+  {"w" :fwd
+   "s" :back
+   "^" :pitch-up
+   "_" :pitch-down
    "<" :turn-left
    ">" :turn-right
    "a" :strafe-left
    "d" :strafe-right
-   "x" :sprint
-   "t" :pitch-up
-   "g" :pitch-down})
+   "x" :sprint})
 
 (def shift-key->slot
   "Capital-letter equivalents of `key->slot` movement keys. In cooked
@@ -153,15 +153,14 @@
 (def ascii->slot
   "ASCII codepoint -> direction-counter slot. WASD movement, ←→ turn
    (kitty reports left-arrow as 57351, right as 57349), 'x' (120) as the
-   legacy sprint key, and 't' (116) / 'g' (103) as look up / down (pitch)
-   — all work under kitty too without needing the SHIFT modifier bit."
+   legacy sprint key — all work under kitty too without needing the SHIFT
+   modifier bit. Look up/down (pitch) rides the ↑/↓ arrows via
+   `arrow-letter->slot`, not a CSI-u codepoint here."
   {119 :fwd
    115 :back
    97 :strafe-left
    100 :strafe-right
    120 :sprint
-   116 :pitch-up
-   103 :pitch-down
    57351 :turn-left
    57349 :turn-right})
 
@@ -250,9 +249,10 @@
 (def arrow-letter->slot
   "Kitty-enhanced arrow CSI sequences (`\\e[1;<mods>(:<event>)?<letter>`)
    keep the legacy letter suffix instead of becoming CSI-u tokens.
-   Letter codes: A=up B=down C=right D=left."
-  {"A" :fwd
-   "B" :back
+   Letter codes: A=up B=down C=right D=left — ↑/↓ look up/down (pitch),
+   ←/→ turn."
+  {"A" :pitch-up
+   "B" :pitch-down
    "D" :turn-left
    "C" :turn-right})
 

--- a/src/io/render/hud.phel
+++ b/src/io/render/hud.phel
@@ -558,9 +558,10 @@
         controls-rows (to-php-array
                        [blnk
                         (sec "CONTROLS")
-                        (bord "  wasd / ↑↓     move forward / back")
+                        (bord "  w / s         move forward / back")
                         (bord "  a / d         strafe left / right")
                         (bord "  ← →           turn left / right")
+                        (bord "  ↑ ↓           look up / down")
                         (bord "  e             about-face (snap 180)")
                         (bord "  space         fire")
                         (bord "  f             action (open secret walls)")

--- a/src/io/render/main.phel
+++ b/src/io/render/main.phel
@@ -2340,9 +2340,9 @@
         controls [:sep blank
                   (pad-visible "  \e[1mCONTROLS\e[40;97m" w)
                   blank
-                  (row2 "w s ↑ ↓" "move"   "1 .. 8" "weapon slot")
+                  (row2 "w s"     "move"   "1 .. 8" "weapon slot")
                   (row2 "a d"     "strafe" "h"      "info menu")
-                  (row2 "← →"     "turn"   "m n"    "map / sound")
+                  (row2 "← → ↑ ↓" "turn/look" "m n" "map / sound")
                   (row2 "e"       "180°"   "p"      "pause")
                   (row2 "space"   "fire"   "F3 q"   "debug / quit")
                   (row2 "r"       "reload" ""       "")

--- a/tests/glue/controls-test.phel
+++ b/tests/glue/controls-test.phel
@@ -284,47 +284,49 @@
     (is (php/<= (:sprint (:moves w')) 5))))
 
 ;; ---------------------------------------------------------------------
-;; Look up/down (pitch): 't' arms :pitch-up, 'g' arms :pitch-down. Both
-;; legacy single-byte and kitty CSI-u (codepoints 116 / 103) paths.
+;; Look up/down (pitch): ↑/↓ arrows arm :pitch-up / :pitch-down on every
+;; encoding (legacy CSI \e[A/\e[B, SS3 \eOA/\eOB, kitty-enhanced
+;; \e[1;..A/B). 't'/'g' are no longer bound.
 ;; ---------------------------------------------------------------------
 
-(deftest test-t-byte-refreshes-pitch-up-slot
-  (let [w' (refresh-from-keys blank-world "t")]
+(deftest test-up-arrow-refreshes-pitch-up-slot
+  (let [w' (refresh-from-keys blank-world "\e[A")]
     (is (php/> (:pitch-up   (:moves w')) 0))
-    (is (= 0   (:pitch-down (:moves w'))))))
+    (is (= 0   (:pitch-down (:moves w'))))
+    (is (= 0   (:fwd        (:moves w'))) "up arrow looks, no longer moves forward")))
 
-(deftest test-g-byte-refreshes-pitch-down-slot
-  (let [w' (refresh-from-keys blank-world "g")]
+(deftest test-down-arrow-refreshes-pitch-down-slot
+  (let [w' (refresh-from-keys blank-world "\e[B")]
     (is (php/> (:pitch-down (:moves w')) 0))
-    (is (= 0   (:pitch-up   (:moves w'))))))
+    (is (= 0   (:pitch-up   (:moves w'))))
+    (is (= 0   (:back       (:moves w'))) "down arrow looks, no longer moves back")))
 
-(deftest test-refresh-move-maps-t-to-pitch-up
-  ;; Direct slot-map check, mirroring the blank-moves style: the byte
-  ;; lands in exactly the :pitch-up slot, nothing else.
-  (let [w' (refresh-move blank-world "t")]
-    (is (php/> (:pitch-up (:moves w')) 0))
+(deftest test-ss3-up-down-arrows-pitch
+  ;; App-cursor SS3 form (tmux / alt-screen) reaches the same slots.
+  (is (php/> (:pitch-up   (:moves (refresh-from-keys blank-world "\eOA"))) 0))
+  (is (php/> (:pitch-down (:moves (refresh-from-keys blank-world "\eOB"))) 0)))
+
+(deftest test-kitty-enhanced-up-down-arrows-pitch
+  ;; Kitty enhanced arrows keep the legacy letter suffix: \e[1;mods:eventA.
+  (is (php/> (:pitch-up   (:moves (refresh-from-keys blank-world "\e[1;1:1A"))) 0))
+  (is (php/> (:pitch-down (:moves (refresh-from-keys blank-world "\e[1;1:1B"))) 0)))
+
+(deftest test-refresh-move-maps-up-standin-to-pitch-up
+  ;; refresh-move sees the normalised single-byte stand-in (^ = up arrow);
+  ;; it lands in exactly :pitch-up, nothing else.
+  (let [w' (refresh-move blank-world "^")]
     (is (= (assoc blank-moves :pitch-up (:pitch-up (:moves w')))
            (:moves w')))))
 
-(deftest test-refresh-move-maps-g-to-pitch-down
-  (let [w' (refresh-move blank-world "g")]
-    (is (php/> (:pitch-down (:moves w')) 0))
-    (is (= (assoc blank-moves :pitch-down (:pitch-down (:moves w')))
-           (:moves w')))))
-
-(deftest test-t-still-works-under-kitty-as-codepoint-116
-  ;; Under kitty, 't' arrives wrapped as \e[116u. Must still hit :pitch-up.
-  (let [w' (refresh-from-keys blank-world "\e[116u")]
-    (is (php/> (:pitch-up (:moves w')) 0))))
-
-(deftest test-g-still-works-under-kitty-as-codepoint-103
-  (let [w' (refresh-from-keys blank-world "\e[103u")]
-    (is (php/> (:pitch-down (:moves w')) 0))))
+(deftest test-t-and-g-no-longer-bound
+  ;; The old t/g pitch keys are freed - they touch no slot now.
+  (is (= blank-moves (:moves (refresh-from-keys blank-world "t"))))
+  (is (= blank-moves (:moves (refresh-from-keys blank-world "g")))))
 
 (deftest test-pitch-slot-uses-short-hold-frames
   ;; Pitch halts fast (like turn), not the long move-hold bridge, so the
   ;; camera doesn't keep drifting after the key is released.
-  (let [w' (refresh-from-keys blank-world "t")]
+  (let [w' (refresh-from-keys blank-world "\e[A")]
     (is (php/<= (:pitch-up (:moves w')) 5))))
 
 ;; ---------------------------------------------------------------------


### PR DESCRIPTION
## 📚 Description

Follow-up to #231 (per user feedback): rebind look up/down (pitch) from `t` / `g` to the **↑ / ↓ arrow keys**. The arrows now form a camera cluster (←/→ turn, ↑/↓ look) while WASD handles movement; `t` / `g` are freed. The render path is untouched, so the `pitch = 0` golden frame stays byte-identical.

## 🔖 Changes

- `controls.phel`: up/down arrows → `:pitch-up` / `:pitch-down` on every encoding (legacy `^`/`_` stand-ins, kitty-enhanced letters `A`/`B`); removed `t`/`g` from `key->slot` + `ascii->slot`. `w`/`s` move, `←`/`→` turn.
- Updated the in-game help menu, start-menu cheat-sheet, README, `gameplay.md`, `input.md`, and CHANGELOG.
- Controls tests rewritten for the arrow encodings + a guard that `t`/`g` are unbound. `composer ci` green (2357 tests); settings/pause menu arrow-nav unaffected.

Closes #240