### PR TITLE
feat(combat): vertical-aware hitscan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 ### Added
 
 - Look up/down camera pitch (issues #231, #240): the ↑ / ↓ arrow keys tilt the view up / down (hold to keep pitching, clamps at the extremes - no wrap). It is a pure vertical shear of the horizon (no extra rays): walls, the sky/floor split, floor-cast and enemy sprites all slide together by an integer row offset capped at +/-0.4 of the viewport height. `:pitch` is stored on the player as a fraction in [-1, 1]; a level gaze renders byte-for-byte identically to before.
+- Vertical-aware hitscan (issue #243): a shot now has to land on the enemy's drawn sprite, not just its horizontal column, so aiming up at the sky or down at the floor misses. The check is screen-space exact (the fixed crosshair must sit within the billboard the renderer projects at that distance), so closer enemies with taller sprites are more forgiving than distant ones. Aiming level (pitch 0) is unchanged.
 
 ## [0.15.0] - 2026-06-16
 

--- a/docs/combat.md
+++ b/docs/combat.md
@@ -57,9 +57,17 @@ Drops push into `:hearts` / `:armors` / `:ammo-boxes` vectors (same as level spa
 Two-step scan per shot:
 
 1. **Wall ray** along player facing via `cast-ray`, returns distance to first wall.
-2. **Enemy scan**: project each alive enemy onto heading (dot product). Nearest one in front, closer than wall, within max-range, within hit-radius perpendicular = hit. Flip `:alive false`, arm respawn timer (3-6s uniform).
+2. **Enemy scan**: project each alive enemy onto heading (dot product). Nearest one in front, closer than wall, within max-range, within hit-radius perpendicular, AND vertically on the sprite (see below) = hit. Flip `:alive false`, arm respawn timer (3-6s uniform).
 
 On hit: `play-shot-sfx` emits weapon report + kill cue (distance-attenuated). `on-shot-hit` bumps `:kills`, chains streak, pushes blood splatter, arms hit-stop if tough enemy dies, and stamps the crosshair hit-marker (see below).
+
+### Vertical aim gate (look up/down)
+
+With camera pitch (issue #243) the XY cylinder test alone is not enough: a shot would otherwise hit any enemy in the horizontal cone even while the crosshair points at the floor or sky. So each candidate hit is additionally gated on the crosshair being on the enemy's **drawn** billboard.
+
+The crosshair is fixed at screen-centre (`svh/2`). An enemy at distance `d` projects to a sprite of half-height `projection/sprite-half-rows(svh, d, scale)` rows, centred on `svh/2 + pr` where `pr = projection/pitch-rows((:pitch player), svh)` is the pitch shear in scene rows. The crosshair lands on the sprite iff `|pr| <= sprite-half-rows`. The gate (`enemy/vertical-hit?`) wraps the existing perp test in `shoot`, `pierce`, and `spread-shoot` (primary + graze). `sprite-half-rows` mirrors the renderer's billboard height (`min(svh, scale * proj-dist / (max(0.5, d) * char-aspect))`, halved), so the check is screen-space exact: closer enemies (taller sprites) are more forgiving, distant ones demand near-level aim, and the cyberdemon's 2x sprite (`scale`) is correspondingly easier to keep on.
+
+`svh` (scene rows) is supplied by the game loop, which stamps `:scene-rows` on the world from `render/scene-rows` (the same `rows - hud-rows` height the renderer draws). Combat stays pure: `svh`/`pr` are plain ints in. A world without `:scene-rows` (headless / legacy tests) disables the gate, which is identical to level aim (`pr = 0`, `|0| <= half-rows` always), so pitch-0 behaviour is byte-for-byte unchanged. The BFG path (`bfg-fire`) is splash-around-an-impact, not a crosshair hitscan, so it is not gated.
 
 ### Hit-marker (crosshair feedback)
 

--- a/docs/input.md
+++ b/docs/input.md
@@ -34,7 +34,7 @@ Each byte refreshes its slot's counter on `world[:moves]`. Physics only reads th
 
 ## Look up/down (pitch)
 
-Hold **↑** to look up, **↓** to look down. The arrow keys form a camera cluster (←/→ turn, ↑/↓ look) while WASD handles movement. They refresh the `:pitch-up` / `:pitch-down` move slots; physics shears the player's `:pitch` fraction (clamped to [-1, 1], no wrap) via the same counter path as turning. `pitch-hold-frames` = 3 (~50ms), so the camera halts quickly on release like turning rather than gliding. The up/down arrows reach pitch on every encoding: legacy CSI/SS3 (`\e[A`/`\eOA`, normalised to `^`/`_`) and kitty-enhanced (`\e[1;..A`/`B`). The shear is a pure render offset (see [raycaster.md](raycaster.md)); a level gaze (`:pitch` 0) renders identically to no pitch at all.
+Hold **↑** to look up, **↓** to look down. The arrow keys form a camera cluster (←/→ turn, ↑/↓ look) while WASD handles movement. They refresh the `:pitch-up` / `:pitch-down` move slots; physics shears the player's `:pitch` fraction (clamped to [-1, 1], no wrap) via the same counter path as turning. `pitch-hold-frames` = 3 (~50ms), so the camera halts quickly on release like turning rather than gliding. The up/down arrows reach pitch on every encoding: legacy CSI/SS3 (`\e[A`/`\eOA`, normalised to `^`/`_`) and kitty-enhanced (`\e[1;..A`/`B`). The shear is a pure render offset (see [raycaster.md](raycaster.md)); a level gaze (`:pitch` 0) renders identically to no pitch at all. Pitch also drives aim: hitscan is vertical-aware (issue #243), so a shot has to land on the enemy's drawn sprite and aiming at the floor / sky misses (see the vertical aim gate in [combat.md](combat.md)).
 
 ## Sprint
 

--- a/src/commands/play.phel
+++ b/src/commands/play.phel
@@ -29,7 +29,7 @@
   (:require phel-doom.core.format   :refer [accuracy-pct run-grade])
   (:require phel-doom.io.scores   :refer [update-scores!])
   (:require phel-doom.io.render   :refer [render! clear-screen
-                                          read-perf-snapshot
+                                          read-perf-snapshot scene-rows
                                           render-start-menu render-settings!
                                           render-death-screen render-victory-screen])
   (:require phel-doom.io.input    :refer [init-input! restore! drain-keys]))
@@ -1004,7 +1004,13 @@
                   :quit)
 
               :else
-              (let [ticked0 (tick-world world keys (php// ms 1000.0) edges)
+              ;; Stamp the scene height the renderer will use this frame
+              ;; so the vertical hitscan gate (issue #243) projects an
+              ;; enemy billboard against the exact rows the player sees.
+              ;; Same `:debug?`-aware HUD reservation as draw-frame's
+              ;; frame-stats, so the hit check and the draw agree.
+              (let [aimed   (assoc world :scene-rows (scene-rows rows {:debug? (:debug? world)}))
+                    ticked0 (tick-world aimed keys (php// ms 1000.0) edges)
                   ;; Pause overlay (#203): while paused (and not in the H
                   ;; info panel) the navigable pause MENU is up. up/down move
                   ;; the cursor, enter/space selects. Selecting Settings drops

--- a/src/core/combat.phel
+++ b/src/core/combat.phel
@@ -1,7 +1,8 @@
 (ns phel-doom.core.combat
   (:require phel-doom.core.rng :as rng)
-  (:require phel-doom.core.engine   :refer [cast-ray])
-  (:require phel-doom.core.enemy    :refer [push-back-enemy shoot beam-impact splash pierce spread-shoot])
+  (:require phel-doom.core.engine     :refer [cast-ray])
+  (:require phel-doom.core.projection :refer [pitch-rows])
+  (:require phel-doom.core.enemy      :refer [push-back-enemy shoot beam-impact splash pierce spread-shoot])
   (:require phel-doom.core.enemy-ai :refer [attacks? noise-wake])
   (:require phel-doom.core.physics  :refer [try-move])
   (:require phel-doom.core.state    :refer [max-lives])
@@ -548,16 +549,38 @@
   (let [p (:player world)]
     (cast-ray (:pgrid world) (:x p) (:y p) (:angle p))))
 
+(defn- aim-svh
+  "Scene viewport height (rows) the hit gate projects against. The game
+   loop stamps `:scene-rows` each frame from the SAME terminal-derived
+   height the renderer uses, so a hitscan agrees with the drawn sprite.
+   nil when absent (tests / headless callers that never set it), which
+   disables the vertical gate downstream - identical to looking level."
+  [world]
+  (:scene-rows world))
+
+(defn- aim-pr
+  "Camera pitch shear in scene rows for the hit gate: `pitch-rows` of the
+   player's `:pitch` at the scene height `svh`. The fixed screen-centre
+   crosshair sits `pr` rows off the sprite centre, so combat compares
+   `|pr|` against `sprite-half-rows`. 0 when `svh` is nil (no scene to
+   project against) or the player has no pitch - the level-aim default."
+  [world svh]
+  (if (nil? svh)
+    0
+    (pitch-rows (or (:pitch (:player world)) 0.0) svh)))
+
 (defn- resolve-shot [world]
   (let [p         (:player world)
         spec      (w-spec world)
         base-dmg  (or (:damage spec) 1)
         dmg-type  (:damage-type spec)
         dmg       (if (berserk? world) (php/* base-dmg (berserk-mul-for dmg-type)) base-dmg)
-        max-range (or (:max-range spec) shot-max-range)]
+        max-range (or (:max-range spec) shot-max-range)
+        svh       (aim-svh world)]
     (shoot (:enemies world) (:x p) (:y p) (:angle p)
            (cast-wall-dist world)
-           shot-hit-radius max-range dmg dmg-type)))
+           shot-hit-radius max-range dmg dmg-type
+           svh (aim-pr world svh))))
 
 (defn- push-blood-fx
   "Append a blood/death fx at `hit-pos`. On a kill the caller passes the
@@ -979,8 +1002,10 @@
         dmg                        (if (berserk? world) (php/* base (berserk-mul-for dtype)) base)
         max-r                      (or (:max-range spec) shot-max-range)
         wall-d                     (cast-wall-dist world)
+        svh                        (aim-svh world)
         [es' killed hit-pos tough] (pierce (:enemies world) (:x p) (:y p) (:angle p)
-                                           wall-d shot-hit-radius max-r dmg dtype)]
+                                           wall-d shot-hit-radius max-r dmg dtype
+                                           svh (aim-pr world svh))]
     (finish-multikill world es' killed hit-pos tough)))
 
 (defn- spread-fire
@@ -1001,8 +1026,10 @@
         half                       (or (:spread-half-angle spec) shotgun-spread-half-angle)
         max-r                      (or (:max-range spec) shot-max-range)
         wall-d                     (cast-wall-dist world)
+        svh                        (aim-svh world)
         [es' killed hit-pos tough] (spread-shoot (:enemies world) (:x p) (:y p) (:angle p)
-                                                 wall-d half max-r prim graze targets dtype)]
+                                                 wall-d half max-r prim graze targets dtype
+                                                 svh (aim-pr world svh))]
     (finish-multikill world es' killed hit-pos tough)))
 
 (defn- single-hitscan-fire

--- a/src/core/enemy.phel
+++ b/src/core/enemy.phel
@@ -1,8 +1,9 @@
 (ns phel-doom.core.enemy
   (:require phel-doom.core.rng :as rng)
-  (:require phel-doom.core.map      :refer [random-spawn wall?])
-  (:require phel-doom.core.enemies  :refer [resists? default-lives-for])
-  (:require phel-doom.core.enemy-ai :refer [apply-pain maybe-start-attack moves? observe start-wander target-pos tick-attack tick-pain tick-wander]))
+  (:require phel-doom.core.map        :refer [random-spawn wall?])
+  (:require phel-doom.core.enemies    :refer [resists? default-lives-for])
+  (:require phel-doom.core.projection :refer [sprite-half-rows])
+  (:require phel-doom.core.enemy-ai   :refer [apply-pain maybe-start-attack moves? observe start-wander target-pos tick-attack tick-pain tick-wander]))
 
 ;; ---------------------------------------------------------------------
 ;; Enemy BODY: state, lifecycle, and physics. This module owns spawning
@@ -144,6 +145,37 @@
           (assoc enemy :x (first hit) :y (second hit))
           enemy)))))
 
+(def boss-sprite-scale
+  "Vertical billboard scale for the cyberdemon: it towers 2× taller than
+   the standard catalog (matches `frame-math/project-enemy-pd`). The
+   vertical hit gate reads this so a far boss's bigger sprite is the
+   harder-to-miss target the player sees. Everything else renders at
+   native 1× height."
+  2.0)
+
+(defn- sprite-scale-for
+  "Billboard vertical scale of `enemy` for the hit gate: `boss-sprite-scale`
+   for the cyberdemon, else 1.0. Mirrors the renderer's per-type scale so
+   the vertical hitscan check agrees with the drawn sprite (issue #243)."
+  [enemy]
+  (if (php/=== (:type enemy) :cyber) boss-sprite-scale 1.0))
+
+(defn- vertical-hit?
+  "True when the screen-centre crosshair is vertically ON the enemy's
+   billboard. `pr` is the camera's pitch shear in scene rows
+   (`projection/pitch-rows`); the fixed crosshair at `svh/2` lands inside
+   the sprite (centred on `svh/2 + pr`) iff `|pr| <= sprite-half-rows`.
+
+   `svh` nil disables the gate (legacy / test callers that pre-date
+   vertical aim): with no scene height there is nothing to project
+   against, so the call behaves exactly like the old XY-only hitscan -
+   which is also the pitch=0 result (pr=0 => |0| <= half-rows always),
+   keeping every existing combat/enemy test green."
+  [enemy ^float dist svh ^int pr]
+  (or (nil? svh)
+      (php/<= (php/abs pr)
+              (sprite-half-rows svh dist (sprite-scale-for enemy)))))
+
 (defn shoot
   "Fire a hitscan from the player along their facing. Returns
    `[new-enemies hit? hit-pos idx]`: the nearest alive enemy in
@@ -151,10 +183,19 @@
    flips to false once `:lives` hits zero, so a 1-damage pistol
    round just wounds a 3-HP cacodemon while a 3-damage shotgun
    shell drops it. `damage` defaults to 1 for callers that don't
-   carry a weapon spec (older tests, etc)."
-  ([enemies ^float px ^float py ^float angle ^float wall-dist ^float hit-radius ^float max-range]
-   (shoot enemies px py angle wall-dist hit-radius max-range 1 nil))
-  ([es' ^float x' ^float y' ^float a' ^float wd' ^float hr ^float max-r ^int damage damage-type]
+   carry a weapon spec (older tests, etc).
+
+   `svh` (scene rows) + `pr` (`projection/pitch-rows` of the camera
+   pitch, scene rows) add the vertical aim gate (issue #243): a hit must
+   land on the enemy's drawn billboard, not just its XY column, so aiming
+   at the floor / sky misses. `svh` nil (the short arities) disables the
+   gate, which is identical to looking level (pr=0) - so legacy callers
+   and pitch=0 stay byte-for-byte unchanged."
+  ([es0 ^float px0 ^float py0 ^float a0 ^float wd0 ^float hr0 ^float mr0]
+   (shoot es0 px0 py0 a0 wd0 hr0 mr0 1 nil nil 0))
+  ([es1 ^float px1 ^float py1 ^float a1 ^float wd1 ^float hr1 ^float mr1 ^int dmg1 dtype1]
+   (shoot es1 px1 py1 a1 wd1 hr1 mr1 dmg1 dtype1 nil 0))
+  ([es' ^float x' ^float y' ^float a' ^float wd' ^float hr ^float max-r ^int damage damage-type svh ^int pr]
    (let [cos-a (php/cos a')
          sin-a (php/sin a')]
      (let [best (loop [i      0
@@ -169,7 +210,8 @@
                                           dy (php/- (:y e) y')]
                                       (let [proj (php/+ (php/* dx cos-a) (php/* dy sin-a))]
                                         (when (and (php/> proj 0.0) (php/< proj best-d)
-                                                   (php/< proj wd'))
+                                                   (php/< proj wd')
+                                                   (vertical-hit? e proj svh pr))
                                           (let [perp-x (php/- dx (php/* proj cos-a))
                                                 perp-y (php/- dy (php/* proj sin-a))]
                                             (let [perp2 (php/+ (php/* perp-x perp-x) (php/* perp-y perp-y))]
@@ -284,43 +326,51 @@
    and `kill-toughness` is the largest `:max-lives` among enemies killed
    this shot (0 if none) so the caller can size hit-stop per the meatiest
    kill. Survivors wake (`:aware`) + take a hit-flash; no pain roll
-   (mirrors `splash`). Pure."
-  [enemies ^float px ^float py ^float angle ^float wall-dist ^float hit-radius ^float max-range ^int damage damage-type]
-  (let [cos-a (php/cos angle)
-        sin-a (php/sin angle)
-        cap   (php/min wall-dist max-range)
-        hr2   (php/* hit-radius hit-radius)]
-    (loop [i 0 acc [] killed 0 best-d cap hit-pos nil tough 0]
-      (if (php/>= i (count enemies))
-        [acc killed hit-pos tough]
-        (let [e     (get enemies i)
-              dx    (php/- (:x e) px)
-              dy    (php/- (:y e) py)
-              proj  (php/+ (php/* dx cos-a) (php/* dy sin-a))
-              perpx (php/- dx (php/* proj cos-a))
-              perpy (php/- dy (php/* proj sin-a))
-              in?   (and (:alive e)
-                         (php/> proj 0.0)
-                         (php/< proj cap)
-                         (php/<= (php/+ (php/* perpx perpx) (php/* perpy perpy)) hr2))]
-          (if (not in?)
-            (recur (php/+ i 1) (conj acc e) killed best-d hit-pos tough)
-            (let [eff     (if (resists? (:type e) damage-type) 0 damage)
-                  lives   (php/max 0 (php/- (or (:lives e) 1) eff))
-                  woke    (assoc e :state :aware :lives lives)
-                  closer? (php/< proj best-d)
-                  hp'     (if closer? {:x (:x e) :y (:y e)} hit-pos)
-                  bd'     (if closer? proj best-d)]
-              (if (php/<= lives 0)
-                (recur (php/+ i 1)
-                       (conj acc (assoc woke
-                                        :alive false
-                                        :respawn-after (respawn-delay-for e)))
-                       (php/+ killed 1) bd' hp'
-                       (php/max tough (or (:max-lives e) 1)))
-                (recur (php/+ i 1)
-                       (conj acc (assoc woke :hit-flash-secs hit-flash-seconds))
-                       killed bd' hp' tough)))))))))
+   (mirrors `splash`). Pure.
+
+   `svh` + `pr` add the same vertical aim gate as `shoot` (issue #243):
+   only enemies whose drawn billboard the screen-centre crosshair sits on
+   are pierced. `svh` nil (the 9-arity form) disables the gate, matching
+   the old XY-only behaviour and the pitch=0 result."
+  ([es0 ^float px0 ^float py0 ^float a0 ^float wd0 ^float hr0 ^float mr0 ^int dmg0 dtype0]
+   (pierce es0 px0 py0 a0 wd0 hr0 mr0 dmg0 dtype0 nil 0))
+  ([enemies ^float px ^float py ^float angle ^float wall-dist ^float hit-radius ^float max-range ^int damage damage-type svh ^int pr]
+   (let [cos-a (php/cos angle)
+         sin-a (php/sin angle)
+         cap   (php/min wall-dist max-range)
+         hr2   (php/* hit-radius hit-radius)]
+     (loop [i 0 acc [] killed 0 best-d cap hit-pos nil tough 0]
+       (if (php/>= i (count enemies))
+         [acc killed hit-pos tough]
+         (let [e     (get enemies i)
+               dx    (php/- (:x e) px)
+               dy    (php/- (:y e) py)
+               proj  (php/+ (php/* dx cos-a) (php/* dy sin-a))
+               perpx (php/- dx (php/* proj cos-a))
+               perpy (php/- dy (php/* proj sin-a))
+               in?   (and (:alive e)
+                          (php/> proj 0.0)
+                          (php/< proj cap)
+                          (vertical-hit? e proj svh pr)
+                          (php/<= (php/+ (php/* perpx perpx) (php/* perpy perpy)) hr2))]
+           (if (not in?)
+             (recur (php/+ i 1) (conj acc e) killed best-d hit-pos tough)
+             (let [eff     (if (resists? (:type e) damage-type) 0 damage)
+                   lives   (php/max 0 (php/- (or (:lives e) 1) eff))
+                   woke    (assoc e :state :aware :lives lives)
+                   closer? (php/< proj best-d)
+                   hp'     (if closer? {:x (:x e) :y (:y e)} hit-pos)
+                   bd'     (if closer? proj best-d)]
+               (if (php/<= lives 0)
+                 (recur (php/+ i 1)
+                        (conj acc (assoc woke
+                                         :alive false
+                                         :respawn-after (respawn-delay-for e)))
+                        (php/+ killed 1) bd' hp'
+                        (php/max tough (or (:max-lives e) 1)))
+                 (recur (php/+ i 1)
+                        (conj acc (assoc woke :hit-flash-secs hit-flash-seconds))
+                        killed bd' hp' tough))))))))))
 
 (defn- in-cone?
   "True when the enemy offset `(dx, dy)` lies in front of the player
@@ -341,56 +391,71 @@
    are grazed for the smaller `graze-dmg`. Distinct from the single big
    hit of `shoot` - the shotgun becomes a crowd weapon. Returns
    `[new-enemies killed-count hit-pos kill-toughness]` like `pierce`,
-   where `hit-pos` is the primary target (blood + sfx)."
-  [enemies ^float px ^float py ^float angle ^float wall-dist ^float half-angle ^float max-range ^int primary-dmg ^int graze-dmg ^int max-targets damage-type]
-  (let [cos-a    (php/cos angle)
-        sin-a    (php/sin angle)
-        cos-half (php/cos half-angle)
-        cap      (php/min wall-dist max-range)
-        primary  (loop [i 0 best -1 best-d cap]
-                   (if (php/>= i (count enemies))
-                     best
-                     (let [e (get enemies i)]
-                       (if (not (:alive e))
-                         (recur (php/+ i 1) best best-d)
-                         (let [dx   (php/- (:x e) px)
-                               dy   (php/- (:y e) py)
-                               proj (php/+ (php/* dx cos-a) (php/* dy sin-a))]
-                           (if (and (php/< proj best-d)
-                                    (in-cone? dx dy cos-a sin-a cos-half cap))
-                             (recur (php/+ i 1) i proj)
-                             (recur (php/+ i 1) best best-d)))))))]
-    (if (php/< primary 0)
-      [enemies 0 nil 0]
-      (loop [i 0 acc [] killed 0 tough 0 grazed 0 hit-pos nil]
-        (if (php/>= i (count enemies))
-          [acc killed hit-pos tough]
-          (let [e (get enemies i)]
-            (if (not (:alive e))
-              (recur (php/+ i 1) (conj acc e) killed tough grazed hit-pos)
-              (let [dx       (php/- (:x e) px)
-                    dy       (php/- (:y e) py)
-                    primary? (php/=== i primary)
-                    graze?   (and (not primary?)
-                                  (php/< grazed (php/- max-targets 1))
-                                  (in-cone? dx dy cos-a sin-a cos-half cap))
-                    dmg      (cond primary? primary-dmg graze? graze-dmg :else 0)]
-                (if (php/<= dmg 0)
-                  (recur (php/+ i 1) (conj acc e) killed tough grazed hit-pos)
-                  (let [eff     (if (resists? (:type e) damage-type) 0 dmg)
-                        lives   (php/max 0 (php/- (or (:lives e) 1) eff))
-                        woke    (assoc e :state :aware :lives lives)
-                        hp'     (if primary? {:x (:x e) :y (:y e)} hit-pos)
-                        grazed' (if graze? (php/+ grazed 1) grazed)]
-                    (if (php/<= lives 0)
-                      (recur (php/+ i 1)
-                             (conj acc (assoc woke
-                                              :alive false
-                                              :respawn-after (respawn-delay-for e)))
-                             (php/+ killed 1) (php/max tough (or (:max-lives e) 1)) grazed' hp')
-                      (recur (php/+ i 1)
-                             (conj acc (assoc woke :hit-flash-secs hit-flash-seconds))
-                             killed tough grazed' hp'))))))))))))
+   where `hit-pos` is the primary target (blood + sfx).
+
+   `svh` + `pr` add the same vertical aim gate as `shoot` (issue #243):
+   an enemy must be drawn under the screen-centre crosshair to be the
+   primary OR a graze, so a shot fired at the floor / sky whiffs the
+   whole cone. `svh` nil (the 12-arity form) disables the gate, matching
+   the old cone-only behaviour and the pitch=0 result."
+  ([es0 ^float px0 ^float py0 ^float a0 ^float wd0 ^float ha0 ^float mr0 ^int pdmg0 ^int gdmg0 ^int mt0 dtype0]
+   (spread-shoot es0 px0 py0 a0 wd0 ha0 mr0 pdmg0 gdmg0 mt0 dtype0 nil 0))
+  ([enemies ^float px ^float py ^float angle ^float wall-dist ^float half-angle ^float max-range ^int primary-dmg ^int graze-dmg ^int max-targets damage-type svh ^int pr]
+   (let [cos-a    (php/cos angle)
+         sin-a    (php/sin angle)
+         cos-half (php/cos half-angle)
+         cap      (php/min wall-dist max-range)
+         ;; In-cone AND vertically on the billboard. `proj` is the forward
+         ;; (perpendicular) distance, which is the depth the sprite path
+         ;; projects against, so it doubles as the gate's `dist`.
+         in-shot? (fn [e ^float dx ^float dy ^float proj]
+                    (and (in-cone? dx dy cos-a sin-a cos-half cap)
+                         (vertical-hit? e proj svh pr)))
+         primary  (loop [i 0 best -1 best-d cap]
+                    (if (php/>= i (count enemies))
+                      best
+                      (let [e (get enemies i)]
+                        (if (not (:alive e))
+                          (recur (php/+ i 1) best best-d)
+                          (let [dx   (php/- (:x e) px)
+                                dy   (php/- (:y e) py)
+                                proj (php/+ (php/* dx cos-a) (php/* dy sin-a))]
+                            (if (and (php/< proj best-d)
+                                     (in-shot? e dx dy proj))
+                              (recur (php/+ i 1) i proj)
+                              (recur (php/+ i 1) best best-d)))))))]
+     (if (php/< primary 0)
+       [enemies 0 nil 0]
+       (loop [i 0 acc [] killed 0 tough 0 grazed 0 hit-pos nil]
+         (if (php/>= i (count enemies))
+           [acc killed hit-pos tough]
+           (let [e (get enemies i)]
+             (if (not (:alive e))
+               (recur (php/+ i 1) (conj acc e) killed tough grazed hit-pos)
+               (let [dx       (php/- (:x e) px)
+                     dy       (php/- (:y e) py)
+                     proj     (php/+ (php/* dx cos-a) (php/* dy sin-a))
+                     primary? (php/=== i primary)
+                     graze?   (and (not primary?)
+                                   (php/< grazed (php/- max-targets 1))
+                                   (in-shot? e dx dy proj))
+                     dmg      (cond primary? primary-dmg graze? graze-dmg :else 0)]
+                 (if (php/<= dmg 0)
+                   (recur (php/+ i 1) (conj acc e) killed tough grazed hit-pos)
+                   (let [eff     (if (resists? (:type e) damage-type) 0 dmg)
+                         lives   (php/max 0 (php/- (or (:lives e) 1) eff))
+                         woke    (assoc e :state :aware :lives lives)
+                         hp'     (if primary? {:x (:x e) :y (:y e)} hit-pos)
+                         grazed' (if graze? (php/+ grazed 1) grazed)]
+                     (if (php/<= lives 0)
+                       (recur (php/+ i 1)
+                              (conj acc (assoc woke
+                                               :alive false
+                                               :respawn-after (respawn-delay-for e)))
+                              (php/+ killed 1) (php/max tough (or (:max-lives e) 1)) grazed' hp')
+                       (recur (php/+ i 1)
+                              (conj acc (assoc woke :hit-flash-secs hit-flash-seconds))
+                              killed tough grazed' hp')))))))))))))
 
 (defn push-back-enemy
   "Shove the enemy at `idx` along `(cos-a, sin-a)` by `dist` world

--- a/src/core/projection.phel
+++ b/src/core/projection.phel
@@ -1,4 +1,5 @@
-(ns phel-doom.core.projection)
+(ns phel-doom.core.projection
+  (:require phel-doom.core.engine :refer [proj-dist]))
 
 ;; ---------------------------------------------------------------------
 ;; Pure vertical-projection kernel. Maps a world height + perpendicular
@@ -73,3 +74,27 @@
      (pitch-rows -1.0 30); => -12 (full look-down, horizon up 12 rows)"
   [^float pitch ^int vh]
   (php/intval (php/round (php/* pitch (php/* pitch-cap vh)))))
+
+(defn sprite-half-rows
+  {:doc "Half the on-screen height (rows) of an enemy billboard at
+         perpendicular distance `dist` in a scene `svh` rows tall, scaled
+         by `scale` (1.0 for standard enemies, 2.0 for the cyberdemon
+         boss). This is HALF the rendered sprite extent, centred on the
+         horizon, so it answers 'how far up/down can the screen-centre
+         crosshair stray and still be on the body'.
+
+         Mirrors the renderer's billboard height exactly:
+         `h = min(svh, intval(scale * proj-dist / (max(0.5, dist) *
+         char-aspect)))`, then `h/2`. The 0.5 distance floor and the
+         `svh` clamp match the sprite path so the vertical hit gate in
+         combat agrees with the pixels drawn (issue #243). Returned as a
+         float so the gate compares `|pitch-rows|` against it without an
+         off-by-one truncation."
+   :see-also ["pitch-rows" "wall-px"]
+   :example "(sprite-half-rows 30 4.0 1.0) ; => 4.0 (proj-dist 70 / (4*2) = 8.75 -> 8 -> /2)"}
+  [^int svh ^float dist ^float scale]
+  (php// (php/min svh
+                  (php/intval (php/* scale
+                                     (php// proj-dist
+                                            (php/* (php/max 0.5 dist) char-aspect)))))
+         2.0))

--- a/src/io/render.phel
+++ b/src/io/render.phel
@@ -24,6 +24,7 @@
 (def direction-char phel-doom.io.render.frame-math/direction-char)
 (def project-enemy phel-doom.io.render.frame-math/project-enemy)
 (def enemy-front-visible-at? phel-doom.io.render.frame-math/enemy-front-visible-at?)
+(def scene-rows phel-doom.io.render.frame-math/scene-rows)
 
 ;; --- paint: reload reminder + blood columns (used by tests)
 (def reload-reminder-visible? phel-doom.io.render.paint/reload-reminder-visible?)

--- a/src/io/render/frame_math.phel
+++ b/src/io/render/frame_math.phel
@@ -14,6 +14,17 @@
   [stats]
   (if (get stats :debug?) 2 base-hud-rows))
 
+(defn scene-rows
+  "Full-detail scene viewport height (rows) for a terminal `rows` tall
+   with HUD `stats`: the same `:vh` the renderer derives in `layout`
+   (`rows - hud-rows`). The game loop stamps this on the world as
+   `:scene-rows` so the vertical hitscan gate (issue #243) projects an
+   enemy billboard against the exact height the player sees. Full detail
+   on purpose: the pixel-doubled downscale is a perf knob and must not
+   change where shots land."
+  [^int rows stats]
+  (php/- rows (hud-rows-for stats)))
+
 (defn- fade-256
   "Darken a 256-color code by factor `t` in [0.0, 1.0]. Handles the
    6×6×6 cube (16-231) by scaling each RGB component, and the 24-step

--- a/tests/core/combat-test.phel
+++ b/tests/core/combat-test.phel
@@ -445,6 +445,78 @@
   ;; identical to the old XY-only hitscan. Guards the regression contract.
   (is (= 1 (shoot-with-pitch 9.5 1.0 nil)) "no scene height => vertical gate off"))
 
+;; The gate has to hold on the MULTI-target combat paths too, not just the
+;; single-scan chaingun: the pistol routes through `pierce-fire` (pierce)
+;; and the shotgun through `spread-fire` (spread-shoot, primary + graze).
+;; These fire the real weapons through `tick-shooting` so the whole
+;; combat path (spec lookup -> svh/pr threading -> enemy gate) is covered.
+
+(defn- fire-weapon-with-pitch
+  ;; Fire `weapon` (with `owned` so its ammo path is valid) once down the
+  ;; corridor at `enemies`, with the player's look `pitch` and scene height
+  ;; `svh`. Returns {:kills N :alive [bools]} after the trigger pull.
+  [weapon owned pitch svh enemies]
+  (let [base (new-world corridor-grid (assoc (new-player 1.5 1.5 0.0) :pitch pitch))
+        w    (assoc base
+                    :scene-rows    svh
+                    :weapon        weapon
+                    :owned-weapons owned
+                    :mag           30
+                    :ammo-reserve  10
+                    :fire-cooldown 0.0
+                    :reload-cooldown 0.0
+                    :jam-secs      0.0
+                    :iframes       0.0
+                    :enemies       enemies)
+        w'   (tick-shooting w true)]
+    {:kills (or (:kills w') 0)
+     :alive (apply vector (map (fn [e] (:alive e)) (:enemies w')))}))
+
+(deftest test-vertical-pierce-level-aim-hits-both
+  ;; Pistol (pierce): two 1-HP enemies in a line at d=2 and d=8. Level aim
+  ;; passes the round through both -> 2 kills, exactly the pre-#243 result.
+  (let [r (fire-weapon-with-pitch :pistol #{:pistol} 0.0 30
+                                  [(new-enemy 3.5 1.5 1) (new-enemy 9.5 1.5 1)])]
+    (is (= 2 (:kills r)) "level pierce drops both")
+    (is (= [false false] (:alive r)) "both enemies dead")))
+
+(deftest test-vertical-pierce-steep-pitch-spares-far
+  ;; Same pistol line at pitch 0.5 (pr=6): the near enemy (d=2, half-rows
+  ;; 8.5) is on the body, the far one (d=8, half-rows 2.0) is above the
+  ;; crosshair -> only the near is pierced, the far survives. The XY-only
+  ;; gate would have killed both.
+  (let [r (fire-weapon-with-pitch :pistol #{:pistol} 0.5 30
+                                  [(new-enemy 3.5 1.5 1) (new-enemy 9.5 1.5 1)])]
+    (is (= 1 (:kills r)) "steep aim pierces only the near enemy")
+    (is (= [false true] (:alive r)) "near dead, far spared by the vertical gate")))
+
+(deftest test-vertical-spread-level-aim-hits-primary-and-graze
+  ;; Shotgun (spread): a near primary on the axis (d=2) plus a graze target
+  ;; in the cone but farther (~d=7, slightly off-axis). Level aim drops the
+  ;; primary AND the graze -> 2 kills.
+  (let [r (fire-weapon-with-pitch :shotgun #{:shotgun} 0.0 30
+                                  [(new-enemy 3.5 1.5 1) (new-enemy 8.5 1.9 1)])]
+    (is (= 2 (:kills r)) "level shotgun drops primary + graze")
+    (is (= [false false] (:alive r)) "both enemies dead")))
+
+(deftest test-vertical-spread-steep-pitch-drops-graze-target
+  ;; Same shotgun shot at pitch 0.5 (pr=6): the near primary (d=2, half-rows
+  ;; 8.5) stays on the body, but the far graze target (~d=7, half-rows 2.5)
+  ;; slips under the crosshair, so the graze whiffs -> 1 kill. Proves the
+  ;; gate applies to graze targets, not just the primary.
+  (let [r (fire-weapon-with-pitch :shotgun #{:shotgun} 0.5 30
+                                  [(new-enemy 3.5 1.5 1) (new-enemy 8.5 1.9 1)])]
+    (is (= 1 (:kills r)) "steep aim drops only the primary, graze whiffs")
+    (is (= [false true] (:alive r)) "primary dead, far graze target spared")))
+
+(deftest test-vertical-spread-aim-down-also-drops-graze
+  ;; Symmetric (|pr|): looking DOWN at the floor (pitch -0.5, pr=-6) clears
+  ;; the far graze target the same way looking up does.
+  (let [r (fire-weapon-with-pitch :shotgun #{:shotgun} -0.5 30
+                                  [(new-enemy 3.5 1.5 1) (new-enemy 8.5 1.9 1)])]
+    (is (= 1 (:kills r)) "aiming down also whiffs the far graze")
+    (is (= [false true] (:alive r)) "primary dead, graze target spared")))
+
 (deftest test-tick-shooting-empty-mag-skip-when-jammed
   ;; Jam already has its own visual cue (paint-door-face / fire-anim).
   ;; Suppress the click so we don't double up.

--- a/tests/core/combat-test.phel
+++ b/tests/core/combat-test.phel
@@ -382,6 +382,69 @@
     (is (php/< (:ttl (:hit-fx w1)) 0.1) "ttl decays")
     (is (nil? (:hit-fx w2)) "cleared once ttl runs out")))
 
+;; ---------------------------------------------------------------------
+;; Vertical-aware hitscan (issue #243): a shot must land on the enemy's
+;; drawn billboard, not just its XY column. The loop stamps `:scene-rows`
+;; (scene height) so the gate projects the sprite; the screen-centre
+;; crosshair is `projection/pitch-rows((:pitch player) svh)` rows off the
+;; sprite centre. Closer enemies project a taller sprite, so the same
+;; pitch is more forgiving up close.
+;; ---------------------------------------------------------------------
+
+(defn- shoot-with-pitch
+  ;; Fire the chaingun (single-target hitscan path) once down the corridor
+  ;; at a 1-HP enemy `enemy-x` cells along the axis, with the player's look
+  ;; `pitch` and the renderer-supplied scene height `svh`. Returns the
+  ;; resulting :kills (1 = the gate let the shot land and dropped it,
+  ;; 0 = the crosshair was off the sprite).
+  [enemy-x pitch svh]
+  (let [base (new-world corridor-grid (assoc (new-player 1.5 1.5 0.0) :pitch pitch))
+        w    (assoc base
+                    :scene-rows    svh
+                    :weapon        :chaingun
+                    :owned-weapons #{:chaingun}
+                    :mag           30
+                    :ammo-reserve  10
+                    :fire-cooldown 0.0
+                    :reload-cooldown 0.0
+                    :jam-secs      0.0
+                    :iframes       0.0
+                    :enemies       [(new-enemy enemy-x 1.5 1)])]
+    (or (:kills (tick-shooting w true)) 0)))
+
+(deftest test-vertical-hitscan-level-aim-hits
+  ;; Pitch 0 (crosshair on the horizon): both a near and a far enemy on
+  ;; the axis are hit, exactly like the pre-#243 XY-only hitscan.
+  (is (= 1 (shoot-with-pitch 3.5 0.0 30)) "near body hit at level aim")
+  (is (= 1 (shoot-with-pitch 9.5 0.0 30)) "far body hit at level aim"))
+
+(deftest test-vertical-hitscan-pitch-misses-far-but-hits-near
+  ;; Look up by 0.5 (pr = round(0.5 * 0.4 * 30) = 6 scene rows). The far
+  ;; enemy (d=8) projects a short sprite (half-rows 2.0) so the crosshair
+  ;; clears its head -> miss; the near enemy (d=2) projects a tall sprite
+  ;; (half-rows 8.5) the crosshair still sits on -> hit.
+  (is (= 0 (shoot-with-pitch 9.5 0.5 30)) "distant enemy missed when aiming up")
+  (is (= 1 (shoot-with-pitch 3.5 0.5 30)) "close enemy still hit at the same pitch"))
+
+(deftest test-vertical-hitscan-closer-is-more-forgiving
+  ;; Steeper look-up (pitch 0.7, pr = round(0.7 * 0.4 * 30) = 8). A point-
+  ;; blank enemy (d=1, half-rows 17.5) is still on the body; a mid enemy
+  ;; (d=4, half-rows ~4) is already off it. Closer = harder to miss.
+  (is (= 1 (shoot-with-pitch 2.5 0.7 30)) "point-blank enemy hit even at a steep pitch")
+  (is (= 0 (shoot-with-pitch 5.5 0.7 30)) "mid-range enemy missed at the same steep pitch"))
+
+(deftest test-vertical-hitscan-aim-down-also-misses
+  ;; Symmetric: looking DOWN at the floor (pitch -0.5, pr = -6) overshoots
+  ;; the far enemy the same way looking up does. The gate uses |pr|.
+  (is (= 0 (shoot-with-pitch 9.5 -0.5 30)) "distant enemy missed when aiming at the floor")
+  (is (= 1 (shoot-with-pitch 3.5 -0.5 30)) "close enemy still hit aiming down"))
+
+(deftest test-vertical-hitscan-no-scene-rows-keeps-xy-only
+  ;; A world without :scene-rows (headless / pre-#243 caller) disables the
+  ;; gate: a steep pitch that WOULD miss with a scene height still lands,
+  ;; identical to the old XY-only hitscan. Guards the regression contract.
+  (is (= 1 (shoot-with-pitch 9.5 1.0 nil)) "no scene height => vertical gate off"))
+
 (deftest test-tick-shooting-empty-mag-skip-when-jammed
   ;; Jam already has its own visual cue (paint-door-face / fire-anim).
   ;; Suppress the click so we don't double up.

--- a/tests/core/enemy-test.phel
+++ b/tests/core/enemy-test.phel
@@ -104,6 +104,50 @@
   (let [[_ hit?] (shoot [(new-enemy 1.5 4.0)] 1.5 1.5 0.0 10.0 0.5 12.0)]
     (is (= false hit?))))
 
+;; Vertical aim gate (issue #243): the 11-arity `shoot` (and the
+;; matching `pierce` / `spread-shoot` arities) take `svh` (scene rows) +
+;; `pr` (horizon shear in scene rows). A hit must land on the enemy's
+;; drawn billboard. svh=30, pr=6 mimics looking up ~0.5: a far enemy
+;; (d=8, sprite half-rows 2.0) is cleared, a near one (d=2, half-rows
+;; 8.5) is still on the body. pr=0 leaves both hittable.
+
+(deftest test-shoot-vertical-gate-level-aim-hits
+  ;; pr=0: the gate is a no-op, both near and far enemies on the axis hit.
+  (let [[_ near?] (shoot [(new-enemy 3.5 1.5)] 1.5 1.5 0.0 10.0 0.5 12.0 1 nil 30 0)
+        [_ far?]  (shoot [(new-enemy 9.5 1.5)] 1.5 1.5 0.0 10.0 0.5 12.0 1 nil 30 0)]
+    (is (= true near?) "near body hit at level aim")
+    (is (= true far?) "far body hit at level aim")))
+
+(deftest test-shoot-vertical-gate-pitch-misses-far
+  ;; pr=6 (look up): the distant enemy's short sprite slips under the
+  ;; crosshair -> miss, while the close enemy's tall sprite still catches.
+  (let [[_ far?]  (shoot [(new-enemy 9.5 1.5)] 1.5 1.5 0.0 10.0 0.5 12.0 1 nil 30 6)
+        [_ near?] (shoot [(new-enemy 3.5 1.5)] 1.5 1.5 0.0 10.0 0.5 12.0 1 nil 30 6)]
+    (is (= false far?) "distant enemy missed when aiming up")
+    (is (= true near?) "close enemy still hit at the same pitch")))
+
+(deftest test-pierce-vertical-gate-skips-off-aim-enemy
+  ;; A pierce shot at pr=6 down a line of two enemies: the near one is on
+  ;; the body (killed), the far one is above the crosshair (untouched), so
+  ;; only one kill instead of the two a level shot would rack up.
+  (let [enemies          [(new-enemy 3.5 1.5 1) (new-enemy 9.5 1.5 1)]
+        [_ killed-level] (pierce enemies 1.5 1.5 0.0 12.0 0.5 12.0 1 nil 30 0)
+        [es' killed-up]  (pierce enemies 1.5 1.5 0.0 12.0 0.5 12.0 1 nil 30 6)]
+    (is (= 2 killed-level) "level aim pierces both")
+    (is (= 1 killed-up) "steep aim only drops the near enemy")
+    (is (= false (:alive (get es' 0))) "near enemy killed")
+    (is (= true (:alive (get es' 1))) "far enemy spared by the vertical gate")))
+
+(deftest test-spread-shoot-vertical-gate-whiffs-far-cone
+  ;; The shotgun cone at pr=6 onto a far enemy (d=8): it is in the cone
+  ;; but under the crosshair vertically, so the cone whiffs (0 kills),
+  ;; whereas a level shot drops it.
+  (let [enemies          [(new-enemy 9.5 1.5 1)]
+        [_ killed-level] (spread-shoot enemies 1.5 1.5 0.0 12.0 0.30 12.0 3 1 3 nil 30 0)
+        [_ killed-up]    (spread-shoot enemies 1.5 1.5 0.0 12.0 0.30 12.0 3 1 3 nil 30 6)]
+    (is (= 1 killed-level) "level shotgun blast hits the far enemy")
+    (is (= 0 killed-up) "aiming up whiffs the whole cone on a distant enemy")))
+
 (deftest test-shoot-empty-list-returns-miss
   (let [[es' hit? hit-pos idx] (shoot [] 1.5 1.5 0.0 10.0 0.5 12.0)]
     (is (= false hit?))

--- a/tests/core/projection-test.phel
+++ b/tests/core/projection-test.phel
@@ -1,6 +1,6 @@
 (ns phel-doom-tests.core.projection-test
   (:require phel.test :refer [deftest is])
-  (:require phel-doom.core.projection :refer [wall-px project-height pitch-rows pitch-cap]))
+  (:require phel-doom.core.projection :refer [wall-px project-height pitch-rows pitch-cap sprite-half-rows]))
 
 ;; ---------------------------------------------------------------------
 ;; wall-px: the shared projection kernel. num / ((max 0.3 dist) * 2.0).
@@ -104,3 +104,54 @@
   ;; index gradient arrays / add to integer wall tops cleanly.
   (is (php/is_int (pitch-rows 0.37 30)))
   (is (php/is_int (pitch-rows -0.81 44))))
+
+;; ---------------------------------------------------------------------
+;; sprite-half-rows: half the on-screen billboard height (rows) the
+;; vertical hitscan gate (issue #243) compares against |pitch-rows|.
+;; Mirrors the renderer's sprite height exactly:
+;;   h = min(svh, intval(scale * proj-dist / (max(0.5, dist) * char-aspect)))
+;; with proj-dist = 70, char-aspect = 2; the helper returns h / 2.
+;; ---------------------------------------------------------------------
+
+(deftest sprite-half-rows-clamped-near
+  ;; Very close (dist below the 0.5 floor): raw height
+  ;; 70 / (0.5 * 2) = 70, clamped to svh=30, halved => 15.0.
+  (is (= 15.0 (sprite-half-rows 30 0.25 1.0))))
+
+(deftest sprite-half-rows-distant-shrinks
+  ;; Far enemy: 70 / (10 * 2) = 3.5 -> intval 3 -> /2 = 1.5. A distant
+  ;; sprite leaves the crosshair almost no vertical slack.
+  (is (= 1.5 (sprite-half-rows 30 10.0 1.0))))
+
+(deftest sprite-half-rows-closer-is-more-forgiving
+  ;; Monotonic: a nearer enemy always projects at least as many rows as a
+  ;; farther one, so the gate is strictly more forgiving up close.
+  (is (php/>= (sprite-half-rows 30 2.0 1.0)
+              (sprite-half-rows 30 8.0 1.0))))
+
+(deftest sprite-half-rows-boss-scale-bigger
+  ;; The 2x boss billboard is taller than a standard enemy at the same
+  ;; depth, so its half-height (hence its vertical slack) is larger.
+  (is (php/> (sprite-half-rows 30 10.0 2.0)
+             (sprite-half-rows 30 10.0 1.0))))
+
+(deftest sprite-half-rows-boss-far-value
+  ;; 2 * 70 / (10 * 2) = 7 -> intval 7 -> /2 = 3.5.
+  (is (= 3.5 (sprite-half-rows 30 10.0 2.0))))
+
+(deftest sprite-half-rows-capped-by-svh
+  ;; The height never exceeds svh, so the half-rows never exceeds svh/2
+  ;; even at point-blank range with the boss scale.
+  (is (= 7.5 (sprite-half-rows 15 0.5 2.0))))
+
+(deftest sprite-half-rows-full-pitch-still-on-near-sprite
+  ;; svh 30: full look-up shears the horizon 12 rows; a point-blank
+  ;; sprite (half-rows 15) still spans the crosshair (|12| <= 15).
+  (is (php/<= (php/abs (pitch-rows 1.0 30))
+              (sprite-half-rows 30 0.5 1.0))))
+
+(deftest sprite-half-rows-full-pitch-misses-far-sprite
+  ;; Same full pitch (12 rows) overshoots a distant sprite (half-rows
+  ;; 1.5): the crosshair points at the floor/sky, not the body.
+  (is (php/> (php/abs (pitch-rows 1.0 30))
+             (sprite-half-rows 30 10.0 1.0))))


### PR DESCRIPTION
## 📚 Description

Look up/down (#231) added vertical aim, but hitscan still used a 2D XY cylinder test, so a shot hit any enemy in the horizontal cone even while the crosshair pointed at the floor or sky. Now a shot must land on the enemy's drawn sprite.

## 🔖 Changes

- `projection/sprite-half-rows`: pure helper mirroring the renderer's billboard height (half-extent), with unit tests.
- `shoot`/`pierce`/`spread-shoot` gate each XY hit on `|pitch-rows| <= sprite-half-rows` (closer = more forgiving; boss 2x sprite easier to hit). BFG splash unchanged.
- The play loop stamps `:scene-rows` (same height the renderer draws, via `render/scene-rows`) and threads `svh` + `pr` as ints; core stays pure.
- `svh` nil disables the gate = identical to pitch 0, so all existing tests stay green (2384 pass).
- New pure tests for the gate; CHANGELOG + docs/combat.md + docs/input.md updated.

Closes #243