### PR TITLE
fix(render): pitch-anchor pickups, projectiles & blood

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 
 - Look up/down camera pitch (issues #231, #240): the ↑ / ↓ arrow keys tilt the view up / down (hold to keep pitching, clamps at the extremes - no wrap). It is a pure vertical shear of the horizon (no extra rays): walls, the sky/floor split, floor-cast and enemy sprites all slide together by an integer row offset capped at +/-0.4 of the viewport height. `:pitch` is stored on the player as a fraction in [-1, 1]; a level gaze renders byte-for-byte identically to before.
 
+### Fixed
+
+- Pickups, projectiles, tracers and blood splats now shear with the horizon when looking up/down (issue #242): previously they stayed pinned to the level-gaze horizon and floated while the walls, floor and enemies pitched. A level gaze renders unchanged.
+
 ## [0.15.0] - 2026-06-16
 
 ### Added

--- a/src/io/render/paint.phel
+++ b/src/io/render/paint.phel
@@ -8,6 +8,7 @@
   (:require phel-doom.io.render.enemy-sprites-data :refer [projectile-sprites death-sprites blood-sprites pickup-sprites])
   (:require phel-doom.io.render.enemy-sprite :refer [sprite-col-x sprite-subcol-x enemy-sprite-cell sprite-fade sprite-fade-index])
   (:require phel-doom.core.engine :refer [proj-dist max-depth])
+  (:require phel-doom.core.projection :refer [pitch-rows])
   (:require phel-doom.core.combat :refer [fx-ttl-seconds corpse-ttl-seconds])
   (:require phel-doom.core.format :refer [format-duration])
   (:require phel-doom.core.map :refer [find-door-cell]))
@@ -1312,10 +1313,11 @@
 
 (defn- blit-billboard-scaled
   "blit-billboard at `scale` x the projected enemy height, kept centred
-   (corpses render a bit smaller than a live enemy)."
-  [buf sprite ^int col ^float d ^float scale ^int vw ^int vh ^float pd dists edists]
+   (corpses render a bit smaller than a live enemy). `pr` is the pitch
+   row offset so the billboard tracks the sheared horizon."
+  [buf sprite ^int col ^float d ^float scale ^int vw ^int vh ^float pd dists edists ^int pr]
   (let [h (php/max 2 (php/intval (php/* (sprite-h-pd pd vh d 1.0) scale)))]
-    (blit-sprite-into buf sprite col d (php/intdiv (php/- vh h) 2) h vw vh dists edists)))
+    (blit-sprite-into buf sprite col d (php/+ (php/intdiv (php/- vh h) 2) pr) h vw vh dists edists)))
 
 (defn- death-frame
   "Pick the death-animation frame for enemy `type-kw` at remaining
@@ -1347,10 +1349,10 @@
 (defn- blit-blood-splat
   "Blit a small blood-spurt `splat` at the enemy's torso (a third of the
    projected height, upper-mid). Returns the buffer."
-  [buf splat ^int col ^float d ^int vw ^int vh ^float pd dists no-enemies]
+  [buf splat ^int col ^float d ^int vw ^int vh ^float pd dists no-enemies ^int pr]
   (let [eh   (sprite-h-pd pd vh d 1.0)
         bh   (php/max 2 (php/intdiv eh 3))
-        mid  (php/+ (php/intdiv (php/- vh eh) 2) (php/intdiv eh 3))
+        mid  (php/+ (php/intdiv (php/- vh eh) 2) pr (php/intdiv eh 3))
         etop (php/- mid (php/intdiv bh 2))]
     (blit-sprite-into buf splat col d etop bh vw vh dists no-enemies)))
 
@@ -1364,7 +1366,8 @@
    value, and the sprite blits go through helpers)."
   [blood-paint stats world dists vw vh ^float pd]
   (let [no-enemies (buf-mk)              ; sprites occlude on walls only
-        on?        (sprites-enabled?)]
+        on?        (sprites-enabled?)
+        pr         (pitch-rows (or (:pitch (:player world)) 0.0) vh)]
     (reduce
      (fn [bp fx]
        (let [proj (project-enemy-pd pd fx (:player world) vw)]
@@ -1382,16 +1385,16 @@
                ;; Kill: collapse->corpse, plus a fresh spurt for the first
                ;; ~0.45s so even a one-life one-shot kill bleeds.
                corpse
-               (let [bp1     (blit-billboard-scaled bp corpse col d 0.5 vw vh pd dists no-enemies)
+               (let [bp1     (blit-billboard-scaled bp corpse col d 0.5 vw vh pd dists no-enemies pr)
                      elapsed (php/- corpse-ttl-seconds ttl)
                      ksplat  (when (php/< elapsed 0.45)
                                (blood-frame (php/max 0.0 (php/- 1.0 (php// elapsed 0.45)))))]
                  (if ksplat
-                   (blit-blood-splat bp1 ksplat col d vw vh pd dists no-enemies)
+                   (blit-blood-splat bp1 ksplat col d vw vh pd dists no-enemies pr)
                    bp1))
                ;; Wound: small Freedoom blood spurt at the torso.
                wsplat
-               (blit-blood-splat bp wsplat col d vw vh pd dists no-enemies)
+               (blit-blood-splat bp wsplat col d vw vh pd dists no-enemies pr)
                ;; NO_SPRITES: ttl-tiered red shade block.
                :else
                (let [hw     (:half-width proj)
@@ -1403,8 +1406,8 @@
                      c-from (php/max 0 (php/- col hw))
                      c-to   (php/min (php/- vw 1) (php/+ col hw))
                      h      (sprite-h-pd pd vh d 1.0)
-                     r-top  (php/+ (php/intdiv (php/- vh h) 2) (php/intdiv (php/* h 2) 3))
-                     r-bot  (php/min vh (php/+ (php/intdiv (php/- vh h) 2) h))]
+                     r-top  (php/max 0 (php/+ (php/intdiv (php/- vh h) 2) pr (php/intdiv (php/* h 2) 3)))
+                     r-bot  (php/min vh (php/+ (php/intdiv (php/- vh h) 2) pr h))]
                  (loop [c c-from]
                    (when (php/<= c c-to)
                      (when (php/< d (buf-get dists c))
@@ -1426,7 +1429,8 @@
    Returns the mutated buffer — PHP arrays pass by value, and the sprite
    path goes through a helper, so the caller must rebind the result."
   [blood-paint pickups player dists edists vw vh ^float pd shade-now glyph-now sprite-key]
-  (let [use-spr (and (sprites-enabled?) (get pickup-sprites sprite-key))]
+  (let [use-spr (and (sprites-enabled?) (get pickup-sprites sprite-key))
+        pr      (pitch-rows (or (:pitch player) 0.0) vh)]
     (reduce
      (fn [bp item]
        (let [proj (project-enemy-pd pd item player vw)]
@@ -1445,14 +1449,14 @@
                                (php/intval (php/* (sprite-h-pd pd vh d 1.0) 0.55)))]
              (if (and use-spr (php/>= ph (php/max 2 (php/intval (php/* 2 lodr)))))
                ;; Sprite: Freedoom item billboard.
-               (let [etop (php/intdiv (php/- vh ph) 2)]
+               (let [etop (php/+ (php/intdiv (php/- vh ph) 2) pr)]
                  (blit-sprite-into bp use-spr col d etop ph vw vh dists edists))
                ;; Far / no-sprite: clean coloured glow + centre icon glyph.
                (let [hw     (php/max 1 (php/intdiv (:half-width proj) 2))
                      c-from (php/max 0 (php/- col hw))
                      c-to   (php/min (php/- vw 1) (php/+ col hw))
                      h      (sprite-h-pd pd vh d 1.0)
-                     mid    (php/+ (php/intdiv (php/- vh h) 2) (php/intdiv h 2))
+                     mid    (php/+ (php/intdiv (php/- vh h) 2) pr (php/intdiv h 2))
                      r-top  (php/max 0 (php/- mid (php/intdiv h 6)))
                      r-bot  (php/min vh (php/+ mid (php/intdiv h 6) 1))]
                  (loop [c c-from]
@@ -1486,10 +1490,11 @@
    Returns the mutated buffer — PHP arrays pass by value, so the caller
    must rebind to see the writes."
   [blood-paint projectiles player dists edists vw vh ^float pd]
-  (let [fireball (and (sprites-enabled?) (get projectile-sprites :fireball))]
+  (let [fireball (and (sprites-enabled?) (get projectile-sprites :fireball))
+        pr       (pitch-rows (or (:pitch player) 0.0) vh)]
     (reduce
-     (fn [bp pr]
-       (let [proj (project-enemy-pd pd pr player vw)]
+     (fn [bp bolt]
+       (let [proj (project-enemy-pd pd bolt player vw)]
          (if (nil? proj)
            bp
            (let [col (:col proj)
@@ -1498,14 +1503,14 @@
                ;; Freedoom fireball billboard at half the projected enemy
                ;; height so the bolt reads as a compact ball in flight.
                (let [fh   (php/max 2 (php/intdiv (sprite-h-pd pd vh d 1.0) 2))
-                     etop (php/intdiv (php/- vh fh) 2)]
+                     etop (php/+ (php/intdiv (php/- vh fh) 2) pr)]
                  (blit-sprite-into bp fireball col d etop fh vw vh dists edists))
                ;; Legacy orange glow + white-hot core (NO_SPRITES).
                (let [hw     (php/max 1 (php/intdiv (:half-width proj) 2))
                      c-from (php/max 0 (php/- col hw))
                      c-to   (php/min (php/- vw 1) (php/+ col hw))
                      h      (sprite-h-pd pd vh d 1.0)
-                     mid    (php/+ (php/intdiv (php/- vh h) 2) (php/intdiv h 2))
+                     mid    (php/+ (php/intdiv (php/- vh h) 2) pr (php/intdiv h 2))
                      r-top  (php/max 0 (php/- mid (php/intdiv h 6)))
                      r-bot  (php/min vh (php/+ mid (php/intdiv h 6) 1))]
                  (loop [c c-from]
@@ -1538,9 +1543,10 @@
              cx   (php/+ (:x tr) (php/* (php/- (:tx tr) (:x tr)) frac))
              cy   (php/+ (:y tr) (php/* (php/- (:ty tr) (:y tr)) frac))
              proj (project-enemy-pd pd {:x cx :y cy} player vw)
-             spr  (get projectile-sprites (:kind tr))]
+             spr  (get projectile-sprites (:kind tr))
+             pr   (pitch-rows (or (:pitch player) 0.0) vh)]
          (if (and proj spr)
-           (blit-billboard-scaled bp spr (:col proj) (:dist proj) 0.7 vw vh pd dists edists)
+           (blit-billboard-scaled bp spr (:col proj) (:dist proj) 0.7 vw vh pd dists edists pr)
            bp)))
      blood-paint
      (or tracers []))))

--- a/tests/io/paint-pitch-test.phel
+++ b/tests/io/paint-pitch-test.phel
@@ -1,0 +1,80 @@
+(ns phel-doom-tests.io.paint-pitch-test
+  (:require phel.test :refer [deftest is])
+  (:require phel-doom.io.render.buffer :refer [buf-mk buf-get buf-set])
+  (:require phel-doom.io.render.paint :refer [paint-pickups-into paint-projectiles-into])
+  (:require phel-doom.core.projection :refer [pitch-rows])
+  (:require phel-doom.core.engine :refer [proj-dist]))
+
+;; ---------------------------------------------------------------------
+;; Pitch anchoring (#242): world-anchored overlays (pickups, projectiles,
+;; tracers, blood) must shear with the horizon when the player looks
+;; up/down, the same integer row offset (`pitch-rows`) the walls, floor,
+;; sky and enemy sprites already use. Before the fix they stayed pinned
+;; to the level-gaze horizon and floated.
+;; ---------------------------------------------------------------------
+
+(def vw 40)
+(def vh 30)
+(def pickup {:x 7.0 :y 5.0})
+
+(defn- all-visible-dists
+  "Walls far in every column, so a pickup at d~2 is visible everywhere."
+  [^int w]
+  (let [a (buf-mk)]
+    (loop [c 0]
+      (when (php/< c w)
+        (buf-set a c 12.0)
+        (recur (php/+ c 1))))
+    a))
+
+(defn- first-written-row
+  "Lowest screen-row index with any painted cell, or -1 if none."
+  [buf ^int w ^int h]
+  (loop [r 0]
+    (if (php/>= r h)
+      -1
+      (if (loop [c 0]
+            (cond (php/>= c w)                                false
+                  (some? (buf-get buf (php/+ (php/* r w) c))) true
+                  :else                                       (recur (php/+ c 1))))
+        r
+        (recur (php/+ r 1))))))
+
+(defn- player-at [^float pitch]
+  {:x 5.0 :y 5.0 :angle 0.0 :pitch pitch})
+
+(deftest test-pickup-glow-shifts-down-by-pitch-rows
+  ;; Glow path forced via an unknown sprite-key. Looking up (pitch > 0)
+  ;; pushes the pickup DOWN the screen by exactly pitch-rows.
+  (let [dists  (all-visible-dists vw)
+        edists (buf-mk)
+        b0     (paint-pickups-into (buf-mk) [pickup] (player-at 0.0) dists edists vw vh proj-dist "S" "g" :no-sprite)
+        bu     (paint-pickups-into (buf-mk) [pickup] (player-at 0.8) dists edists vw vh proj-dist "S" "g" :no-sprite)
+        r0     (first-written-row b0 vw vh)
+        ru     (first-written-row bu vw vh)
+        pr     (pitch-rows 0.8 vh)]
+    (is (php/> r0 0) "pickup paints at level gaze")
+    (is (php/> pr 0) "pitch 0.8 yields a positive row offset")
+    (is (= (php/+ r0 pr) ru) "look-up shifts the pickup down by exactly pitch-rows")))
+
+(deftest test-pickup-level-gaze-matches-no-pitch
+  ;; pitch 0.0 and an absent :pitch both yield pr 0, so the paint is
+  ;; identical - the regression guard for byte-stable level gaze.
+  (let [dists  (all-visible-dists vw)
+        edists (buf-mk)
+        a      (paint-pickups-into (buf-mk) [pickup] (player-at 0.0) dists edists vw vh proj-dist "S" "g" :no-sprite)
+        b      (paint-pickups-into (buf-mk) [pickup] {:x 5.0 :y 5.0 :angle 0.0} dists edists vw vh proj-dist "S" "g" :no-sprite)]
+    (is (= (first-written-row a vw vh) (first-written-row b vw vh)))))
+
+(deftest test-projectile-responds-to-pitch
+  ;; Projectiles shear with pitch too (billboard path): the painted row
+  ;; moves down under look-up.
+  (let [dists  (all-visible-dists vw)
+        edists (buf-mk)
+        bolt   {:x 7.0 :y 5.0}
+        b0     (paint-projectiles-into (buf-mk) [bolt] (player-at 0.0) dists edists vw vh proj-dist)
+        bu     (paint-projectiles-into (buf-mk) [bolt] (player-at 0.8) dists edists vw vh proj-dist)
+        r0     (first-written-row b0 vw vh)
+        ru     (first-written-row bu vw vh)]
+    (is (php/>= r0 0) "projectile paints at level gaze")
+    (is (php/> ru r0) "look-up pushes the projectile down the screen")))


### PR DESCRIPTION
## 📚 Description

Fixes floating pickups/projectiles/blood when looking up/down (reported on the pitch feature). The pitch shear (#231) moves the horizon by an integer row offset that walls, floor, sky and enemy sprites already follow; four world-anchored painters did not, so they stayed pinned to the level-gaze horizon and floated. Each now derives the same offset and tracks the horizon. A level gaze (pitch 0) renders byte-identically.

## 🔖 Changes

- `paint-pickups-into`, `paint-projectiles-into`, `paint-tracers-into`, `paint-blood-fx-into` compute `pitch-rows` from the player + viewport and add it to every vertical anchor (sprite `etop`, glow `mid`, blood splat, billboard helpers).
- New `tests/io/paint-pitch-test.phel`: pickup shifts down by exactly `pitch-rows`; projectile responds to pitch; level gaze unchanged.
- Golden frame hashes unchanged (pitch 0 byte-identical); `composer ci` green (2363 tests).

Closes #242