### PR TITLE
feat: render per-cell floor/step heights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 
 ### Added
 
+- Per-cell floor heights (issue #232): cells can carry a floor height, and the raycaster + renderer draw a DOOM-style step (a shaded vertical riser plus a flat cap for the step top) where a ray climbs onto a raised floor. The foundation for steps, platforms and pits; levels opt in via an optional `:floor-heights` map (none ship yet, so the world stays flat). With every floor at 0 the frame is byte-for-byte identical to before. Stepping up onto the floor (Z physics) and textured step caps follow in later issues.
 - Look up/down camera pitch (issues #231, #240): the ↑ / ↓ arrow keys tilt the view up / down (hold to keep pitching, clamps at the extremes - no wrap). It is a pure vertical shear of the horizon (no extra rays): walls, the sky/floor split, floor-cast and enemy sprites all slide together by an integer row offset capped at +/-0.4 of the viewport height. `:pitch` is stored on the player as a fraction in [-1, 1]; a level gaze renders byte-for-byte identically to before.
 - Vertical-aware hitscan (issue #243): a shot now has to land on the enemy's drawn sprite, not just its horizontal column, so aiming up at the sky or down at the floor misses. The check is screen-space exact (the fixed crosshair must sit within the billboard the renderer projects at that distance), so closer enemies with taller sprites are more forgiving than distant ones. Aiming level (pitch 0) is unchanged.
 

--- a/docs/level-system.md
+++ b/docs/level-system.md
@@ -58,6 +58,7 @@ Optional:
 | `:enemy-lives` | Override the catalog's `:default-lives` (single-type entries only) |
 | `:door-lock`   | `:blue` / `:red` / `:yellow` - adds a matching keycard pickup and locks the exit |
 | `:layout`      | Hand-authored ASCII grid (vector of strings) - bypasses `random-grid` |
+| `:floor-heights` | `{[x y] height}` map of per-cell floor `z` (#232) - raised cells render a step riser + cap. Omitted on every current level (flat floor, byte-identical render); the showcase level lands in #237 |
 
 ### Mixed-monster rooms
 

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -193,6 +193,21 @@ Effect on `cast-frame` (2000-iter bench, `default-grid`):
 
 Cast scales linearly with column count. Live perf is available in-game via **F3** (cast/render split, bytes emitted, PHP memory, RLE compression).
 
+### Per-cell floor heights (#232)
+
+The riser side-channel adds 5 parallel `:step-*` arrays to `cast-frame` (one extra DDA recur accumulator + 5 `php/aset` per output column). On a FLAT world (`build-world 1`, no `:floor-heights`) at the three viewports, no-JIT `phel run` absolutes (trust deltas, not ms):
+
+| Viewport | metric | main | #232 | Δ% | verdict |
+|---|---|---|---|---|---|
+| 80x24  | cast   | 0.157 | 0.192 | +22% | structural (5 asets/col) |
+| 80x24  | render | 4.62  | 4.74  | +2.6% | noise |
+| 120x30 | cast   | 0.227 | 0.278 | +22% | structural |
+| 120x30 | render | 6.26  | 6.43  | +2.7% | noise |
+| 180x40 | cast   | 0.338 | 0.410 | +21% | structural |
+| 180x40 | render | 9.35  | 9.73  | +4% | noise-ish |
+
+The cast delta is a fixed +0.03 to +0.07 ms (the 5 array writes), on a base that is ~25x smaller than render, so it is a rounding error against the 5 ms cast+render budget. The render path is unchanged on a flat world (the riser/cap branches are dead when `step-from = vh`), consistent with the byte-identical golden hashes. The compiled `do-cast` keeps its 5 closures (none new in the DDA loop) and the per-cell render loops keep their closure count, so the closure-tax invariant holds. Frame output is byte-identical with all floors 0 (`render-cache-test/test-frame-bytes-pinned`, hashes unchanged).
+
 Half-block sub-pixel rendering (`frame->string`, 200-iter mean, measured BEFORE the closure-tax fix - the ratios still hold, the absolutes are ~5-10x today's):
 
 | Viewport | half-block | flat (`NO_SUBPIXEL`) | Δ CPU | bytes Δ |

--- a/docs/raycaster.md
+++ b/docs/raycaster.md
@@ -52,16 +52,33 @@ Returns raw (uncorrected) distance. Detailed tuple `[dist side hx hy]` is comput
 
 ```phel
 (defn cast-frame [world ^int width ^int scale]
-  ...returns {:dists :hits :sides :hxs :hys})
+  ...returns {:dists :hits :sides :hxs :hys :wallxs :floordxs :floordys
+              :step-dists :step-fzs :step-sides :step-hxs :step-hys})
 ```
 
-Cast `width / scale` rays; return 8 parallel PHP arrays (one per output column).
+Cast `width / scale` rays; return the parallel PHP arrays (one per output column).
 - `dists`: fish-eye corrected wall distance
 - `hits`: cell value at hit (0 if escaped to max-depth)
 - `sides`: 0 = vertical, 1 = horizontal (side-shading)
 - `hxs, hys`: hit cell coordinates
 - `wallxs`: wall-hit fraction in [0, 1) - the texture U coordinate (frac of world-y on a vertical face, world-x on a horizontal face, from the raw perpendicular distance)
 - `floordxs, floordys`: floor-cast basis = ray direction / cos(offset). A floor cell at per-row perpendicular distance `dperp` sits at world `player + dperp * (floordx, floordy)`, so the renderer needs no per-cell trig (two mul-adds + a frac for the texture sample)
+- `step-dists, step-fzs, step-sides, step-hxs, step-hys`: per-cell floor-height riser side-channel (#232, see below). Each entry is nil per column when the ray crossed no raised floor, so a flat world leaves them all-nil (additive contract).
+
+## Per-cell floor heights (#232)
+
+A second per-cell grid, `:floor-pgrid` (a PHP `float[][]` twin of `:pgrid`, same shape, all `0.0` by default), gives each cell the world `z` its floor sits at. The DDA march carries one extra accumulator, `step-acc`: scanning outward it records the FIRST floor cell it crosses whose height rises above the player's own floor (`:floor-z`, today always 0). That first riser is pinned (the nearest one occludes farther steps) and surfaced as the additive `:step-*` arrays:
+
+| Field | Meaning |
+|---|---|
+| `step-dists` | fish-eye corrected distance to the riser (or nil) |
+| `step-fzs`   | the riser cell's floor height (world z) |
+| `step-sides` | 0/1 face of the crossed boundary (EW shading, like walls) |
+| `step-hxs, step-hys` | integer coords of the riser cell |
+
+The accumulator is computed as nested `if` in the loop's tail position (never `and`, never a `let`-binding statement-form), so it compiles closure-free and the flat all-zero floor never trips the `fh > player-floor-z` test - the cast stays allocation-equivalent to the pre-#232 path (verified by diffing the compiled `out/` do-cast: still 5 closures, none new in the DDA loop).
+
+The renderer (`compute-wall-shades` + the px1 cell loop, see [rendering.md](rendering.md)) turns each riser into a vertical **riser face** plus a flat-shaded **cap** (the step top surface), painted into the floor band below the main wall (the nearer wall always wins its own rows). The cap rows are claimed before the floor-cast clause so the ground texture does not also paint them. A flat world leaves every `:step-*` entry nil, so the riser/cap branches are dead and the frame is byte-identical (pinned by `render-cache-test/test-frame-bytes-pinned`). Z physics (stepping up onto the riser) is deferred to #233; textured caps to #236.
 
 ## Two key details
 

--- a/docs/state.md
+++ b/docs/state.md
@@ -9,6 +9,7 @@ Pure data shapes that every other module operates on. `src/core/state.phel`.
 ```phel
 {:grid       <vector of vectors of cell ints>
  :pgrid      <PHP nested array, fast-path twin of :grid>
+ :floor-pgrid <PHP float[][], per-cell floor heights (#232); same shape as :pgrid, all 0.0 by default>
  :width      <int>
  :height     <int>
  :player     <player map>
@@ -87,6 +88,14 @@ After `build-world` from `core/level.phel` stamps level metadata, the world also
 ```
 
 On grid mutation (door turning into floor, etc.) **both** must update. See `pickup-hearts` and door logic in `commands/play.phel`.
+
+## :floor-pgrid (per-cell floor heights, #232)
+
+A third PHP-native grid, a `float[][]` of the SAME shape as `:pgrid`, holding the world `z` each cell's floor sits at. `new-world` builds it all-`0.0` (the classic flat world); `state/apply-floor-heights` stamps a `{[x y] height}` map into it, and `level/build-world` calls that with the level config's optional `:floor-heights` (absent on every current level, so the default is flat). The raycaster reads it to accumulate the first riser a column crosses (see [raycaster.md](raycaster.md)); the renderer paints that riser + its cap.
+
+`rebuild-pgrid` carries `:floor-pgrid` along (preserving an existing grid, or building a fresh all-zero one sized to `:grid` when absent, e.g. a loaded savegame) so a wall mutation can't leave it stale. Note PHP's value semantics: a stamp reads the inner row, writes the cell, then writes the row back into the grid (the closure array-copy gotcha) - a chained two-level `php/aset` would land on a copy.
+
+All-zero `:floor-pgrid` is byte-identical to the pre-#232 renderer.
 
 ## The player
 

--- a/src/core/engine.phel
+++ b/src/core/engine.phel
@@ -168,6 +168,12 @@
    wraps this with a paused-frame cache short-circuit."
   [world ^int width ^int scale]
   (let [pgrid               (:pgrid world)
+        ;; Parallel per-cell floor heights (#232). nil-safe: a world
+        ;; built before #232 (or a fixture without :floor-pgrid) reads as
+        ;; the flat all-zero floor, so the step accumulator below never
+        ;; fires and the cast stays byte-identical.
+        floor-pgrid         (:floor-pgrid world)
+        player-floor-z      (or (:floor-z (:player world)) 0.0)
         {:keys [x y angle]} (:player world)
         tables              (offset-tables-for width)
         offsets             (:offsets tables)
@@ -179,68 +185,116 @@
         hys                 (php/array)
         wallxs              (php/array)
         floordxs            (php/array)
-        floordys            (php/array)]
+        floordys            (php/array)
+        ;; Step riser side-channel (#232), 5 parallel arrays per output
+        ;; column. nil sentinel in :step-dists marks "no riser crossed";
+        ;; every render branch keys off that, so a flat world leaves them
+        ;; all-nil and paints nothing new.
+        step-dists          (php/array)
+        step-fzs            (php/array)
+        step-hxs            (php/array)
+        step-hys            (php/array)
+        step-sides          (php/array)]
      ;; DDA traversal is inlined: avoids one fn call per column AND
      ;; replaces the per-ray Phel-vector `[d h side hx hy]` return
      ;; with a cheap `php/array` so the hot loop allocates a plain
      ;; PHP array per ray instead of a persistent vector.
     (loop [col 0]
       (when (php/< col width)
-        (let [a       (php/+ angle (php/aget offsets col))
-              dirx    (php/cos a)
-              diry    (php/sin a)
-              stepx   (if (php/< dirx 0.0) -1 1)
-              stepy   (if (php/< diry 0.0) -1 1)
-              deltax  (if (php/=== dirx 0.0) dda-inf (php/abs (php// 1.0 dirx)))
-              deltay  (if (php/=== diry 0.0) dda-inf (php/abs (php// 1.0 diry)))
-              cx0     (php/intval (php/floor x))
-              cy0     (php/intval (php/floor y))
-              sidex0  (if (php/< dirx 0.0)
-                        (php/* (php/- x cx0) deltax)
-                        (php/* (php/- (php/+ cx0 1.0) x) deltax))
-              sidey0  (if (php/< diry 0.0)
-                        (php/* (php/- y cy0) deltay)
-                        (php/* (php/- (php/+ cy0 1.0) y) deltay))
-              hit-arr (loop [cx cx0 cy cy0 sidex sidex0 sidey sidey0]
-                        (if (php/< sidex sidey)
-                          (let [cx'  (php/+ cx stepx)
-                                dist sidex
-                                hit  (cell-at pgrid cx' cy)]
-                            (cond
-                              (php/> dist max-depth) (php/array max-depth 0 0 cx' cy)
-                              (php/!== 0 hit)        (php/array dist hit 0 cx' cy)
-                              :else
-                              (recur cx' cy (php/+ sidex deltax) sidey)))
-                          (let [cy'  (php/+ cy stepy)
-                                dist sidey
-                                hit  (cell-at pgrid cx cy')]
-                            (cond
-                              (php/> dist max-depth) (php/array max-depth 0 1 cx cy')
-                              (php/!== 0 hit)        (php/array dist hit 1 cx cy')
-                              :else
-                              (recur cx cy' sidex (php/+ sidey deltay))))))
-              rawd    (php/aget hit-arr 0)
-              d-corr  (php/* rawd (php/aget cos-offs col))
-              h       (php/aget hit-arr 1)
-              side    (php/aget hit-arr 2)
-              hx      (php/aget hit-arr 3)
-              hy      (php/aget hit-arr 4)
+        (let [a        (php/+ angle (php/aget offsets col))
+              dirx     (php/cos a)
+              diry     (php/sin a)
+              stepx    (if (php/< dirx 0.0) -1 1)
+              stepy    (if (php/< diry 0.0) -1 1)
+              deltax   (if (php/=== dirx 0.0) dda-inf (php/abs (php// 1.0 dirx)))
+              deltay   (if (php/=== diry 0.0) dda-inf (php/abs (php// 1.0 diry)))
+              cx0      (php/intval (php/floor x))
+              cy0      (php/intval (php/floor y))
+              sidex0   (if (php/< dirx 0.0)
+                         (php/* (php/- x cx0) deltax)
+                         (php/* (php/- (php/+ cx0 1.0) x) deltax))
+              sidey0   (if (php/< diry 0.0)
+                         (php/* (php/- y cy0) deltay)
+                         (php/* (php/- (php/+ cy0 1.0) y) deltay))
+              ;; DDA march. `step-acc` accumulates the FIRST crossed floor
+              ;; cell whose floor height rises above the player's own floor
+              ;; (#232): nil until then, thereafter a php/array
+              ;; `[dist fh side cx cy]` pinned at that first riser. Once
+              ;; set it sticks (the nearest riser occludes farther ones).
+              ;; The `:else` floor-step arm reads the cell's height through
+              ;; a `let` (statement position - the cond-arm BODY, exactly
+              ;; like the existing wall `let [cx' dist hit]`), then folds the
+              ;; new accumulator into the `recur` arg as nested `if` (never
+              ;; `and`, never a binding VALUE). Both stay off the closure
+              ;; tax: the whole loop still compiles to the single `hit-arr`
+              ;; closure, no new ones (verify by diffing out/ do-cast). The
+              ;; flat all-zero floor never trips `(> fh player-floor-z)`, so
+              ;; the accumulator stays nil and the loop is allocation-
+              ;; equivalent to pre-#232.
+              hit-arr  (loop [cx cx0 cy cy0 sidex sidex0 sidey sidey0 step-acc nil]
+                         (if (php/< sidex sidey)
+                           (let [cx'  (php/+ cx stepx)
+                                 dist sidex
+                                 hit  (cell-at pgrid cx' cy)]
+                             (cond
+                               (php/> dist max-depth) (php/array max-depth 0 0 cx' cy step-acc)
+                               (php/!== 0 hit)        (php/array dist hit 0 cx' cy step-acc)
+                               :else
+                               (let [row (if (php/=== nil floor-pgrid) nil (php/aget floor-pgrid cy))
+                                     fh  (if (php/=== nil row) player-floor-z (php/aget row cx'))]
+                                 (recur cx' cy (php/+ sidex deltax) sidey
+                                        (if (php/=== nil step-acc)
+                                          (if (php/> fh player-floor-z) (php/array dist fh 0 cx' cy) nil)
+                                          step-acc)))))
+                           (let [cy'  (php/+ cy stepy)
+                                 dist sidey
+                                 hit  (cell-at pgrid cx cy')]
+                             (cond
+                               (php/> dist max-depth) (php/array max-depth 0 1 cx cy' step-acc)
+                               (php/!== 0 hit)        (php/array dist hit 1 cx cy' step-acc)
+                               :else
+                               (let [row (if (php/=== nil floor-pgrid) nil (php/aget floor-pgrid cy'))
+                                     fh  (if (php/=== nil row) player-floor-z (php/aget row cx))]
+                                 (recur cx cy' sidex (php/+ sidey deltay)
+                                        (if (php/=== nil step-acc)
+                                          (if (php/> fh player-floor-z) (php/array dist fh 1 cx cy') nil)
+                                          step-acc)))))))
+              rawd     (php/aget hit-arr 0)
+              d-corr   (php/* rawd (php/aget cos-offs col))
+              h        (php/aget hit-arr 1)
+              side     (php/aget hit-arr 2)
+              hx       (php/aget hit-arr 3)
+              hy       (php/aget hit-arr 4)
               ;; Texture U: fractional position along the wall face where
               ;; the ray hit. Vertical face (side 0) → frac of world-y at
               ;; the hit; horizontal face (side 1) → frac of world-x.
               ;; Uses the raw (perpendicular) side distance, not the
               ;; fish-eye-corrected one. In [0, 1) → texture column.
-              wallx   (if (php/=== side 0)
-                        (let [wy (php/+ y (php/* rawd diry))] (php/- wy (php/floor wy)))
-                        (let [wx (php/+ x (php/* rawd dirx))] (php/- wx (php/floor wx))))
+              wallx    (if (php/=== side 0)
+                         (let [wy (php/+ y (php/* rawd diry))] (php/- wy (php/floor wy)))
+                         (let [wx (php/+ x (php/* rawd dirx))] (php/- wx (php/floor wx))))
               ;; Floor-cast basis for this column: the ray direction
               ;; divided by cos(offset). A floor cell at perpendicular
               ;; distance `dperp` (a per-ROW constant the renderer knows)
               ;; sits at world `player + dperp * (floordx, floordy)`, so
               ;; the renderer needs no per-cell trig — just two mul-adds.
-              inv-cos (php// 1.0 (php/aget cos-offs col))
-              floordx (php/* dirx inv-cos)
-              floordy (php/* diry inv-cos)]
+              inv-cos  (php// 1.0 (php/aget cos-offs col))
+              floordx  (php/* dirx inv-cos)
+              floordy  (php/* diry inv-cos)
+              ;; Unpack the first-riser accumulator (#232), index 5 of the
+              ;; terminal hit array. nil sentinel = no step crossed; the
+              ;; per-cell `if`s below are all pure expressions (no `let`/
+              ;; `and` in a binding value), so the closure-free contract
+              ;; holds. step-d is fisheye-corrected (raw side-distance ×
+              ;; cos-offset) just like the wall dist, so the riser projects
+              ;; on the same forward axis with no barrel bow.
+              step-hit (php/aget hit-arr 5)
+              s-rawd   (if (php/=== nil step-hit) nil (php/aget step-hit 0))
+              step-d   (if (php/=== nil step-hit) nil (php/* s-rawd (php/aget cos-offs col)))
+              step-fz  (if (php/=== nil step-hit) nil (php/aget step-hit 1))
+              step-sd  (if (php/=== nil step-hit) nil (php/aget step-hit 2))
+              step-hx  (if (php/=== nil step-hit) nil (php/aget step-hit 3))
+              step-hy  (if (php/=== nil step-hit) nil (php/aget step-hit 4))]
            ;; Replicate this sample across the next `scale` output
            ;; columns. `scale` is 1 today (crisp 1:1 walls everywhere),
            ;; so this fills exactly one cell; the loop keeps the
@@ -260,10 +314,21 @@
               (php/aset wallxs c wallx)
               (php/aset floordxs c floordx)
               (php/aset floordys c floordy)
+              (php/aset step-dists c step-d)
+              (php/aset step-fzs c step-fz)
+              (php/aset step-sides c step-sd)
+              (php/aset step-hxs c step-hx)
+              (php/aset step-hys c step-hy)
               (recur (php/+ c 1) (php/+ fill 1))))
           (recur (php/+ col scale)))))
+    ;; Additive contract (#232): all pre-existing keys stay; the 5
+    ;; :step-* arrays are appended. Each holds nil per column when no
+    ;; riser was crossed, so the renderer's step branches stay dead on a
+    ;; flat world and the frame is byte-identical.
     {:dists dists :hits hits :sides sides :hxs hxs :hys hys :wallxs wallxs
-     :floordxs floordxs :floordys floordys}))
+     :floordxs floordxs :floordys floordys
+     :step-dists step-dists :step-fzs step-fzs :step-sides step-sides
+     :step-hxs step-hxs :step-hys step-hys}))
 
 (def visit-radius
   "Square radius (cells) around the player scanned each frame for
@@ -386,6 +451,18 @@
            :sides  0 = vertical face, 1 = horizontal face (side-shading)
            :hxs    integer x coord of the hit cell (brick-texture hash)
            :hys    integer y coord of the hit cell
+           :wallxs wall-hit fraction (texture U) in [0, 1)
+           :floordxs/:floordys floor-cast basis (ray dir / cos offset)
+
+         Per-cell floor heights (#232) append 5 more parallel arrays,
+         each nil per column when the ray crossed no raised floor:
+           :step-dists fish-eye corrected distance to the FIRST riser
+                       (a floor cell taller than the player's own floor)
+           :step-fzs   that cell's floor height (world z)
+           :step-sides 0/1 face of the crossed riser boundary (EW shading)
+           :step-hxs/:step-hys integer coords of the riser cell
+         The contract is additive: a flat (all-zero) floor leaves every
+         :step-* entry nil, so consumers that ignore them are unaffected.
 
          `scale` controls the ray-replication factor (see `do-cast`).
 

--- a/src/core/level.phel
+++ b/src/core/level.phel
@@ -1,6 +1,6 @@
 (ns phel-doom.core.level
   (:require phel-doom.core.rng :as rng)
-  (:require phel-doom.core.state      :refer [max-backpacks max-lives new-player new-world with-enemies])
+  (:require phel-doom.core.state      :refer [apply-floor-heights max-backpacks max-lives new-player new-world with-enemies])
   (:require phel-doom.core.map        :refer [cell-door cell-door-blue cell-door-red cell-door-yellow count-secrets parse-layout random-grid random-spawn seed-doors seed-secrets])
   (:require phel-doom.core.enemy      :refer [default-wander-fraction promote-wanderers spawn-enemies spawn-enemies-mixed])
   (:require phel-doom.core.enemy-ai   :refer [aggression-for])
@@ -530,8 +530,14 @@
                        (:grid built))
          [px py]     spawn
          specs       (normalise-enemies cfg)
-         world       (new-world grid (new-player px py (php/* (rng/int! 360)
-                                                              (php// php/M_PI 180.0))))
+         ;; Seed per-cell floor heights (#232) from the level config's
+         ;; optional `:floor-heights` map (`{[x y] height}`). Absent on
+         ;; every current level -> all-zero flat floor -> render
+         ;; byte-identical to pre-#232.
+         world       (apply-floor-heights
+                      (new-world grid (new-player px py (php/* (rng/int! 360)
+                                                               (php// php/M_PI 180.0))))
+                      (:floor-heights cfg))
          spawned     (spawn-enemies-mixed grid specs
                                           enemy-min-spawn-dist px py)
          ;; Nightmare: stamp every spawned enemy so respawn picks the

--- a/src/core/state.phel
+++ b/src/core/state.phel
@@ -88,15 +88,57 @@
    cooldown) while not."
   100.0)
 
+(defn- zero-floor-pgrid
+  "Build a PHP float[][] of the same shape as `grid`, every cell 0.0.
+   The parallel floor-height grid (#232): cell (x, y) holds the world
+   z its floor sits at; all-zero is the classic flat world. Sized off
+   `:grid` so it always matches `:pgrid`'s shape."
+  [grid]
+  (to-php-array (map (fn [row] (to-php-array (map (fn [_] 0.0) row))) grid)))
+
+(defn apply-floor-heights
+  "Stamp per-cell floor heights from a `{[x y] height}` map onto the
+   world's `:floor-pgrid` (#232). Pure on the world map (returns a new
+   world), but mutates the PHP float[][] in place via `php/aset` - safe
+   because `:floor-pgrid` is freshly built by `new-world` and not shared.
+   Out-of-bounds cells are skipped. An empty / nil map is a no-op, so
+   levels without `:floor-heights` keep the all-zero flat floor and the
+   render stays byte-identical."
+  [world floor-map]
+  (if (or (nil? floor-map) (empty? floor-map))
+    world
+    (let [fpg (:floor-pgrid world)]
+      (foreach [xy h floor-map]
+        (let [x   (first xy)
+              y   (second xy)
+              row (php/aget fpg y)]
+          (when (php/!== row nil)
+            ;; PHP nested arrays are value types: `(php/aget fpg y)`
+            ;; COPIES the row, so the in-cell write must be assigned back
+            ;; into fpg at y to take effect (the closure array-copy
+            ;; gotcha, statement position). `(php/* 1.0 h)` coerces an
+            ;; int config height to float so the grid stays float[][].
+            (php/aset row x (php/* 1.0 h))
+            (php/aset fpg y row))))
+      (assoc world :floor-pgrid fpg))))
+
 (defn rebuild-pgrid
   "Re-derive `:pgrid` from `:grid`. Call after any in-game mutation
    of the grid (secret reveal, switch toggle, door open) so the
    raycaster's hot-path PHP-array view stays in sync with the
    persistent Phel vector. Without this the 3D view paints the
    pre-mutation cell (player walks through a wall that still
-   visually looks solid)."
+   visually looks solid).
+
+   Carries `:floor-pgrid` along (#232) so the parallel float floor grid
+   can't go stale relative to `:grid`: cell wall-mutations (door/secret/
+   switch) never move floor heights, so an existing grid is preserved
+   verbatim; a world without one (e.g. a loaded savegame) gets a fresh
+   all-zero grid sized to the current `:grid`."
   [world]
-  (assoc world :pgrid (to-php-array (map to-php-array (:grid world)))))
+  (assoc world
+         :pgrid       (to-php-array (map to-php-array (:grid world)))
+         :floor-pgrid (or (:floor-pgrid world) (zero-floor-pgrid (:grid world)))))
 
 (defn new-world
   {:doc "Bundle map grid and player into the world state. Stores a PHP-native
@@ -107,6 +149,14 @@
   [grid player]
   {:grid      grid
    :pgrid     (to-php-array (map to-php-array grid))
+   ;; Parallel per-cell floor heights (#232): a PHP float[][] of the
+   ;; SAME shape as :pgrid, all 0.0 by default (flat world). Cell (x, y)
+   ;; holds the world z its floor sits at; the raycaster reads it to
+   ;; accumulate the first step riser a column crosses, the renderer
+   ;; paints that riser + its cap. apply-floor-heights / build-world seed
+   ;; non-zero heights from the level config; all-zero is byte-identical
+   ;; to the pre-#232 flat renderer.
+   :floor-pgrid (zero-floor-pgrid grid)
    :width     (count (first grid))
    :height    (count grid)
    :player    player

--- a/src/io/render/main.phel
+++ b/src/io/render/main.phel
@@ -9,7 +9,7 @@
   (:require phel-doom.io.render.hud :refer [minimap-door minimap-door-pulse minimap-rows minimap-frame hud-debug-line hud-line-str help-menu-string settings-menu-string pause-menu-string])
   (:require phel-doom.io.render.paint :refer [paint-face-overlay paint-crosshair paint-intro-splash paint-locked-bump paint-door-face paint-blood-drops paint-rear-warning paint-low-ammo paint-reload-reminder paint-save-flash paint-reload-ready paint-game-info paint-berserk-badge paint-invuln-badge paint-empty-click paint-flicker paint-heartbeat-vignette paint-hit-vignette paint-berserk-tint paint-heat-bar paint-kill-streak paint-compass paint-enemy-hp-flashes paint-hearts-hud paint-pistol-hud paint-weapon-hud paint-blood-fx-into paint-pickups-into paint-projectiles-into paint-tracers-into build-blood-cols])
   (:require phel-doom.core.engine :refer [cast-frame max-depth proj-dist])
-  (:require phel-doom.core.projection :refer [char-aspect wall-px pitch-rows])
+  (:require phel-doom.core.projection :refer [char-aspect wall-px pitch-rows project-height])
   (:require phel-doom.core.perf :refer [render-scale])
   (:require phel-doom.core.format :refer [format-duration])
   (:require phel-doom.core.version :refer [version]))
@@ -303,8 +303,19 @@
    `pr`         look up/down horizon shear in scene rows (default 0):
                 added to every wall top so the whole wall band slides
                 down (look up) / up (look down) with the sky/floor
-                split. pr=0 keeps the shading byte-identical."
-  [vw vh haze-shift cast palette blood-cols ^float pd & [pr-arg]]
+                split. pr=0 keeps the shading byte-identical.
+
+   Optional variadic tail (#232 per-cell floor heights):
+   `pr-arg`       the pitch shear above.
+   `step-dists`   per-col fish-eye distance to the first riser, or nil.
+   `step-fzs`     per-col riser floor height (world z).
+   `step-sides`   per-col 0/1 crossed-face for the riser's EW shading.
+   `eye-z-arg`    camera eye height (default 0.5) for the projection.
+   When `step-dists` is absent or its entry is nil, the returned
+   `:step-bots`/`:step-tops`/`:step-cap-tops` are sentinels (vh / vh+1)
+   so every riser/cap branch in the cell loops is dead and the frame is
+   byte-identical to the flat renderer."
+  [vw vh haze-shift cast palette blood-cols ^float pd & [pr-arg step-dists step-fzs step-sides eye-z-arg]]
   (let [{:keys [dists hits sides wallxs]}                              cast
         {:keys [stbl ctbl sky-c floor-c door-shade-now door-code-now
                 door-tex-boost
@@ -329,7 +340,26 @@
         tex-u                                                          (buf-mk)
         tex-level                                                      (buf-mk)
         tex-px                                                         (buf-mk)
-        pr                                                             (or pr-arg 0)]
+        pr                                                             (or pr-arg 0)
+        ;; Per-cell floor-height riser bands (#232). step-bots = riser
+        ;; bottom row (player-floor plane at the riser distance), step-tops
+        ;; = riser top / cap near edge (raised-floor plane at the riser
+        ;; distance), step-cap-tops = cap far edge (raised-floor plane at
+        ;; the MAIN wall distance). step-face / step-cap hold the shaded
+        ;; cell strings. Sentinels (vh / vh+1) when the column has no riser
+        ;; -> the cell-loop range test never matches.
+        ;; step-from  = first row the riser/cap occupies (clamped to start
+        ;;              at the main wall bottom - the wall always wins above)
+        ;; step-bots  = first row past the riser (exclusive bottom), <= vh
+        ;; step-tops  = boundary row: rows below it are the flat cap (step
+        ;;              top surface), at/below it is the vertical riser face
+        ;; step-face  = riser-face solid cell, step-cap = cap solid cell
+        step-from                                                      (buf-mk)
+        step-bots                                                      (buf-mk)
+        step-tops                                                      (buf-mk)
+        step-face                                                      (buf-mk)
+        step-cap                                                       (buf-mk)
+        eye-z                                                          (or eye-z-arg 0.5)]
     (loop [col 0]
       (when (php/< col vw)
         (let [dist         (buf-get dists col)
@@ -415,11 +445,64 @@
                   (buf-set tex-u     col (php/min 63 (php/intval (php/* (buf-get wallxs col) 64))))
                   (buf-set tex-level col idx)
                   (buf-set tex-px    col wall-tex-px)))))
+          ;; Per-cell floor-height riser + cap (#232). Runs once per
+          ;; COLUMN (a let/cond is fine here - the closure tax is a
+          ;; per-CELL concern), so the cell loops below read plain agets.
+          ;; nil step distance -> sentinel band (vh / vh+1) that the cell
+          ;; range test never enters -> byte-identical flat path.
+          (let [s-d (if (php/=== nil step-dists) nil (buf-get step-dists col))]
+            (if (php/=== nil s-d)
+              ;; No riser: empty band [vh, vh) so `row >= step-from (vh)`
+              ;; is false for every on-screen row (0..vh-1) -> clause dead.
+              ;; step-tops = vh+1 keeps the riser/cap split nominal even
+              ;; though the band can never be entered.
+              (do (buf-set step-from col vh)
+                  (buf-set step-bots col vh)
+                  (buf-set step-tops col (php/+ vh 1))
+                  (buf-set step-face col "")
+                  (buf-set step-cap  col ""))
+              (let [s-fz      (buf-get step-fzs col)
+                    s-side    (if (php/=== nil step-sides) 0 (buf-get step-sides col))
+                    wall-bot  (php/+ top wall-h)
+                    ;; Riser bottom = player-floor plane (z 0) at the riser
+                    ;; distance; top = raised-floor plane at the same
+                    ;; distance; cap far edge = raised-floor plane at the
+                    ;; MAIN wall distance (where the step surface recedes
+                    ;; behind the wall). project-height already folds in
+                    ;; char-aspect + the wall-px falloff.
+                    s-bot     (php/+ (php/intval (php/round (project-height pd vh s-d eye-z 0.0))) pr)
+                    s-top     (php/+ (php/intval (php/round (project-height pd vh s-d eye-z s-fz))) pr)
+                    s-cap-top (php/+ (php/intval (php/round (project-height pd vh dist eye-z s-fz))) pr)
+                    ;; Occlusion window: the riser/cap only fill the floor
+                    ;; band BELOW the main wall (the nearer wall wins for
+                    ;; its own rows). Start at max(cap far edge, wall
+                    ;; bottom), clamped on screen; end at the riser bottom,
+                    ;; capped at vh.
+                    s-from    (php/max 0 (php/min vh (php/max s-cap-top wall-bot)))
+                    s-to      (php/min vh s-bot)
+                    ;; Same gamma distance fog + EW side shading as a wall,
+                    ;; minus the near-death haze, sampled at the riser
+                    ;; distance. The cap (horizontal step top) is shaded a
+                    ;; touch darker so the surface reads distinct from the
+                    ;; vertical riser face.
+                    s-idx-raw (php/max 0
+                                       (php/min 23
+                                                (php/+ (php/intval (php/* (php/pow (php/- 1.0 (php/min 1.0 (php// s-d max-depth))) 0.6) 23))
+                                                       (if (php/=== s-side 0) 3 0))))
+                    s-idx     (php/max 0 (php/- s-idx-raw haze-shift))
+                    cap-idx   (php/max 0 (php/- s-idx 2))]
+                (buf-set step-from col s-from)
+                (buf-set step-bots col s-to)
+                (buf-set step-tops col s-top)
+                (buf-set step-face col (buf-get stbl-l s-idx))
+                (buf-set step-cap  col (buf-get stbl-l cap-idx)))))
           (recur (php/+ col 1)))))
     {:tops tops :bots bots :normal normal
      :top-edge top-edge :bot-edge bot-edge
      :top-shadow top-shadow :bot-shadow bot-shadow
-     :tex-u tex-u :tex-level tex-level :tex-px tex-px}))
+     :tex-u tex-u :tex-level tex-level :tex-px tex-px
+     :step-from step-from :step-bots step-bots :step-tops step-tops
+     :step-face step-face :step-cap step-cap}))
 ;; =====================================================================
 ;; § Pulse cadences + near-death haze
 ;; =====================================================================
@@ -698,10 +781,18 @@
         ;; ray per two columns, full-width FOV tables) and compact every
         ;; second sample to scene width — same framing as full detail,
         ;; no zoom. Wall/sprite heights below scale through scene-pd.
-        {:keys [dists hits sides wallxs floordxs floordys]}
+        cast-result
         (if px2?
           (compact-cast-2 (cast-frame world vw 2) svw)
           (cast-frame world svw scale))
+        {:keys [dists hits sides wallxs floordxs floordys]} cast-result
+        ;; Per-cell floor-height riser arrays (#232). Present only on the
+        ;; full-detail cast; compact-cast-2 (px2) drops them, so they read
+        ;; nil there -> compute-wall-shades emits sentinel bands -> px2
+        ;; stays byte-identical (the riser is a px1-only feature for now).
+        step-dists                         (:step-dists cast-result)
+        step-fzs                           (:step-fzs cast-result)
+        step-sides                         (:step-sides cast-result)
         scene-pd                           (if px2? (php/* 0.5 proj-dist) proj-dist)
         tex-on?                            (wall-textures-enabled?)
         floor-tex-on?                      (and tex-on? (floor-textures-enabled?))
@@ -829,7 +920,12 @@
          :bot-shadow        shades-bot-shadow
          :tex-u             shades-tex-u
          :tex-level         shades-tex-level
-         :tex-px            shades-tex-px}
+         :tex-px            shades-tex-px
+         :step-from         shades-step-from
+         :step-bots         shades-step-bots
+         :step-tops         shades-step-tops
+         :step-face         shades-step-face
+         :step-cap          shades-step-cap}
         (compute-wall-shades svw svh haze-shift
                              {:dists dists :hits hits :sides sides :wallxs wallxs}
                              {:stbl stbl :ctbl ctbl
@@ -845,7 +941,9 @@
                               :blood-floor-code-grad blood-floor-code-gradient}
                              blood-cols
                              scene-pd
-                             pr)
+                             pr
+                             ;; #232 riser arrays (nil in px2 -> sentinels)
+                             step-dists step-fzs step-sides 0.5)
         ;; Enemy sprite zone boundaries (head/body/legs). For each
         ;; column carrying an enemy:
         ;;   row in [tops, mids)   -> head
@@ -1723,6 +1821,23 @@
                             ;; live tops/bots.
                             mixw? (php/=== 1 (php/aget wsub-mix col))]
                         (cond
+                          ;; Per-cell floor-height riser + cap (#232).
+                          ;; FIRST clause: claims the floor-band rows a
+                          ;; raised step occupies, BEFORE the floor cast can
+                          ;; paint them (occlusion). step-from .. step-bots
+                          ;; is the on-screen band (already clamped below the
+                          ;; main wall); rows above step-tops are the flat
+                          ;; cap (step top surface), at/below it the vertical
+                          ;; riser face. On a flat world step-from = vh, so
+                          ;; this test never fires and the frame is
+                          ;; byte-identical. Sky rows (< top) and wall rows
+                          ;; (< bot) never enter the band, so order is safe.
+                          (if (php/>= row (buf-get shades-step-from col))
+                            (php/< row (buf-get shades-step-bots col))
+                            false)
+                          (if (php/< row (buf-get shades-step-tops col))
+                            (php/aset cell-reg 0 (buf-get shades-step-cap col))
+                            (php/aset cell-reg 0 (buf-get shades-step-face col)))
                           ;; Half-block sky stacks two gradient sub-rows
                           ;; per cell (2× vertical). Blood columns keep
                           ;; the flat red wash.

--- a/tests/core/engine-test.phel
+++ b/tests/core/engine-test.phel
@@ -184,6 +184,88 @@
         (recur (php/+ i 1))))))
 
 ;; ---------------------------------------------------------------------
+;; Per-cell floor heights (#232): do-cast accumulates the FIRST riser a
+;; column crosses into the additive :step-* arrays. A flat world leaves
+;; every entry nil; raising a cell's floor surfaces a :step-dists entry
+;; nearer than the wall :dists at the columns whose ray crosses it.
+;; Fixtures raise a cell with a direct php/aset on :floor-pgrid, mirroring
+;; the new-world + aset style used elsewhere here.
+;; ---------------------------------------------------------------------
+
+(defn- raise-cell [world x y h]
+  ;; Stamp one cell's floor height via the PHP float[][] twin (the same
+  ;; path apply-floor-heights uses), returning the mutated world. The row
+  ;; is bound first: a php/aset onto a chained (php/aget ...) temporary is
+  ;; a write-to-temporary the compiler rejects.
+  (let [fpg (:floor-pgrid world)
+        row (php/aget fpg y)]
+    (php/aset row x (php/* 1.0 h))
+    (php/aset fpg y row)
+    (assoc world :floor-pgrid fpg)))
+
+(deftest test-cast-frame-flat-world-step-dists-all-nil
+  ;; No raised cells -> the step accumulator never fires -> every
+  ;; :step-dists entry is nil (the sentinel the renderer keys off to skip
+  ;; all riser paint, preserving byte-identity).
+  (let [w  (new-world chamber-grid (new-player 2.5 2.5 0.0))
+        c  (cast-frame w 16 1)
+        sd (:step-dists c)]
+    (is (= 16 (php/count sd)))
+    (loop [i 0]
+      (when (php/< i 16)
+        (is (php/=== nil (php/aget sd i)) "flat world: no step crossed")
+        (recur (php/+ i 1))))))
+
+(deftest test-cast-frame-step-arrays-are-parallel-and-additive
+  ;; The 5 new arrays size to width like the rest, and none of the
+  ;; pre-existing keys vanished (additive contract).
+  (let [w (raise-cell (new-world chamber-grid (new-player 2.5 2.5 0.0)) 3 2 0.5)
+        c (cast-frame w 8 1)]
+    (is (= 8 (php/count (:step-dists c))))
+    (is (= 8 (php/count (:step-fzs c))))
+    (is (= 8 (php/count (:step-sides c))))
+    (is (= 8 (php/count (:step-hxs c))))
+    (is (= 8 (php/count (:step-hys c))))
+    ;; pre-existing keys still present + parallel
+    (is (= 8 (php/count (:dists c))))
+    (is (= 8 (php/count (:floordxs c))))))
+
+(deftest test-cast-frame-raised-cell-yields-step-nearer-than-wall
+  ;; Centre column faces east from (2.5, 2.5); the wall is at x=4
+  ;; (dist 1.5). Raising the floor of cell (3, 2) - crossed at the x=3
+  ;; grid line, dist ~0.5 - makes the centre column report a riser with
+  ;; step-d < dists and the riser's floor height in :step-fzs.
+  (let [w   (raise-cell (new-world chamber-grid (new-player 2.5 2.5 0.0)) 3 2 0.5)
+        c   (cast-frame w 1 1)
+        sd  (php/aget (:step-dists c) 0)
+        sfz (php/aget (:step-fzs c) 0)
+        d   (php/aget (:dists c) 0)]
+    (is (php/!== nil sd) "centre column crosses the riser")
+    (is (php/< sd d) "riser is nearer than the wall behind it")
+    (is (= 0.5 sfz) "riser carries the raised floor height")
+    ;; The x=3 boundary sits ~1.0 ahead of the wall: dist ~0.5 vs 1.5.
+    (is (php/< (php/abs (php/- sd 0.5)) 0.05) "riser distance ~0.5")))
+
+(deftest test-cast-frame-step-side-records-crossed-face
+  ;; Facing east, the riser boundary is an x-line -> side 0 (vertical
+  ;; face), matching the EW shading convention used for walls.
+  (let [w (raise-cell (new-world chamber-grid (new-player 2.5 2.5 0.0)) 3 2 0.5)
+        c (cast-frame w 1 1)]
+    (is (= 0 (php/aget (:step-sides c) 0)))
+    (is (= 3 (php/aget (:step-hxs c) 0)))
+    (is (= 2 (php/aget (:step-hys c) 0)))))
+
+(deftest test-cast-frame-nearest-riser-wins
+  ;; Two raised cells in line (x=3 then... only one floor cell before the
+  ;; wall here): raising (3,2) only. Confirm the accumulator pins the
+  ;; FIRST crossing and a lower second cell can't override it. We raise
+  ;; (3,2) high; the centre ray's first floor crossing is (3,2), so that
+  ;; is what surfaces regardless.
+  (let [w (raise-cell (new-world chamber-grid (new-player 2.5 2.5 0.0)) 3 2 0.8)
+        c (cast-frame w 1 1)]
+    (is (= 0.8 (php/aget (:step-fzs c) 0)))))
+
+;; ---------------------------------------------------------------------
 ;; Paused-frame cast cache: while `:paused` is truthy AND the player
 ;; hasn't moved, the most recent cast result is reused verbatim.
 ;; ---------------------------------------------------------------------

--- a/tests/core/state-test.phel
+++ b/tests/core/state-test.phel
@@ -1,7 +1,7 @@
 (ns phel-doom-tests.core.state-test
   (:require phel.test :refer [deftest is])
   (:require phel-doom.core.state :refer [new-player new-world move-player turn-player
-                                         rebuild-pgrid
+                                         rebuild-pgrid apply-floor-heights
                                          toggle-map toggle-pause toggle-debug with-enemies
                                          advance-game-time at-backpack-cap?
                                          backpack-level gain-armor-shard gain-backpack
@@ -113,6 +113,56 @@
         post (php/aget (php/aget (:pgrid w2) 1) 1)]
     (is (= 0 pre))
     (is (= 1 post))))
+
+;; ---------------------------------------------------------------------
+;; Per-cell floor heights (#232): :floor-pgrid is a PHP float[][] twin
+;; of :pgrid, all 0.0 by default; apply-floor-heights stamps a
+;; {[x y] height} map into it; rebuild-pgrid carries it along.
+;; ---------------------------------------------------------------------
+
+(deftest test-new-world-floor-pgrid-matches-grid-shape-all-zero
+  (let [w   (new-world [[1 1 1] [1 0 1] [1 1 1]] (new-player 1.5 1.5 0.0))
+        fpg (:floor-pgrid w)]
+    ;; Same shape as :pgrid (3 rows, 3 cols) ...
+    (is (= 3 (php/count fpg)))
+    (is (= 3 (php/count (php/aget fpg 0))))
+    ;; ... every cell 0.0 (flat world).
+    (is (= 0.0 (php/aget (php/aget fpg 1) 1)))
+    (is (= 0.0 (php/aget (php/aget fpg 0) 2)))))
+
+(deftest test-apply-floor-heights-stamps-cells
+  (let [w  (new-world [[1 1 1] [1 0 1] [1 1 1]] (new-player 1.5 1.5 0.0))
+        w' (apply-floor-heights w {[1 1] 0.5 [2 0] 1.0})]
+    (is (= 0.5 (php/aget (php/aget (:floor-pgrid w') 1) 1)))
+    (is (= 1.0 (php/aget (php/aget (:floor-pgrid w') 0) 2)))
+    ;; Untouched cell stays flat.
+    (is (= 0.0 (php/aget (php/aget (:floor-pgrid w') 0) 0)))))
+
+(deftest test-apply-floor-heights-empty-map-is-noop
+  ;; The flat-world contract: nil / empty leaves the all-zero grid so the
+  ;; renderer stays byte-identical.
+  (let [w  (new-world [[1 1 1] [1 0 1] [1 1 1]] (new-player 1.5 1.5 0.0))
+        w0 (apply-floor-heights w nil)
+        w1 (apply-floor-heights w {})]
+    (is (= 0.0 (php/aget (php/aget (:floor-pgrid w0) 1) 1)))
+    (is (= 0.0 (php/aget (php/aget (:floor-pgrid w1) 1) 1)))))
+
+(deftest test-rebuild-pgrid-carries-floor-pgrid
+  ;; Wall mutation (switch/secret) must not lose seeded floor heights.
+  (let [w0 (apply-floor-heights
+            (new-world [[1 1 1] [1 0 1] [1 1 1]] (new-player 1.5 1.5 0.0))
+            {[1 1] 0.5})
+        w1 (rebuild-pgrid (assoc w0 :grid (assoc-in (:grid w0) [1 1] 1)))]
+    (is (= 0.5 (php/aget (php/aget (:floor-pgrid w1) 1) 1)))))
+
+(deftest test-rebuild-pgrid-builds-zero-floor-when-absent
+  ;; A world without :floor-pgrid (loaded savegame) gets a fresh all-zero
+  ;; grid sized to :grid, never nil.
+  (let [w0 (new-world [[1 1 1] [1 0 1] [1 1 1]] (new-player 1.5 1.5 0.0))
+        w1 (rebuild-pgrid (dissoc w0 :floor-pgrid))]
+    (is (php/!== nil (:floor-pgrid w1)))
+    (is (= 3 (php/count (:floor-pgrid w1))))
+    (is (= 0.0 (php/aget (php/aget (:floor-pgrid w1) 1) 1)))))
 
 ;; ---------------------------------------------------------------------
 ;; Soulsphere (issue #68): pickup pushes lives over max-lives toward

--- a/tests/io/render-cache-test.phel
+++ b/tests/io/render-cache-test.phel
@@ -1,6 +1,7 @@
 (ns phel-doom-tests.io.render-cache-test
   (:require phel.test :refer [deftest is])
   (:require phel-doom.core.level :refer [build-world])
+  (:require phel-doom.core.state :refer [new-world new-player])
   (:require phel-doom.core.engine :refer [mark-visible-cells])
   (:require phel-doom.io.render.frame-math :refer [halfblock build-sky-halfblock])
   (:require phel-doom.io.render.palette :refer [shade-code-table])
@@ -192,3 +193,66 @@
 (deftest test-px2-differs-from-full-detail
   (is (not= (frame->string world (assoc stats :px2? true) 120 30)
             (frame->string world stats 120 30))))
+
+;; ---------------------------------------------------------------------
+;; Per-cell floor heights (#232): a raised floor cell in front of the
+;; player draws a riser + cap, so the frame differs from the flat world
+;; at the same pose. A flat world is unchanged (the byte-identity guard
+;; is already pinned by test-frame-bytes-pinned; here we re-assert it at
+;; the frame level for a controlled chamber, and that raising a cell is
+;; what makes the difference).
+;; ---------------------------------------------------------------------
+
+;; A roomy 9x9 chamber so the east-facing player sees floor in front of
+;; the wall (room to project a step).
+(def step-chamber
+  [[1 1 1 1 1 1 1 1 1]
+   [1 0 0 0 0 0 0 0 1]
+   [1 0 0 0 0 0 0 0 1]
+   [1 0 0 0 0 0 0 0 1]
+   [1 0 0 0 0 0 0 0 1]
+   [1 0 0 0 0 0 0 0 1]
+   [1 0 0 0 0 0 0 0 1]
+   [1 0 0 0 0 0 0 0 1]
+   [1 1 1 1 1 1 1 1 1]])
+
+(defn- step-world []
+  ;; Player near the west wall facing east (angle 0): a long floor run
+  ;; ahead, then the east wall at x=8.
+  (mark-visible-cells (new-world step-chamber (new-player 1.5 4.5 0.0))))
+
+(defn- raise-floor [world x y h]
+  ;; Stamp one cell's floor height through the PHP float[][] twin, writing
+  ;; the row back (PHP nested-array value semantics) and re-assoc'ing so
+  ;; the mutated grid is the one carried on the returned world.
+  (let [fpg (:floor-pgrid world)
+        row (php/aget fpg y)]
+    (php/aset row x (php/* 1.0 h))
+    (php/aset fpg y row)
+    (assoc world :floor-pgrid fpg)))
+
+(deftest test-flat-step-chamber-is-stable
+  ;; Sanity: with no raised cells the controlled chamber renders
+  ;; deterministically (the flat path).
+  (is (= (frame->string (step-world) stats 120 30)
+         (frame->string (step-world) stats 120 30))))
+
+(deftest test-raised-floor-changes-the-frame
+  ;; Raising the floor of a cell in the player's forward path draws a
+  ;; riser + cap, so the bytes differ from the flat chamber at the same
+  ;; pose. (Exact bytes intentionally NOT pinned - geometry may be tuned;
+  ;; the contract is 'a step is visibly rendered'.)
+  (let [flat   (frame->string (step-world) stats 120 30)
+        raised (frame->string (raise-floor (step-world) 5 4 0.5) stats 120 30)]
+    (is (not= flat raised) "a raised floor cell renders differently than flat")))
+
+(deftest test-raised-floor-flat-elsewhere-still-identical
+  ;; Raising a cell the forward rays never cross (behind the player /
+  ;; outside the room interior the centre sweep sees) must leave the
+  ;; flat-world frame untouched - the riser only appears where a ray
+  ;; actually climbs it. Cell (1,1) is a wall corner; raising its floor
+  ;; height is invisible (walls occlude their own floor), so the frame
+  ;; equals the flat chamber.
+  (let [flat   (frame->string (step-world) stats 120 30)
+        hidden (frame->string (raise-floor (step-world) 1 1 0.5) stats 120 30)]
+    (is (= flat hidden) "a step inside a wall cell is not visible")))


### PR DESCRIPTION
## 📚 Description

Foundation for DOOM-style steps / platforms / pits (the first of the floor-height series). Cells can now carry a floor height, and the raycaster + renderer draw a step where a ray climbs onto a raised floor: a shaded vertical **riser face** plus a flat **cap** for the step top, painted into the floor band below the main wall (the nearer wall always wins its own rows). The contract is **additive and byte-identical when every floor is 0** - no level ships heights yet, so today's worlds render exactly as before (`test-frame-bytes-pinned` hashes unchanged).

Stepping up onto a riser (Z physics, #233) and textured step caps (#236) build on this.

## 🔖 Changes

- **state** (`core/state.phel`): new `:floor-pgrid`, a PHP `float[][]` twin of `:pgrid` (same shape, all `0.0`). `apply-floor-heights` stamps a `{[x y] height}` map (copy-back to dodge PHP nested-array value semantics); `rebuild-pgrid` carries it along so a wall mutation can't leave it stale.
- **level** (`core/level.phel`): `build-world` seeds heights from the optional `:floor-heights` config (absent on every current level → flat → no change).
- **engine** (`core/engine.phel`): `do-cast` threads a closure-free step accumulator through the DDA loop and returns 5 additive parallel arrays - `:step-dists :step-fzs :step-sides :step-hxs :step-hys` - each `nil` per column when no riser was crossed. The nearest riser is pinned (occludes farther ones). Compiled `do-cast` keeps its 5 closures, **none new in the inner loop** (verified by diffing `out/`).
- **render** (`io/render/main.phel`): `compute-wall-shades` builds per-column riser/cap bands + shade strings (sentinel band when no step); a new px1 cell-loop clause paints the riser/cap before the floor cast (so the ground doesn't also paint the cap rows). Per-cell render loops keep their closure count (24, unchanged).
- **tests**: cast (raised cell → `:step-dists` nearer than the wall at the right column; flat → all-nil), render (raised floor renders different bytes, flat stays identical, occluded step is invisible), state (apply / rebuild-carry / zero-grid).
- **docs**: `raycaster.md`, `state.md`, `level-system.md`, `performance.md` + `CHANGELOG.md`.

### Perf (flat world, no-JIT `phel run` - trust deltas)

| Viewport | render Δ | cast Δ |
|---|---|---|
| 80×24 | +2.6% (noise) | +0.03 ms |
| 120×30 | +2.7% (noise) | +0.05 ms |
| 180×40 | +4% (noise-ish) | +0.07 ms |

The render path is unchanged on a flat world (riser/cap branches are dead when `step-from = vh`); the cast delta is the 5 extra `php/aset` per column, on a base ~25x smaller than render and well inside the 5 ms cast+render budget.

Closes #232