### PR TITLE
chore(deps): pin phel to stable v0.45 (was dev-main)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,11 +19,11 @@
   "homepage": "https://github.com/Chemaclass/phel-doom",
   "license": "MIT",
   "type": "project",
-  "minimum-stability": "dev",
+  "minimum-stability": "stable",
   "prefer-stable": true,
   "require": {
     "php": ">=8.4",
-    "phel-lang/phel-lang": "dev-main",
+    "phel-lang/phel-lang": "^0.45",
     "symfony/console": "^7.4"
   },
   "require-dev": {


### PR DESCRIPTION
## 📚 Description

Switch `phel-lang/phel-lang` from `dev-main` to a stable release: `^0.45` (resolves **v0.45.1**), and set `minimum-stability` to `stable` since no dev-only dependency remains. The codebase builds and all 2711 tests pass byte-identical (golden frame hashes unchanged), so nothing relied on a dev-main-only API.

## 🔖 Changes

- `composer.json`: `phel-lang/phel-lang` `dev-main` -> `^0.45`; `minimum-stability` `dev` -> `stable`.
- No source changes; `composer.lock` is untracked in this repo (constraints resolve fresh per install).