### PR TITLE
docs(core): fix docstring drift

### DIFF
--- a/src/core/engine.phel
+++ b/src/core/engine.phel
@@ -114,9 +114,9 @@
 (def- pause-cast-cache (atom nil))
 
 (defn- ^int cell-at
-  "Return the cell value at integer (x, y) in `pgrid`. 0 = floor, 1 =
-   wall, 2 = closed door. Out-of-bounds yields 1 so rays stop at the
-   map edge."
+  "Return the cell value at integer (x, y) in `pgrid`. 0 = floor (ray
+   passes); any non-zero value (wall / door / secret / switch) stops the
+   ray. Out-of-bounds yields 1 so rays stop at the map edge."
   [pgrid ^int x ^int y]
   (let [row (php/aget pgrid y)]
     (if (php/=== row nil)

--- a/src/core/level.phel
+++ b/src/core/level.phel
@@ -511,9 +511,9 @@
 (defn- maybe-spawn-weapon-pickups
   "Per-level weapon drops. L2 always seeds a shotgun, L3 a chaingun,
    L4 the chainsaw, L5 the rocket launcher (issue #123), L6 the
-   incinerator (issue #122), L7 the rare BFG (issue #58), L8 the super
-   shotgun (issue #126). Each skipped if the player already owns the
-   weapon so a re-played level doesn't spam duplicate pickups. Returns a
+   incinerator (issue #122), L7 the rare BFG (issue #58). Each skipped
+   if the player already owns the weapon so a re-played level doesn't
+   spam duplicate pickups. Returns a
    vector of `{:x :y :weapon kw}` items."
   [grid level-num owned]
   (let [owned'     (or owned #{:pistol})

--- a/src/core/map.phel
+++ b/src/core/map.phel
@@ -169,8 +169,8 @@
       :else                      true)))
 
 (defn find-door-cell
-  "Scan `grid` for the first door cell (any variant: unlocked /
-   blue-locked / red-locked) and return its `[x y]`. nil when no
+  "Scan `grid` for the first door cell (any variant: unlocked or any
+   locked colour) and return its `[x y]`. nil when no
    door is present — never happens for a valid level, but the
    defensive path keeps the renderer crash-safe on test fixtures
    that skip seed-doors."

--- a/src/core/state.phel
+++ b/src/core/state.phel
@@ -66,8 +66,8 @@
 
 (def soulsphere-cap
   "Hard ceiling on lives after a soulsphere pickup: `max-lives +
-   soul-overcap` = 7. Set so a player at full health still benefits
-   from grabbing one (no fully-wasted pickup)."
+   soul-overcap` = 14 (7 hearts). Set so a player at full health still
+   benefits from grabbing one (no fully-wasted pickup)."
   (php/+ max-lives soul-overcap))
 
 (def soul-overcap-decay-secs
@@ -84,7 +84,7 @@
   5)
 
 (def armor-shard-overcap
-  "Lives the armor-shard pickup (issue #68) is allowed to push the
+  "Armor units the armor-shard pickup (issue #68) is allowed to push the
    player above `max-armor` for. Shards add +1 each up to
    `(+ max-armor armor-shard-overcap)`; the over-cap portion does
    NOT decay (DOOM-style helmet bonus), so the player banks shards


### PR DESCRIPTION
From the improve-sweep (#261). Docstring-only fixes to soulsphere cap, armor-shard wording, weapon-drop list, find-door-cell, and cell-at. Render byte-identical; 2716 tests. Closes #261