### PR TITLE
feat(controls): native FPS mouse aim feel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 
 ### Changed
 
+- Native-FPS mouse feel (issue #246): the mouse now aims like a modern shooter. The fixed screen-centre crosshair IS the aim point, so the terminal caret is re-hidden every frame (it can never resurface behind the streaming motion reports or after a resize), and turning the OS pointer setting off no longer leaves you blind: with mouselook on, an `:off` Crosshair still draws a minimal centre aim dot. The default turn speed is snappier (per-cell yaw 0.012 to 0.018, so a full-width flick sweeps ~124 deg instead of ~82 deg at the neutral 1.0x sensitivity); pitch and the Sensitivity slider (default 50% = 1.0x) are unchanged. All keyboard controls stay as-is and the mouse remains on by default.
 - Textured step caps (issue #236): the top surface of a raised floor step (#232) is now textured and fogged with the same stone as the ground floor, projected at the step's height, instead of a single flat shade. A step top reads as continuous stone that gets nearer/lit as it rises and fogs out with distance, matching the floor it joins. Flat floors are untouched: a cell at height 0 never enters the new path, so the frame stays byte-for-byte identical and the flat fast path does not regress (measured < 0.1 ms at 120x30).
 
 ### Fixed

--- a/docs/input.md
+++ b/docs/input.md
@@ -9,7 +9,7 @@ Raw stdin to world state.
 
 `init-input!` sequence: `stty -icanon -echo min 0 time 0` (raw mode, immediate return) + `stream_set_blocking(STDIN, false)` + ANSI setup:
 - `\e[?1049h`: alternate screen buffer
-- `\e[?25l`: hide cursor
+- `\e[?25l`: hide cursor (also re-asserted every frame by `render!` so the caret can't resurface mid-session behind streaming mouse reports or after a resize - see [Aim point](#aim-point-hidden-pointer-fixed-centre-crosshair))
 - `\e[?7l`: disable autowrap
 - `\e[2J\e[H`: clear + home
 - `\e[>3u`: kitty keyboard protocol opt-in (press/repeat/release events)
@@ -70,6 +70,7 @@ So `b=0` final `M` is a left press, `b=32` is a left drag (button 0 + motion), `
 
 `controls/mouse-look` (pure) parses every report in the drained byte string and returns `{:yaw :pitch :fire? :fire-held? :pos}`:
 - Terminals report **absolute** cell coords with **no pointer lock and no warp**, so yaw/pitch come from the **delta between consecutive position reports**, summed across the frame. This is NOT the discrete hold-counter model the keyboard uses (turn-hold-frames etc.); it is a per-frame angular delta applied directly to `:angle` / `:pitch`.
+- Per-cell scales (`mouse-yaw-scale` 0.018 rad, `mouse-pitch-scale` 0.02 fraction) tune the native-FPS feel. Yaw is sized so a brisk full-width flick (~120 cols) sweeps ~2.16 rad (~124 deg) at the neutral 1.0x sensitivity - a strong turn per stroke before the pointer saturates at the edge. Pitch covers a useful slice of the clamped [-1, 1] range in a few cells of vertical travel.
 - Motion RIGHT (+dx) -> +yaw; motion UP -> +pitch (rows grow DOWNWARD, so up is a decreasing y, hence the dy is negated).
 - **Edge-clamp caveat**: because the coords are absolute and clamp to `1..cols` / `1..rows`, a continuous drag into a screen edge produces a **zero delta** there - the terminal equivalent of running the mouse off the pad. There is no recentering. This approximates true mouselook within the terminal's limits, not perfectly.
 - `:pos` threads forward as the next frame's baseline (in `game-loop`, alongside `prev-keys`). The very first report of a session only establishes the baseline (zero delta), so the pointer's opening absolute position can't read as one giant jump.
@@ -80,9 +81,16 @@ So `b=0` final `M` is a left press, `b=32` is a left drag (button 0 + motion), `
 
 A left-button **press** (`b=0`, final `M`) sets `:fire?`, which the game loop ORs into the existing `:fire` rising edge - so a click shoots exactly like space. A held / dragged left button (`b=32`) sets `:fire-held?`, ORed into `:fire-held` so auto-fire weapons (pistol, chaingun) spray while the button is down, matching the space `:fire-held` path. Release (`m`) clears both.
 
+### Aim point: hidden pointer, fixed centre crosshair
+
+The aim is the **fixed screen-centre crosshair**, never a moving pointer (the terminal reports motion but offers no pointer warp, so a roaming pointer would not even track the aim). Two things keep that contract:
+
+- **Caret stays hidden.** `init-input!` hides the terminal caret once with `\e[?25l`, and `render!` re-asserts `\e[?25l` every frame. A terminal can resurface the caret on a mode flip, a resize, or when SGR mouse tracking is enabled, which would leave a blinking caret racing the crosshair; the per-frame re-assert (one idempotent escape) keeps it hidden for the whole session. The OS pointer arrow some terminals draw over their own window is outside our control, but the in-terminal caret never reappears.
+- **Crosshair is always the aim indicator while mouse-aiming.** `paint-crosshair` reads a `:mouse` flag (the Mouse setting, threaded through `frame-stats`). When mouselook is ON, an `:off` Crosshair style still draws a minimal centre dot `·` so the player is never left with no aim point. With the mouse OFF, `:off` keeps hiding the idle reticle exactly as before. The hit-marker (`✗` kill / `×` wound) overrides regardless of style or mouse state.
+
 ### Sensitivity
 
-A `Sensitivity` percent setting (0..100, step 10, default 50) maps through `core/settings.mouse-sensitivity` to a multiplier: the midpoint (50%) is the neutral 1.0x, 0% disables the look (delta scaled to 0), 100% doubles the per-cell yaw/pitch. `mouse-look` multiplies the raw delta by it.
+A `Sensitivity` percent setting (0..100, step 10, default 50) maps through `core/settings.mouse-sensitivity` to a multiplier: the midpoint (50%) is the neutral 1.0x, 0% disables the look (delta scaled to 0), 100% doubles the per-cell yaw/pitch. `mouse-look` multiplies the raw delta by it. Combined with the snappier 0.018 yaw scale, the default (50% / 1.0x) gives a responsive turn out of the box; raise it for a faster flick, lower it for fine tracking.
 
 ### Backward-compat guard
 

--- a/src/commands/play.phel
+++ b/src/commands/play.phel
@@ -794,6 +794,11 @@
    ;; timer in the HUD strip. Both are pure overlay reads.
    :crosshair            (or (:crosshair (:settings world)) :cross)
    :run-timer?           (boolean (:timer (:settings world)))
+   ;; Mouselook on flag (#246): the screen-centre crosshair IS the mouse
+   ;; aim point (no visible OS pointer), so paint-crosshair forces a
+   ;; minimal centre dot even when the player set Crosshair to :off, so
+   ;; mouse-aiming always has an aim indicator.
+   :mouse                (boolean (:mouse (:settings world)))
    ;; Accessibility (issue #200): high-contrast HUD un-dims the dim/grey
    ;; HUD elements (compass, empty hearts, reserve ammo) for low-quality
    ;; terminals.

--- a/src/glue/controls.phel
+++ b/src/glue/controls.phel
@@ -353,9 +353,12 @@
 
 (def mouse-yaw-scale
   "Radians of yaw per one cell of horizontal pointer travel, before the
-   player's sensitivity multiplier. Sized so a brisk flick across a
-   ~120-column terminal sweeps roughly a half turn at sensitivity 1.0."
-  0.012)
+   player's sensitivity multiplier. Tuned for a snappy native-FPS turn
+   (#246): a brisk flick across a ~120-column terminal sweeps ~2.16 rad
+   (~124°) at sensitivity 1.0, so a single stroke covers most of a
+   turn-around before the pointer saturates at the screen edge. The
+   earlier 0.012 felt sluggish (~82° per full-width flick)."
+  0.018)
 
 (def mouse-pitch-scale
   "Look up/down `:pitch` fraction per one cell of vertical pointer

--- a/src/io/render/main.phel
+++ b/src/io/render/main.phel
@@ -2376,6 +2376,13 @@
         shake-x (if shake?
                   (php/+ 1 (mod (php/intval (php/* t 50.0)) 3))
                   1)]
+    ;; Re-assert hide-cursor every frame (#246): init-input! hides the
+    ;; terminal caret once, but a terminal can resurface it on a mode
+    ;; flip / resize / SGR-mouse-tracking enable, which would leave a
+    ;; blinking caret racing the fixed-centre crosshair (the real FPS aim
+    ;; point). Re-emitting \e[?25l per frame is one idempotent escape and
+    ;; keeps the caret reliably hidden for the whole session.
+    (print "\e[?25l")
     (print (str "\e[1;" shake-x "H"))
     (if (php/> (or (get stats :flash-secs) 0.0) 0.0)
       (print (white-flash-frame cols rows))

--- a/src/io/render/paint.phel
+++ b/src/io/render/paint.phel
@@ -109,6 +109,13 @@
    while :fire-anim > 0 so the recoil feels like a kick; a live hit-fx
    overrides the idle glyph with a `✗`/`×` hit-marker (even when `:off`).
 
+   FPS-aim guarantee (#246): the screen-centre crosshair IS the mouse
+   aim point (the OS pointer stays hidden), so when mouselook is ON
+   (`:mouse` true) the `:off` style still paints a minimal centre dot
+   `·` rather than leaving the player with no aim indicator. With the
+   mouse off, `:off` keeps hiding the idle reticle as before (the
+   hit-marker still flashes on a hit regardless).
+
    `center-bg` is the SGR-only prefix of the cell currently under the
    crosshair (the wall/door body shade at the centre column). Painting
    the `+` on that BG keeps the cell's real colour visible underneath
@@ -125,12 +132,16 @@
         hit?    (and hit-fx (php/> (or (:ttl hit-fx) 0.0) 0.0))
         kill?   (and hit? (:kill? hit-fx))
         ;; Idle reticle glyph from the crosshair-style setting (#203);
-        ;; :off draws nothing when idle (nil glyph). The hit-marker
-        ;; overrides regardless so a hit always confirms.
+        ;; :off normally draws nothing when idle (nil glyph). But while
+        ;; mouselook is on the centre reticle IS the aim point, so :off
+        ;; falls back to a minimal dot so the player always has an aim
+        ;; indicator (#246). The hit-marker overrides regardless so a hit
+        ;; always confirms.
+        mouse?  (boolean (get stats :mouse))
         style   (or (get stats :crosshair) :cross)
         idle    (cond (= style :dot)  "·"
                       (= style :open) "○"
-                      (= style :off)  nil
+                      (= style :off)  (if mouse? "·" nil)
                       :else           "+")
         glyph   (cond kill? "✗" hit? "×" :else idle)
         ;; Idle: bold bright-white (NOT the old faint `2`, which read as a

--- a/tests/glue/controls-test.phel
+++ b/tests/glue/controls-test.phel
@@ -461,7 +461,7 @@
 ;;   b = 35 -> motion bit set, low bits 3 = bare hover (no button held)
 ;; Deltas are measured against the previous pointer position; motion
 ;; RIGHT (+dx) -> +yaw, motion UP (-dy, rows grow downward) -> +pitch.
-;; Scales: yaw 0.012, pitch 0.02 rad/fraction per cell at sensitivity 1.
+;; Scales: yaw 0.018, pitch 0.02 rad/fraction per cell at sensitivity 1.
 ;; ---------------------------------------------------------------------
 
 ;; Shared baseline so deltas are computed immediately (a non-nil prev-pos
@@ -469,8 +469,8 @@
 (def mouse-origin [10 10])
 
 (defn- approx?
-  "Float compare with a tolerance, so e.g. -6 * 0.012 (which lands on
-   -0.07199999... not the exact literal) still matches -0.072."
+  "Float compare with a tolerance, so e.g. -6 * 0.018 (which lands on
+   -0.10799999... not the exact literal) still matches -0.108."
   [^float a ^float b]
   (php/< (php/abs (php/- a b)) 1.0e-9))
 
@@ -485,19 +485,19 @@
     (is (= mouse-origin (:pos r)) "prev-pos carried forward")))
 
 (deftest test-mouse-look-motion-right-yields-positive-yaw
-  ;; Hover (b=35) from x=10 to x=15: dx=+5 -> yaw = 5 * 0.012 = 0.06.
+  ;; Hover (b=35) from x=10 to x=15: dx=+5 -> yaw = 5 * 0.018 = 0.09.
   ;; No pitch (dy=0), no fire (hover, not a press / drag).
   (let [r (mouse-look "\e[<35;15;10M" mouse-origin 1.0)]
-    (is (approx? 0.06 (:yaw r)) "+dx -> +yaw")
+    (is (approx? 0.09 (:yaw r)) "+dx -> +yaw")
     (is (= 0.0 (:pitch r)))
     (is (= false (:fire? r)))
     (is (= false (:fire-held? r)) "bare hover is not held-fire")
     (is (= [15 10] (:pos r)))))
 
 (deftest test-mouse-look-motion-left-yields-negative-yaw
-  ;; Hover from x=10 to x=4: dx=-6 -> yaw = -6 * 0.012 = -0.072.
+  ;; Hover from x=10 to x=4: dx=-6 -> yaw = -6 * 0.018 = -0.108.
   (let [r (mouse-look "\e[<35;4;10M" mouse-origin 1.0)]
-    (is (approx? -0.072 (:yaw r)) "-dx -> -yaw")
+    (is (approx? -0.108 (:yaw r)) "-dx -> -yaw")
     (is (= 0.0 (:pitch r)))))
 
 (deftest test-mouse-look-motion-up-yields-positive-pitch
@@ -534,25 +534,25 @@
   (let [r (mouse-look "\e[<32;15;10M" mouse-origin 1.0)]
     (is (= false (:fire? r)) "a drag is not a rising-edge press")
     (is (= true (:fire-held? r)) "left held during drag = held-fire")
-    (is (approx? 0.06 (:yaw r)) "drag still turns")))
+    (is (approx? 0.09 (:yaw r)) "drag still turns")))
 
 (deftest test-mouse-look-multiple-events-accumulate
   ;; Two hover reports in one frame: 10->15 (dx+5) then 15->20 (dx+5).
-  ;; Deltas sum: total dx=10 -> yaw = 10 * 0.012 = 0.12; pos ends at 20.
+  ;; Deltas sum: total dx=10 -> yaw = 10 * 0.018 = 0.18; pos ends at 20.
   (let [r (mouse-look "\e[<35;15;10M\e[<35;20;10M" mouse-origin 1.0)]
-    (is (approx? 0.12 (:yaw r)) "deltas across the frame sum")
+    (is (approx? 0.18 (:yaw r)) "deltas across the frame sum")
     (is (= [20 10] (:pos r)) "pos trails the last report")))
 
 (deftest test-mouse-look-press-then-move-fires-and-turns
   ;; A press followed by a hover move in the same frame: fire AND yaw.
   (let [r (mouse-look "\e[<0;10;10M\e[<35;16;10M" mouse-origin 1.0)]
     (is (= true (:fire? r)) "the press still registers")
-    (is (approx? 0.072 (:yaw r)) "the move still turns (dx +6 -> 0.072)")))
+    (is (approx? 0.108 (:yaw r)) "the move still turns (dx +6 -> 0.108)")))
 
 (deftest test-mouse-look-sensitivity-scales-the-delta
   ;; sensitivity 2.0 doubles, 0.0 zeroes the look (mouselook effectively
-  ;; off) while leaving fire untouched.
-  (is (approx? 0.12 (:yaw (mouse-look "\e[<35;15;10M" mouse-origin 2.0))) "2x sensitivity doubles yaw")
+  ;; off) while leaving fire untouched. dx=5 -> 5 * 0.018 * 2.0 = 0.18.
+  (is (approx? 0.18 (:yaw (mouse-look "\e[<35;15;10M" mouse-origin 2.0))) "2x sensitivity doubles yaw")
   (is (= 0.0  (:yaw (mouse-look "\e[<35;15;10M" mouse-origin 0.0))) "0 sensitivity = no look")
   (let [r (mouse-look "\e[<0;10;10M" mouse-origin 0.0)]
     (is (= true (:fire? r)) "0 sensitivity still lets a click fire")))
@@ -578,7 +578,7 @@
     (is (= [30 30] (:pos r)) "but :pos still advances to the wheel cell"))
   ;; Wheel tick then a hover from the wheel's cell: only the hover counts.
   (let [r (mouse-look "\e[<64;30;30M\e[<35;33;30M" mouse-origin 1.0)]
-    (is (approx? 0.036 (:yaw r)) "delta measured from the wheel cell (33-30=3)")))
+    (is (approx? 0.054 (:yaw r)) "delta measured from the wheel cell (33-30=3)")))
 
 (deftest test-mouse-look-malformed-sequence-ignored
   ;; A truncated SGR report (missing the y coord + terminator) does not
@@ -615,7 +615,7 @@
   ;; here (refresh-from-keys handles it elsewhere) but must not corrupt
   ;; the delta.
   (let [r (mouse-look "w\e[<35;15;10Md" mouse-origin 1.0)]
-    (is (approx? 0.06 (:yaw r)) "WASD bytes around the report don't affect yaw")
+    (is (approx? 0.09 (:yaw r)) "WASD bytes around the report don't affect yaw")
     (is (= [15 10] (:pos r)))))
 
 (deftest test-mouse-look-bytes-do-not-leak-into-key-parsing

--- a/tests/io/paint-test.phel
+++ b/tests/io/paint-test.phel
@@ -59,6 +59,28 @@
   (let [s (crosshair-str {:fire-anim 0.0 :crosshair :off :hit-fx {:kill? true :ttl 0.1}})]
     (is (php/str_contains s "✗") "kill marker shows even with reticle off")))
 
+;; FPS-aim guarantee (#246): the centre crosshair IS the mouse aim point
+;; (the OS pointer stays hidden), so when mouselook is ON the :off style
+;; must still draw a minimal centre dot - the player is never left with
+;; no aim indicator while mouse-aiming. Mouse OFF keeps :off hidden.
+
+(deftest test-crosshair-off-with-mouse-on-shows-aim-dot
+  (let [s (crosshair-str {:fire-anim 0.0 :crosshair :off :mouse true})]
+    (is (php/str_contains s "·") "mouse-on forces a centre aim dot even when crosshair is off")
+    (is (not (php/str_contains s "+")) "no plus - the dot is the minimal aim point")))
+
+(deftest test-crosshair-off-with-mouse-off-stays-hidden
+  ;; Backward-compat: with the mouse off, :off keeps hiding the idle
+  ;; reticle exactly as before.
+  (let [s (crosshair-str {:fire-anim 0.0 :crosshair :off :mouse false})]
+    (is (= "" s) "mouse-off leaves :off hidden")))
+
+(deftest test-crosshair-non-off-style-ignores-mouse-flag
+  ;; The mouse flag only rescues the :off case; an explicit style is
+  ;; unchanged whether or not the mouse is on.
+  (let [s (crosshair-str {:fire-anim 0.0 :crosshair :cross :mouse true})]
+    (is (php/str_contains s "+") "explicit cross stays a plus with the mouse on")))
+
 ;; Run-timer setting (issue #203): elapsed run time appended to the
 ;; row-2 game-info strip only when :run-timer? is on.
 


### PR DESCRIPTION
## 📚 Description

Polishes the existing terminal mouse (#246: SGR reporting, yaw/pitch deltas, left-click fire) into a modern-FPS aim feel. The fixed screen-centre crosshair is the aim point: the OS pointer/caret stays hidden, the crosshair always shows an aim indicator while mouse-aiming, the default turn is snappier, and the mouse stays on by default. All keyboard controls are unchanged (purely additive).

## 🔖 Changes

- **Hidden caret for the whole session.** `render!` now re-asserts `\e[?25l` every frame, so the terminal cursor can never resurface behind the streaming mouse-motion reports or after a resize. `init-input!` already hid it once at setup; this guards the rest of the session. (`src/io/render/main.phel`)
- **Crosshair is always an aim point while mouse-aiming.** With mouselook ON, an `:off` Crosshair style still paints a minimal centre dot `·` so the player is never left with no aim indicator. Mouse OFF (or absent) keeps `:off` hidden exactly as before. Threaded via a new `:mouse` frame-stat. (`src/io/render/paint.phel`, `src/commands/play.phel`)
- **Snappier default turn.** Per-cell yaw scale `mouse-yaw-scale` 0.012 -> 0.018 (a full-width flick now sweeps ~124 deg instead of ~82 deg) at the neutral 1.0x sensitivity. Pitch scale and the Sensitivity slider (default 50% = 1.0x) are unchanged. (`src/glue/controls.phel`)
- **Mouse on by default** (already the #246 default; confirmed). All keyboard bindings unchanged.
- **Tests:** 3 new `paint-crosshair` cases (off+mouse-on shows dot, off+mouse-off stays hidden, explicit style ignores the flag); mouse-look yaw assertions updated for the new 0.018 scale. The golden `test-frame-bytes-pinned` is **untouched** (input/settings only - all 4 hashes unmodified). (`tests/io/paint-test.phel`, `tests/glue/controls-test.phel`)
- **Docs:** `docs/input.md` (new Aim-point section + per-cell scales) and `CHANGELOG.md` (`### Changed`).

IO boundary respected: parsing/math stays pure in `glue/controls`; escapes + cursor handling stay in `io/`.

`composer ci` green (format-check, lint, 2720 tests pass, build OK).
