### PR TITLE
ref(io): drop dead defs + route bell! through print

### DIFF
--- a/src/io/render/hud.phel
+++ b/src/io/render/hud.phel
@@ -313,28 +313,6 @@
          (or (get stats :secrets-found) 0) "/"
          (or (get stats :secrets-total) 0))))
 
-(defn- ammo-cell
-  "HUD readout: e.g. `ammo 7/10 [23]` — loaded rounds / capacity, then
-   bracketed spare reserve. Mag colour goes amber at 3 or fewer rounds
-   and red on empty; the reserve goes amber under one mag's worth and
-   red on empty so the player can read both the immediate round count
-   and the spare pool at a glance."
-  [stats]
-  (let [mag     (or (get stats :mag) 0)
-        cap     (or (get stats :mag-size) 10)
-        reserve (or (get stats :ammo-reserve) 0)
-        mag-low (php/max 1 (php/intdiv cap 3))
-        res-low cap
-        mag-col (cond (php/<= mag 0)       "\e[1;91m"
-                      (php/<= mag mag-low) "\e[1;93m"
-                      :else                "\e[1m")
-        res-col (cond (php/<= reserve 0)       "\e[1;91m"
-                      (php/<= reserve res-low) "\e[1;93m" ; one mag's worth
-                      :else                    "\e[2m")]
-    (str "\e[1mammo\e[0m "
-         mag-col mag "\e[0m/" cap " "
-         res-col "[" reserve "]\e[0m")))
-
 (def hud-line-str
   "Bottom-status row. Was the dump for pos/angle/fps + a cramped key
    legend; those moved to the F3 debug overlay and the H info menu.

--- a/src/io/render/palette.phel
+++ b/src/io/render/palette.phel
@@ -5,8 +5,6 @@
 
 (def sky        "\e[48;5;236m ")
 (def floor      "\e[48;5;239m ")
-(def sky-blood  "\e[48;5;52m ")
-(def floor-blood "\e[48;5;88m ")
 (def enemy-head "\e[48;5;196m ")
 (def enemy-body "\e[48;5;52m ")
 
@@ -103,8 +101,6 @@
 ;; instead of a staircase.
 (def sky-code         "236")
 (def floor-code       "239")
-(def sky-blood-code   "52")
-(def floor-blood-code "88")
 (def door-code        "172")
 (def boss-door-code   "196")
 (def kill-flash    "\e[48;5;231;38;5;226;1m✦")

--- a/src/io/sound.phel
+++ b/src/io/sound.phel
@@ -145,8 +145,8 @@
                                                 " > /dev/null 2>&1 &")))))
 
 (defn- bell! []
-  (php/fwrite php/STDOUT "\a")
-  (php/fflush php/STDOUT))
+  (print "\a")
+  (php/flush))
 
 (defn- muted?
   "Test gate: when the PHEL_DOOM_SILENT env var is set to \"1\",


### PR DESCRIPTION
From the improve-sweep (#259). Removes 5 unused defs (4 palette blood consts + hud ammo-cell) and fixes the last direct `php/fwrite` in src/ (bell! -> print, io-boundary rule). Byte-identical; 2720 tests. Closes #259