### PR TITLE
docs: fix stale drain-bytes figure

### DIFF
--- a/docs/game-loop.md
+++ b/docs/game-loop.md
@@ -43,7 +43,7 @@ Four lifecycle layers:
 
 1. Capture terminal size; clear buffer on resize.
 2. Render frame via `draw-frame` + `render!` (io/render.phel); adaptive-sleep yields per frame budget.
-3. Drain input: `drain-keys` reads up to 64 bytes non-blocking. Held keys send multiple bytes per frame.
+3. Drain input: `drain-keys` reads up to `drain-bytes` (512) bytes non-blocking. Held keys send multiple bytes per frame.
 4. Compute dt + edges: `ms-since` for wall-clock; `rising-edges` diffs key snapshots for one-shots.
 5. Tick world: pure `tick-world` call (used by tests too).
 6. Branch: quit (Q), die (lives <= 0), door (next level or victory), or recur.

--- a/docs/input.md
+++ b/docs/input.md
@@ -25,7 +25,7 @@ Kitty-enabled terminals (kitty, WezTerm, Ghostty, Alacritty >= 0.13, iTerm2 >= 3
 
 ## Reading input
 
-`drain-keys` reads up to 64 bytes from STDIN, returns empty string if nothing queued. Called once per frame. Held keys produce multiple bytes via OS auto-repeat; `refresh-from-keys` ingests all of them.
+`drain-keys` reads up to `drain-bytes` (512) bytes from STDIN, returns empty string if nothing queued. Called once per frame. Held keys produce multiple bytes via OS auto-repeat; `refresh-from-keys` ingests all of them.
 
 ## Arrow keys
 


### PR DESCRIPTION
From the improve-sweep (#258). Two doc lines said drain reads 64 bytes; it is drain-bytes (512). Closes #258