### PR TITLE
test: pin mouse-look + perf LUTs; honest reduced-motion comment

### DIFF
--- a/src/commands/play.phel
+++ b/src/commands/play.phel
@@ -704,9 +704,14 @@
    ;; enemy-themed level label from the top game-info line.
    :hide-weapon?         (boolean (:hide-weapon? world))
    :hide-level-name?     (boolean (:hide-level-name? world))
-   ;; Accessibility: reduced-motion gates the strobing horror beats
-   ;; (flicker, heartbeat pulse, jump-scare, berserk pulse). Driven by
-   ;; the saved setting OR the PHEL_DOOM_REDUCED_MOTION env override.
+   ;; Accessibility: :reduced-motion? is currently INERT. It was meant to
+   ;; gate the strobing horror beats (flicker, heartbeat pulse, jump-scare,
+   ;; berserk pulse), but those have since been removed or made steady, and
+   ;; NO render branch reads this flag today. It is kept as a persisted
+   ;; back-compat setting (the saved value + the PHEL_DOOM_REDUCED_MOTION
+   ;; env override still flow through) so a future motion-sensitive effect
+   ;; can re-wire to it without a settings migration. Removing the setting
+   ;; / env helpers is a separate product decision.
    :reduced-motion?      (or (boolean (:reduced-motion (:settings world)))
                              (reduced-motion-env?))
    ;; UX settings (issue #203): crosshair reticle style + always-on run

--- a/tests/glue/controls-test.phel
+++ b/tests/glue/controls-test.phel
@@ -628,3 +628,79 @@
         w'   (refresh-from-keys blank-world drag)]
     (is (= false (:sp st)) "no phantom fire from the mouse digits")
     (is (= blank-moves (:moves w')) "no phantom movement from the report")))
+
+(deftest test-mouse-look-right-button-does-not-fire
+  ;; Right-button report (b=2: low bits 2 = button 2, final M). Only the
+  ;; LEFT button maps to fire, so a right click must leave :fire? /
+  ;; :fire-held? clear (and at the same cell adds no look delta).
+  (let [r (mouse-look "\e[<2;10;10M" mouse-origin 1.0)]
+    (is (= false (:fire? r)) "right press is not a fire edge")
+    (is (= false (:fire-held? r)) "right button is not held-fire")
+    (is (= 0.0 (:yaw r)) "right press at the same cell adds no yaw")
+    (is (= 0.0 (:pitch r)))))
+
+(deftest test-mouse-look-middle-button-does-not-fire
+  ;; Middle-button report (b=1: low bits 1 = button 1, final M). Same rule
+  ;; as the right button - only button 0 (left) fires.
+  (let [r (mouse-look "\e[<1;10;10M" mouse-origin 1.0)]
+    (is (= false (:fire? r)) "middle press is not a fire edge")
+    (is (= false (:fire-held? r)) "middle button is not held-fire")
+    (is (= 0.0 (:yaw r)) "middle press at the same cell adds no yaw")))
+
+(deftest test-mouse-look-press-then-release-fires-once
+  ;; A full click in ONE drained frame: left press (M) immediately
+  ;; followed by its release (m), both at the origin. :fire? is OR'd
+  ;; across the events, so the press still latches the single rising-edge
+  ;; fire; the trailing release neither re-fires nor un-fires it. :held?
+  ;; is OR'd too, so the in-frame press keeps it set for this frame even
+  ;; though the button is up by the end (the press itself is held-fire).
+  (let [r (mouse-look "\e[<0;10;10M\e[<0;10;10m" mouse-origin 1.0)]
+    (is (= true (:fire? r)) "press latches one fire even with a trailing release")
+    (is (= true (:fire-held? r)) "the in-frame press counts as held this frame")
+    (is (= 0.0 (:yaw r)) "click in place adds no look delta")
+    (is (= [10 10] (:pos r)) "pos trails the last (release) report"))
+  ;; The NEXT frame, fed only the release tail (button already up), is a
+  ;; clean no-op: no fire, no held, no delta.
+  (let [r (mouse-look "\e[<0;10;10m" mouse-origin 1.0)]
+    (is (= false (:fire? r)) "release-only frame does not fire")
+    (is (= false (:fire-held? r)) "release-only frame is not held")
+    (is (= 0.0 (:yaw r)))))
+
+(deftest test-mouse-look-left-drag-counts-as-held-fire
+  ;; PIN (existing-correct): a left DRAG (b=32, motion bit + button 0) is
+  ;; the terminal's only "trigger still down" signal during motion, so it
+  ;; must read as held-fire (auto-fire weapons spray) without being a fresh
+  ;; press edge. Distinct from the right/middle buttons above, which never
+  ;; fire at all.
+  (let [r (mouse-look "\e[<32;12;10M" mouse-origin 1.0)]
+    (is (= true (:fire-held? r)) "left drag = held-fire")
+    (is (= false (:fire? r)) "but not a rising-edge press")))
+
+(deftest test-mouse-look-wide-flick-yields-proportional-yaw
+  ;; Large-delta saturation: a single wide pointer flick from x=10 to
+  ;; x=110 (a ~100-cell sweep across a wide terminal) yields a yaw that is
+  ;; exactly proportional to the travel: dx=100 -> 100 * 0.018 = 1.8 rad.
+  ;; No clamping inside mouse-look itself - the proportionality is linear
+  ;; right up to wherever the terminal stops reporting.
+  (let [r (mouse-look "\e[<35;110;10M" mouse-origin 1.0)]
+    (is (approx? 1.8 (:yaw r)) "wide flick -> proportional yaw (100 cells)")
+    (is (= 0.0 (:pitch r)) "horizontal flick has no pitch")
+    (is (= [110 10] (:pos r)) "pos trails the flick endpoint")))
+
+(deftest test-mouse-look-edge-clamped-coords-yield-zero-delta
+  ;; PIN the docstring's edge-clamp promise: terminals report ABSOLUTE
+  ;; clamped cell coords with no pointer lock, so once the pointer
+  ;; saturates at a screen edge it reports the SAME clamped cell every
+  ;; frame. Two consecutive reports at the same edge cell therefore carry
+  ;; a zero delta - the terminal equivalent of the mouse running off the
+  ;; pad. Drive the pointer to an edge cell, then hold there: the second
+  ;; report adds no further yaw/pitch.
+  (let [edge [120 1]
+        held (mouse-look "\e[<35;120;1M" edge 1.0)]
+    (is (= 0.0 (:yaw held)) "re-report at the clamped edge cell adds no yaw")
+    (is (= 0.0 (:pitch held)) "and no pitch")
+    (is (= [120 1] (:pos held)) "pos stays pinned at the edge cell"))
+  ;; A flick INTO the edge, then a second report stuck at the edge: only
+  ;; the approach contributes; the saturated tail is a zero delta.
+  (let [r (mouse-look "\e[<35;120;10M\e[<35;120;10M" mouse-origin 1.0)]
+    (is (approx? (php/* 110 0.018) (:yaw r)) "only the approach to the edge turns; the stuck tail adds nothing")))

--- a/tests/io/fog-lut-test.phel
+++ b/tests/io/fog-lut-test.phel
@@ -1,7 +1,9 @@
 (ns phel-doom-tests.io.fog-lut-test
   (:require phel.test :refer [deftest is])
   (:require phel-doom.io.render.palette :refer [code-r code-g code-b nearest-256])
-  (:require phel-doom.io.render.frame-math :refer [tex-fade-table]))
+  (:require phel-doom.io.render.frame-math
+            :refer [tex-fade-table bg-cell-cache
+                    seam-darken-16 seam-darken-8 seam-darken-5]))
 
 ;; ---------------------------------------------------------------------
 ;; Colour-space helpers (palette): 256-colour code <-> RGB round-trip.
@@ -67,3 +69,62 @@
     (is (>= bright-near bright-far) "bright code darkens toward haze with distance")
     (is (<= dim-near dim-far) "dim code lightens toward haze with distance")
     (is (= bright-far dim-far) "bright + dim codes both reach the same haze at the far end")))
+
+;; ---------------------------------------------------------------------
+;; Perf-hoisted seam-darken LUTs (#273). 256-entry per-step darken
+;; tables baked once at load. Grayscale codes (>=232) subtract `steps`
+;; clamped at 232; cube codes (<232) fade hue-true toward black by
+;; steps/24. These pin the bake so a future builder edit fails HERE
+;; (named, readable) rather than only via the opaque golden frame hash.
+;; ---------------------------------------------------------------------
+
+(deftest seam-darken-tables-are-256-wide
+  ;; Indexed straight by 256-colour code, so every code must resolve.
+  (is (= 256 (php/count seam-darken-16)) "seam-darken-16 covers all 256 codes")
+  (is (= 256 (php/count seam-darken-8)) "seam-darken-8 covers all 256 codes")
+  (is (= 256 (php/count seam-darken-5)) "seam-darken-5 covers all 256 codes"))
+
+(deftest seam-darken-grayscale-subtracts-steps
+  ;; Grayscale ramp (>=232): straight `code - steps` (the old seam
+  ;; arithmetic). 255 - 16/8/5 = 239/247/250.
+  (is (= 239 (php/aget seam-darken-16 255)) "gray 255 -16 = 239")
+  (is (= 247 (php/aget seam-darken-8 255)) "gray 255 -8 = 247")
+  (is (= 250 (php/aget seam-darken-5 255)) "gray 255 -5 = 250"))
+
+(deftest seam-darken-grayscale-clamps-at-232
+  ;; Never drops below the darkest grayscale entry (232): a near-floor
+  ;; code minus a big step saturates, and 232 itself is a fixed point.
+  (is (= 232 (php/aget seam-darken-16 240)) "240 -16 clamps to 232, not 224")
+  (is (= 232 (php/aget seam-darken-16 232)) "232 is the grayscale floor"))
+
+(deftest seam-darken-cube-stays-on-the-cube-and-hue-true
+  ;; Cube black (16 = 0,0,0) has no light to remove, so it is a fixed
+  ;; point across every step count.
+  (is (= 16 (php/aget seam-darken-16 16)) "cube black -16 stays black")
+  (is (= 16 (php/aget seam-darken-8 16)) "cube black -8 stays black")
+  ;; Cube white (231 = 5,5,5) fades hue-true toward black via steps/24;
+  ;; more steps = darker. Anchor the exact bake AND the monotonic order.
+  (is (= 102 (php/aget seam-darken-16 231)) "cube white -16 = 102 (hue-true fade)")
+  (is (= 145 (php/aget seam-darken-8 231)) "cube white -8 = 145")
+  (is (= 188 (php/aget seam-darken-5 231)) "cube white -5 = 188")
+  (is (< (php/aget seam-darken-16 231)
+         (php/aget seam-darken-8 231)
+         (php/aget seam-darken-5 231))
+      "more darken steps -> a dimmer cube code"))
+
+;; ---------------------------------------------------------------------
+;; Perf-hoisted bg-cell-cache (#273): 256 pre-baked BG paint cells, one
+;; per 256-colour code, fetched after a `tex-fade-table` lookup so the
+;; hot wall path allocates no per-cell strings. Pin the exact cell shape
+;; (escape + single space) and the full coverage.
+;; ---------------------------------------------------------------------
+
+(deftest bg-cell-cache-is-256-wide
+  (is (= 256 (php/count bg-cell-cache)) "one BG cell per 256-colour code"))
+
+(deftest bg-cell-cache-cell-is-bg-escape-plus-space
+  ;; Each entry paints background colour <code> then emits a single space:
+  ;; ESC [ 48 ; 5 ; <code> m <space>. Pin two anchors so a stray byte in
+  ;; the bake (extra reset, missing space, fg instead of bg) trips here.
+  (is (= "\e[48;5;10m " (php/aget bg-cell-cache 10)) "code 10 BG cell")
+  (is (= "\e[48;5;196m " (php/aget bg-cell-cache 196)) "code 196 BG cell"))


### PR DESCRIPTION
## 📚 Description

Small post-session test + comment cleanup. All changes are behaviour-preserving: the golden `test-frame-bytes-pinned` hashes are unchanged and `composer ci` is fully green. No CHANGELOG entry (test/comment only).

Three things:

1. **Honest `:reduced-motion?` comment** (`play.phel`): the old comment claimed the flag gates "the strobing horror beats (flicker, heartbeat pulse, jump-scare, berserk pulse)". Those have since been removed or made steady, and no render branch reads `:reduced-motion?` anymore. The comment now states honestly that the flag is currently inert: a persisted back-compat setting that no render code reads. The setting + env helpers are left in place (removing them is a separate product decision for the maintainer).

2. **Mouse-look button/edge pins** (`controls-test.phel`): fill gaps in the existing `mouse-look` coverage.

3. **Perf-hoisted LUT pins** (`fog-lut-test.phel`): value/shape pins for the #273 hoisted `seam-darken-16/8/5` and `bg-cell-cache` LUTs, mirroring the existing `tex-fade-table` pins, so a future builder edit fails on a named local test instead of only via the opaque golden frame hash.

## 🔖 Changes

- `controls-test.phel`: right (b=2) and middle (b=1) mouse reports do NOT set `:fire?` / `:fire-held?` (only the left button fires).
- `controls-test.phel`: a press-then-release in one drained string fires exactly once; the release tail neither re-fires nor un-fires, and the next release-only frame is a clean no-op.
- `controls-test.phel`: pin the existing-correct left-drag (b=32) held-fire behaviour explicitly.
- `controls-test.phel`: a wide pointer flick (100-cell sweep) yields a proportional yaw (`dx * 0.018`); coords clamped at a screen edge across two reports yield a zero delta (pins the docstring's edge-clamp / pointer-saturation promise).
- `fog-lut-test.phel`: `seam-darken-16/8/5` are 256-wide; grayscale codes (>=232) subtract `steps` clamped at 232; cube codes fade hue-true toward black (more steps = dimmer, exact anchors at code 16 / 231).
- `fog-lut-test.phel`: `bg-cell-cache` is 256-wide and each cell is exactly `ESC[48;5;<code>m` + a single space.
- `play.phel`: rewrite the `:reduced-motion?` comment to be honest about the flag being inert back-compat.
