### PR TITLE
perf(play): throttle per-frame stty resize poll

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 ### Performance
 
 - Render hot-path (issue #262): pin referred frame-math globals (`tex-fade-table`, `bg-cell-cache`, `seam-darken-*`) as frame-level locals in `frame->string` and hoist `floor-flat?` / `vh-1` out of the inner loops, eliminating per-row and per-cell `Phel::getDefinition()` calls. Byte-identical output (golden hashes unchanged); measured -5.9% at 180x40 on no-JIT local PHP.
+- Throttled the per-frame terminal-size poll (issue #280): `term-size` forks + execs `stty size` (~1ms + jitter) and ran once per loop iteration before the render-start timestamp, so its cost fell outside the measured adaptive-sleep budget on a 5ms hot path. A resize is a human-timescale event, so the four size-polling loops (game loop, end screens, settings sub-loop, start menu) now sample `term-size` only every 6th frame and reuse the last dimensions in between, dropping ~5/6 of the forks. The first frame stays eager and a resize is still noticed within ~6 frames; fixed-size frames are byte-identical (golden hashes unchanged).
 
 ### Removed
 

--- a/docs/game-loop.md
+++ b/docs/game-loop.md
@@ -41,7 +41,7 @@ Four lifecycle layers:
                                                [rows cols])))))))
 ```
 
-1. Capture terminal size; clear buffer on resize.
+1. Capture terminal size; clear buffer on resize. `term-size` forks + execs `stty size`, so the real loop does NOT call it every frame: a `poll-frame` counter is threaded through the recur and `term-size` is sampled only when `(poll-size? poll-frame)` is true (frame 0, then every `resize-poll-frames` = 6 frames). Between samples the last `[rows cols]` is reused. The first frame is always eager so initial sizing is never delayed; `redraw-if-resized` + the auto-calibration tolerate a resize being noticed up to ~6 frames late. The simplified snippet above omits this throttle for clarity. Throttled at all four size-polling loops: the game loop, the end screens (`end-loop`), the settings sub-loop (`settings-screen!`), and the start menu (`show-start-menu!`).
 2. Render frame via `draw-frame` + `render!` (io/render.phel); adaptive-sleep yields per frame budget.
 3. Drain input: `drain-keys` reads up to `drain-bytes` (512) bytes non-blocking. Held keys send multiple bytes per frame.
 4. Compute dt + edges: `ms-since` for wall-clock; `rising-edges` diffs key snapshots for one-shots.

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -37,6 +37,10 @@ Cadence and render-scale are **uniform at every terminal size**. The old "big-sc
 
 Wide terminals are render-bound, not cadence-bound: the cost is the per-column cast + wall-shade work, which scales with column count. The minimap still caps at 40 cols (see `layout`). Physics and input tick once per frame.
 
+### Resize poll is throttled (issue #280)
+
+`term-size` reads the terminal dimensions by forking + execing `stty size`. A fork + exec costs roughly 1ms plus scheduler jitter, and it ran once per loop iteration BEFORE the render-start timestamp, so its cost landed OUTSIDE the measured adaptive-sleep budget on a 5ms-target hot path. A resize is a human-timescale event, so ~5 of every 6 of those forks were pure waste. The loops now thread a `poll-frame` counter and sample `term-size` only on poll frames (`poll-size?`: frame 0, then every `resize-poll-frames` = 6 frames), reusing the last `[rows cols]` in between. That drops ~5/6 of the per-frame forks while still noticing a resize within ~6 frames, which `redraw-if-resized` and the auto-calibration already tolerate. The first frame stays eager so initial sizing is never delayed. Same throttle at the four size-polling loops (game loop, end screens, settings sub-loop, start menu). Fixed-size frames are byte-identical, so the golden `test-frame-bytes-pinned` hashes are unchanged.
+
 ```phel
 (def standard-frame-us 16667)   ; ~60fps, every size
 (def standard-scale     1)      ; crisp 1:1, every size

--- a/src/commands/play.phel
+++ b/src/commands/play.phel
@@ -80,6 +80,24 @@
     (php/exec "stty size 2>/dev/null" out)
     (or (parse-stty-line (php/aget out 0)) default-term-size)))
 
+(def resize-poll-frames
+  "How often the loops re-sample `term-size`. Each sample forks + execs
+   `stty size` (~1ms + jitter), so polling every frame on a 5ms budget
+   is most of the per-frame IO cost yet a resize is a human-timescale
+   event. Sampling every Nth frame keeps resize handling responsive
+   (re-drawn within ~Nth of a second) while dropping ~5/6 of the forks."
+  6)
+
+(defn poll-size?
+  "True when frame `frame` should re-sample `term-size`: the very first
+   frame (so initial sizing is never delayed) or every
+   `resize-poll-frames`th frame thereafter. Pure so it is unit-testable;
+   between samples the loops reuse the last measured [rows cols], which
+   `redraw-if-resized` + the auto-calibration already tolerate."
+  [frame]
+  (or (php/=== frame 0)
+      (php/=== 0 (php/% frame resize-poll-frames))))
+
 ;; =====================================================================
 ;; § Per-frame tick orchestration (pure, exported for tests)
 ;; =====================================================================
@@ -910,22 +928,29 @@
         ;; An explicit cap (or 0 = fill) opts out: full detail at the
         ;; player's size.
         auto?   (and (php/< max-cols 0) (php/< max-rows 0))]
-    (loop [world     world0
-           t-last    t-start
-           frame-ms  0
-           fps       0
-           prev-keys initial-key-snapshot
-           dims      [0 0]
-           cal       {:px nil :n 0 :best 1.0e9 :tdims [0 0]}
+    (loop [world      world0
+           t-last     t-start
+           frame-ms   0
+           fps        0
+           prev-keys  initial-key-snapshot
+           dims       [0 0]
+           cal        {:px nil :n 0 :best 1.0e9 :tdims [0 0]}
            ;; Last pointer position mouselook (#246) measured against;
            ;; nil until the first SGR report so the pointer's opening
            ;; absolute position can't read as one giant jump. Threaded
            ;; like prev-keys.
-           prev-mpos nil]
+           prev-mpos  nil
+           ;; Frame counter + last raw terminal [trows tcols], threaded so
+           ;; the per-frame `stty size` fork only runs on poll frames
+           ;; (issue #280); other frames reuse the last dims. Named
+           ;; `poll-frame` (not `frame`) to avoid shadowing the demo frame
+           ;; map bound lower in the loop body.
+           poll-frame 0
+           tdims-last [0 0]]
       ;; Manual --max-cols/--max-rows still inset-cap the render area;
       ;; auto mode always fills the terminal (cap-dims with -1 = no-op)
       ;; and varies pixel detail instead.
-      (let [[trows tcols] (term-size)
+      (let [[trows tcols] (if (poll-size? poll-frame) (term-size) tdims-last)
             [rows cols]   (cap-dims trows tcols max-rows max-cols)
             px2?          (and auto? (php/=== 2 (:px cal)))]
         (redraw-if-resized dims rows cols)
@@ -1037,7 +1062,9 @@
                                                              now-keys
                                                              [rows cols]
                                                              cal'
-                                                             (:pos look)))))))))))
+                                                             (:pos look)
+                                                             (php/+ poll-frame 1)
+                                                             [trows tcols]))))))))))
 
 ;; =====================================================================
 ;; § End screens (death / victory)
@@ -1052,8 +1079,10 @@
         spawn or wall layout.
    `render-fn` takes (cols rows) and draws the variant."
   [render-fn]
-  (loop [dims [0 0]]
-    (let [[rows cols] (term-size)]
+  (loop [dims       [0 0]
+         frame      0
+         tdims-last [0 0]]
+    (let [[rows cols] (if (poll-size? frame) (term-size) tdims-last)]
       (redraw-if-resized dims rows cols)
       (render-fn cols rows)
       (php/usleep menu-frame-us)
@@ -1062,7 +1091,7 @@
           (str/contains? keys "q") :quit
           (str/contains? keys "R") :restart-same
           (str/contains? keys "r") :restart
-          :else                    (recur [rows cols]))))))
+          :else                    (recur [rows cols] (php/+ frame 1) [rows cols]))))))
 
 (defn- death-loop [kills survived-s level level-name scores summary]
   (end-loop (fn [cols rows]
@@ -1283,11 +1312,13 @@
    keys ramp); volume edits apply live; the final map is persisted and
    returned so the caller starts the run with the player's choices."
   [settings0]
-  (loop [settings settings0
-         cursor   0
-         prev     initial-key-snapshot
-         dims     [0 0]]
-    (let [[rows cols] (term-size)]
+  (loop [settings   settings0
+         cursor     0
+         prev       initial-key-snapshot
+         dims       [0 0]
+         frame      0
+         tdims-last [0 0]]
+    (let [[rows cols] (if (poll-size? frame) (term-size) tdims-last)]
       (redraw-if-resized dims rows cols)
       (render-settings! cols rows settings cursor)
       (php/usleep menu-frame-us)
@@ -1308,7 +1339,7 @@
           (let [{:cursor cursor-steps :value value-steps} (nav-deltas keys)
                 nav                                       (navigate settings cursor cursor-steps value-steps)]
             (when (:adjusted? nav) (apply-audio-settings! (:settings nav)))
-            (recur (:settings nav) (:cursor nav) now [rows cols])))))))
+            (recur (:settings nav) (:cursor nav) now [rows cols] (php/+ frame 1) [rows cols])))))))
 
 (defn- start-pressed?
   "True when `keys` carries an ENTER / Return (raw mode sends CR; some
@@ -1325,18 +1356,22 @@
    Other keys are ignored so a stray arrow can't launch the run by
    accident. Returns :quit, or the (possibly edited) settings map."
   [settings0]
-  (loop [settings settings0
-         dims     [0 0]]
-    (let [[rows cols] (term-size)]
+  (loop [settings   settings0
+         dims       [0 0]
+         frame      0
+         tdims-last [0 0]]
+    (let [[rows cols] (if (poll-size? frame) (term-size) tdims-last)]
       (redraw-if-resized dims rows cols)
       (render-start-menu cols rows)
       (php/usleep menu-frame-us)
       (let [keys (drain-keys)]
         (cond
           (str/contains? keys "q") :quit
-          (str/contains? keys "s") (recur (settings-screen! settings) [rows cols])
+          ;; Returning from the settings sub-loop is a fresh entry; reset
+          ;; the poll counter so the menu re-samples size eagerly.
+          (str/contains? keys "s") (recur (settings-screen! settings) [rows cols] 0 [rows cols])
           (start-pressed? keys)    settings
-          :else                    (recur settings [rows cols]))))))
+          :else                    (recur settings [rows cols] (php/+ frame 1) [rows cols]))))))
 
 (defn- resolve-difficulty
   "Pick the run difficulty: an explicit, valid --difficulty CLI value

--- a/tests/commands/play-test.phel
+++ b/tests/commands/play-test.phel
@@ -5,7 +5,8 @@
   (:require phel-doom.core.level  :refer [build-world])
   (:require phel-doom.core.rng    :as rng)
   (:require phel-doom.commands.play  :refer [tick-world resumed-pause? step-pause-menu
-                                             apply-mouse-look clamp-frame-ms adopt-loaded-world]))
+                                             apply-mouse-look clamp-frame-ms adopt-loaded-world
+                                             poll-size? resize-poll-frames]))
 
 (def open-grid
   (apply vector
@@ -374,3 +375,22 @@
   (let [w' (apply-mouse-look (player-at-angle 1.0 0.0)
                              {:yaw -0.4 :pitch 0.0})]
     (is (php/< (:angle (:player w')) 1.0) "negative yaw decreases the angle")))
+
+;; poll-size? (#280): the resize-poll throttle. Frame 0 always samples
+;; (initial sizing is never delayed); then only every resize-poll-frames'th
+;; frame re-forks `stty size`, the rest reuse the last dims.
+(deftest test-poll-size-samples-first-frame
+  (is (= true (poll-size? 0)) "frame 0 always samples so initial sizing is eager"))
+
+(deftest test-poll-size-skips-between-samples
+  (is (= false (poll-size? 1)) "frame 1 reuses last dims")
+  (is (= false (poll-size? 2)) "frame 2 reuses last dims")
+  (is (= false (poll-size? 3)) "frame 3 reuses last dims")
+  (is (= false (poll-size? 4)) "frame 4 reuses last dims")
+  (is (= false (poll-size? 5)) "frame 5 reuses last dims"))
+
+(deftest test-poll-size-samples-every-sixth-frame
+  (is (= 6 resize-poll-frames) "the throttle period is every 6th frame")
+  (is (= true (poll-size? 6)) "frame 6 re-samples term-size")
+  (is (= true (poll-size? 12)) "frame 12 re-samples term-size")
+  (is (= false (poll-size? 7)) "frame 7 reuses last dims again"))


### PR DESCRIPTION
## 📚 Description

`term-size` reads the terminal dimensions by forking + execing `stty size` (~1ms + scheduler jitter). It ran once per loop iteration BEFORE the render-start timestamp, so its cost landed OUTSIDE the measured adaptive-sleep budget on a 5ms-target hot path. A resize is a human-timescale event, so ~5 of every 6 of those forks per second were pure waste.

This throttles the poll: a `poll-frame` counter is threaded through the recur and `term-size` is sampled only on poll frames (frame 0, then every `resize-poll-frames` = 6 frames), reusing the last `[rows cols]` in between. The first frame stays eager so initial sizing is never delayed, and a resize is still noticed within ~6 frames, which `redraw-if-resized` + the auto-calibration already tolerate.

Stays in `commands/` (`term-size` already forks, so no purity boundary is crossed). No `pcntl_async_signals`. Fixed-size frames are byte-identical, so the golden `test-frame-bytes-pinned` hashes are unchanged.

## 🔖 Changes

- New pure `poll-size?` helper + `resize-poll-frames` (= 6) const in `commands/play.phel`; `poll-size?` returns true on frame 0 or every 6th frame (unit-tested).
- Throttled all four size-polling loops: the game loop, the end screens (`end-loop`), the settings sub-loop (`settings-screen!`), and the start menu (`show-start-menu!`). Each threads a frame counter + last-dims through its recur (the game loop names it `poll-frame` to avoid shadowing the demo `frame` map).
- New unit tests for `poll-size?` (frame 0 -> true, 1..5 -> false, 6/12 -> true, period = 6).
- Docs: `docs/game-loop.md` (resize/`term-size` step) and `docs/performance.md` (new "Resize poll is throttled" section) updated same commit.
- CHANGELOG `## [Unreleased]` -> `### Performance`.

Golden hashes unchanged; `composer ci` green (2862 tests). A deterministic single frame renders byte-identical (md5 `a68ddd13b...`).

Closes #280
