### PR TITLE
feat(controls): movable aim crosshair (WIP)

### DIFF
--- a/src/commands/play.phel
+++ b/src/commands/play.phel
@@ -5,10 +5,11 @@
                                             clamp-pitch decay-soul-overcap gain-armor-shard gain-backpack
                                             gain-life gain-soulsphere
                                             max-armor max-lives max-stamina turn-player
-                                            rebuild-pgrid toggle-debug toggle-map toggle-pause toggle-sound])
+                                            rebuild-pgrid reset-reticle set-reticle
+                                            toggle-debug toggle-map toggle-pause toggle-sound])
   (:require phel-doom.core.map      :refer [door? reveal-secret secret? switch? toggle-switch])
   (:require phel-doom.glue.controls :refer [refresh-from-keys key-states rising-edges
-                                            initial-key-snapshot nav-deltas mouse-look])
+                                            initial-key-snapshot nav-deltas mouse-aim])
   (:require phel-doom.core.physics  :refer [apply-physics tick-heartbeat tick-blood-drops tick-stamina])
   (:require phel-doom.core.engine   :refer [mark-visible-cells])
   (:require phel-doom.core.combat   :refer [ammo-per-box arm-berserk damage-step fire-anim-seconds invuln-seconds push-sfx reload reloading? reload-cooldown-seconds tick-armory tick-shooting])
@@ -126,13 +127,14 @@
   (update-in world [:player :angle] (fn [a] (php/+ a php/M_PI))))
 
 (defn apply-mouse-look
-  "Apply one frame's positional mouselook steering (#318) to the player.
-   `look` is the `controls/mouse-look` result; `:yaw` rotates `:angle`
-   (same path as a keyboard turn) and `:pitch` shears `:pitch` clamped to
-   [-1, 1] via `clamp-pitch` (same saturation as the ↑/↓ keys). A zero
-   yaw/pitch (pointer in the centre deadzone) is a no-op so the keyboard
-   look is untouched. Pure; the game loop calls it only on an unpaused
-   frame so the camera can't drift while a menu is up."
+  "Apply one frame's mouse edge-pan (#324, was positional steer #318) to the
+   player. `look` is the `controls/mouse-aim` result; `:yaw` rotates
+   `:angle` (same path as a keyboard turn) and `:pitch` shears `:pitch`
+   clamped to [-1, 1] via `clamp-pitch` (same saturation as the ↑/↓ keys).
+   Both are non-zero only while the reticle sits in the outer edge band, so
+   a reticle in the centre region (zero yaw/pitch) is a no-op and the
+   keyboard look is untouched. Pure; the game loop calls it only on an
+   unpaused frame so the camera can't drift while a menu is up."
   [world look]
   (let [yaw   (or (:yaw look) 0.0)
         pitch (or (:pitch look) 0.0)
@@ -731,11 +733,15 @@
    ;; timer in the HUD strip. Both are pure overlay reads.
    :crosshair            (or (:crosshair (:settings world)) :cross)
    :run-timer?           (boolean (:timer (:settings world)))
-   ;; Mouselook on flag (#246): the screen-centre crosshair IS the mouse
-   ;; aim point (no visible OS pointer), so paint-crosshair forces a
-   ;; minimal centre dot even when the player set Crosshair to :off, so
-   ;; mouse-aiming always has an aim indicator.
+   ;; Mouselook on flag (#246): the crosshair IS the mouse aim point (no
+   ;; visible OS pointer), so paint-crosshair forces a minimal centre dot
+   ;; even when the player set Crosshair to :off, so mouse-aiming always has
+   ;; an aim indicator.
    :mouse                (boolean (:mouse (:settings world)))
+   ;; Movable aim crosshair (#324): the reticle cell the gun aims at, so
+   ;; render draws the `+` there. nil (mouse off / not placed) centres it.
+   :aim-col              (:aim-col world)
+   :aim-row              (:aim-row world)
    ;; Accessibility (issue #200): high-contrast HUD un-dims the dim/grey
    ;; HUD elements (compass, empty hearts, reserve ammo) for low-quality
    ;; terminals.
@@ -1003,26 +1009,29 @@
                 ms        (or (:ms frame) live-ms)
                 now-keys  (key-states keys)
                 edges0    (rising-edges now-keys prev-keys)
-                ;; Positional mouselook (#318): parse the same drained byte
-                ;; string for SGR mouse reports. `:yaw`/`:pitch` steer the
-                ;; camera by how far the cached pointer sits from the terminal
-                ;; CENTER (applied below before the tick, so the frame renders
-                ;; + aims with the new heading); a left click ORs into the
+                ;; Movable aim crosshair (#324): parse the same drained byte
+                ;; string for SGR mouse reports. `:aim-col`/`:aim-row` are the
+                ;; reticle cell the gun aims at (stamped on the world below so
+                ;; this frame's off-centre hitscan + crosshair use it);
+                ;; `:yaw`/`:pitch` edge-pan the camera when the reticle is in
+                ;; the outer band (applied before the tick so the frame aims +
+                ;; renders with the new heading). A left click ORs into the
                 ;; existing space-fire edges so a mouse click shoots exactly
                 ;; like space (held button feeds auto-fire weapons). `:pos`
-                ;; threads forward as the next frame's cached pointer. Seed the
-                ;; cached pointer to CENTER at game start (prev-mpos nil) and
-                ;; reset it on a resize: a centered pointer steers zero, so the
-                ;; camera never auto-spins before a real report or when the
-                ;; absolute coords shift meaning under a new terminal size. The
-                ;; live `[rows cols]` gives steer-rate the axis lengths so the
-                ;; pointer keeps turning the camera while held off-center.
+                ;; threads forward as the next frame's cached pointer. Seed it
+                ;; to CENTER at game start (prev-mpos nil) and reset it on a
+                ;; resize: a centred pointer places the reticle dead centre
+                ;; (no edge-pan) so nothing auto-spins before a real report or
+                ;; when the absolute coords shift meaning under a new terminal
+                ;; size. The live `[rows cols]` gives mouse-aim the axis
+                ;; lengths the reticle clamp + edge band need.
+                mouse-on? (boolean (:mouse (:settings world)))
                 mpos      (if (or (nil? prev-mpos) (not= [rows cols] dims))
                             [(php// (php/+ 1 cols) 2.0) (php// (php/+ 1 rows) 2.0)]
                             prev-mpos)
-                look      (mouse-look keys mpos
-                                      (mouse-sensitivity (:settings world))
-                                      [rows cols])
+                look      (mouse-aim keys mpos
+                                     (mouse-sensitivity (:settings world))
+                                     [rows cols])
                 edges     (assoc edges0
                                  :fire      (or (:fire edges0) (:fire? look))
                                  :fire-held (or (:fire-held edges0) (:fire-held? look)))]
@@ -1034,38 +1043,49 @@
                   :quit)
 
               :else
-              ;; Stamp the scene height the renderer will use this frame
-              ;; so the vertical hitscan gate (issue #243) projects an
-              ;; enemy billboard against the exact rows the player sees.
-              ;; Same `:debug?`-aware HUD reservation as draw-frame's
-              ;; frame-stats, so the hit check and the draw agree.
-              (let [scened  (assoc world :scene-rows (scene-rows rows {:debug? (:debug? world)}))
-                    ;; Apply the mouselook yaw/pitch to the camera BEFORE the
-                    ;; tick so this frame's hitscan + render use the new
-                    ;; heading. Gated on not-paused so the camera can't drift
-                    ;; while a menu is up (tick-world freezes gameplay anyway,
-                    ;; but the steering yaw/pitch is outside that short-circuit).
-                    aimed   (if (:paused world) scened (apply-mouse-look scened look))
-                    ticked0 (tick-world aimed keys (php// ms 1000.0) edges)
+              ;; Stamp the scene height AND width the renderer will use this
+              ;; frame so the hitscan gates project against the exact view the
+              ;; player sees: `:scene-rows` for the vertical gate (#243),
+              ;; `:scene-cols` (= the cast width vw) for the off-centre
+              ;; reticle-column aim (#324). Same `:debug?`-aware HUD
+              ;; reservation as draw-frame's frame-stats, so the hit check and
+              ;; the draw agree.
+              (let [scened   (assoc world
+                                    :scene-rows (scene-rows rows {:debug? (:debug? world)})
+                                    :scene-cols cols)
+                    ;; Place the reticle + apply the edge-pan BEFORE the tick
+                    ;; so this frame's hitscan + crosshair use them. With the
+                    ;; mouse ON: stamp the reticle cell from mouse-aim and
+                    ;; (unpaused) edge-pan the camera. With the mouse OFF or
+                    ;; while paused: reset the reticle to centre (nil) so the
+                    ;; hitscan fires dead ahead + the crosshair sits centre,
+                    ;; exactly like keyboard-only play, and skip the edge-pan.
+                    reticled (if mouse-on?
+                               (set-reticle scened (:aim-col look) (:aim-row look))
+                               (reset-reticle scened))
+                    aimed    (if (and mouse-on? (not (:paused world)))
+                               (apply-mouse-look reticled look)
+                               reticled)
+                    ticked0  (tick-world aimed keys (php// ms 1000.0) edges)
                   ;; Pause overlay (#203): while paused (and not in the H
                   ;; info panel) the navigable pause MENU is up. up/down move
                   ;; the cursor, enter/space selects. Selecting Settings drops
                   ;; into the options sub-page (same nav); enter/space backs
                   ;; out to the menu. tick-world already froze gameplay,
                   ;; so this only drives menu/settings state.
-                    ticked  (cond
-                              (not (and (:paused ticked0) (not (:help? ticked0))))
-                              ticked0
-                              (= (:pause-screen ticked0) :settings)
-                              (let [s (step-settings! ticked0 keys)]
-                                (if (:confirm edges) (assoc s :pause-screen :menu) s))
-                              :else
-                              (step-pause-menu ticked0 (:cursor (nav-deltas keys)) (:confirm edges)))
+                    ticked   (cond
+                               (not (and (:paused ticked0) (not (:help? ticked0))))
+                               ticked0
+                               (= (:pause-screen ticked0) :settings)
+                               (let [s (step-settings! ticked0 keys)]
+                                 (if (:confirm edges) (assoc s :pause-screen :menu) s))
+                               :else
+                               (step-pause-menu ticked0 (:cursor (nav-deltas keys)) (:confirm edges)))
                   ;; F5 / F9 quick-save / load run here (file IO),
                   ;; outside the pure tick. Load swaps the whole world;
                   ;; both stamp a brief HUD flash so the player sees it
                   ;; took.
-                    world'  (handle-save-load ticked edges)]
+                    world'   (handle-save-load ticked edges)]
               ;; Resuming out of the pause/settings page persists the
               ;; player's choices (volumes were already applied live).
                 (when (resumed-pause? world world')

--- a/src/core/combat.phel
+++ b/src/core/combat.phel
@@ -1,6 +1,6 @@
 (ns phel-doom.core.combat
   (:require phel-doom.core.rng :as rng)
-  (:require phel-doom.core.engine     :refer [cast-ray])
+  (:require phel-doom.core.engine     :refer [cast-ray fov-proj-dist])
   (:require phel-doom.core.projection :refer [pitch-rows])
   (:require phel-doom.core.enemy      :refer [push-back-enemy shoot beam-impact splash pierce spread-shoot])
   (:require phel-doom.core.enemy-ai :refer [attacks? noise-wake])
@@ -545,9 +545,43 @@
 ;; § Shooting (one trigger pull → world update)
 ;; =====================================================================
 
-(defn- cast-wall-dist [world]
+(defn aim-angle-offset
+  "Radians to add to the player's facing so a hitscan aims at the movable
+   crosshair (#324). Maps the reticle's screen COLUMN to the per-column FOV
+   ray the renderer casts for that column: `atan((aim-col - center) / pd)`
+   where `center = scene-cols / 2` and `pd = fov-proj-dist(scene-cols)`.
+   Sharing the engine's `fov-proj-dist` keeps the shot's ray identical to
+   the column the player sees the reticle on, so the enemy whose projected
+   sprite the `+` sits over is the one struck.
+
+   Returns 0.0 (fire straight ahead, the centre-aim default) when the
+   reticle is at screen centre, OR when `aim-col` / `scene-cols` is nil
+   (mouse off / headless world): a centred reticle offsets nothing, so the
+   mouse-off render + hitscan stay byte-identical to the pre-#324 game."
+  [aim-col scene-cols]
+  (if (or (nil? aim-col) (nil? scene-cols) (php/<= scene-cols 0))
+    0.0
+    (let [center (php/* 0.5 scene-cols)
+          pd     (fov-proj-dist scene-cols)]
+      (php/atan (php// (php/- aim-col center) pd)))))
+
+(defn- aim-angle
+  "Player facing PLUS the reticle's angular offset (#324) - the direction
+   every hitscan / beam / cone is fired along. A mouse-off world (no
+   `:aim-col`) offsets 0, so this is just `:angle` and the shot fires dead
+   ahead exactly as before."
+  [world]
+  (php/+ (:angle (:player world))
+         (aim-angle-offset (:aim-col world) (:scene-cols world))))
+
+(defn- cast-wall-dist
+  "Distance to the wall along the AIM direction (#324): an off-centre
+   reticle steers the wall probe too, so the shot stops at the wall the
+   reticle points at, not the one dead ahead. Centre / mouse-off aims down
+   `:angle`, identical to the pre-#324 cast."
+  [world]
   (let [p (:player world)]
-    (cast-ray (:pgrid world) (:x p) (:y p) (:angle p))))
+    (cast-ray (:pgrid world) (:x p) (:y p) (aim-angle world))))
 
 (defn- aim-svh
   "Scene viewport height (rows) the hit gate projects against. The game
@@ -577,7 +611,9 @@
         dmg       (if (berserk? world) (php/* base-dmg (berserk-mul-for dmg-type)) base-dmg)
         max-range (or (:max-range spec) shot-max-range)
         svh       (aim-svh world)]
-    (shoot (:enemies world) (:x p) (:y p) (:angle p)
+    ;; Fire along the AIM direction (#324) so the reticle column selects the
+    ;; target enemy; a centred / mouse-off reticle reduces to `:angle`.
+    (shoot (:enemies world) (:x p) (:y p) (aim-angle world)
            (cast-wall-dist world)
            shot-hit-radius max-range dmg dmg-type
            svh (aim-pr world svh) (:floor-pgrid world)
@@ -734,12 +770,13 @@
         chain?    (pos? (or (:streak-secs world) 0.0))
         streak'   (if chain? (php/+ (or (:streak world) 0) 1) 1)
         ;; Shot-direction knockback: shove wounded enemies one cell
-        ;; back along the player's facing so heavy targets visibly
-        ;; recoil per hit. Skip on the killing blow so the corpse +
+        ;; back along the SHOT direction (the aim angle, #324) so an
+        ;; off-centre hit recoils away from the muzzle line, not the
+        ;; screen centre. Skip on the killing blow so the corpse +
         ;; loot drop stay on the death cell.
         pushed-es (if killed?
                     enemies-after
-                    (let [a     (:angle (:player world))
+                    (let [a     (aim-angle world)
                           cos-a (php/cos a)
                           sin-a (php/sin a)]
                       (push-back-enemy enemies-after (:grid world)
@@ -902,7 +939,7 @@
         dmg          (if (berserk? world) (php/* base (berserk-mul-for dtype)) base)
         max-r        (or (:max-range spec) shot-max-range)
         wall-d       (cast-wall-dist world)
-        [ix iy]      (beam-impact (:enemies world) (:x p) (:y p) (:angle p)
+        [ix iy]      (beam-impact (:enemies world) (:x p) (:y p) (aim-angle world)
                                   wall-d shot-hit-radius max-r)
         [es' killed] (splash (:enemies world) ix iy radius dmg dtype)
         woken        (noise-wake es' (:grid world) (:x p) (:y p))
@@ -1004,7 +1041,7 @@
         max-r                      (or (:max-range spec) shot-max-range)
         wall-d                     (cast-wall-dist world)
         svh                        (aim-svh world)
-        [es' killed hit-pos tough] (pierce (:enemies world) (:x p) (:y p) (:angle p)
+        [es' killed hit-pos tough] (pierce (:enemies world) (:x p) (:y p) (aim-angle world)
                                            wall-d shot-hit-radius max-r dmg dtype
                                            svh (aim-pr world svh) (:floor-pgrid world)
                                            (or (:eye-z p) 0.5))]
@@ -1029,7 +1066,7 @@
         max-r                      (or (:max-range spec) shot-max-range)
         wall-d                     (cast-wall-dist world)
         svh                        (aim-svh world)
-        [es' killed hit-pos tough] (spread-shoot (:enemies world) (:x p) (:y p) (:angle p)
+        [es' killed hit-pos tough] (spread-shoot (:enemies world) (:x p) (:y p) (aim-angle world)
                                                  wall-d half max-r prim graze targets dtype
                                                  svh (aim-pr world svh) (:floor-pgrid world)
                                                  (or (:eye-z p) 0.5))]

--- a/src/core/state.phel
+++ b/src/core/state.phel
@@ -306,6 +306,16 @@
    ;; :mag and :ammo-reserve mirror the active weapon's live state so
    ;; combat / render / HUD code can read them without an extra hop;
    ;; weapons/switch keeps the mirror in sync.
+   ;; Movable aim crosshair (#324). The reticle's viewport cell the gun
+   ;; aims at: combat reads :aim-col (+ :scene-cols) to steer the off-centre
+   ;; hitscan, render paints the `+` at (:aim-col, :aim-row). nil = centred
+   ;; (mouse off / not yet placed): combat then offsets 0 and render draws
+   ;; at screen centre, so a fresh / mouse-off world stays byte-identical to
+   ;; the pre-#324 centre-aim. The play loop stamps concrete cells from
+   ;; controls/mouse-aim while the mouse is on and resets them to nil on a
+   ;; resize or when the mouse is off (see reset-reticle).
+   :aim-col        nil
+   :aim-row        nil
    :weapon         :pistol
    ;; Fresh runs only own the pistol. Shotgun + chaingun must be
    ;; found on the map (level.phel/maybe-spawn-weapon-pickup).
@@ -469,3 +479,25 @@
   "Rotate the player by dtheta radians."
   [world dtheta]
   (assoc-in world [:player :angle] (+ (:angle (:player world)) dtheta)))
+
+(defn set-reticle
+  "Place the movable aim crosshair (#324) at viewport cell `(col, row)`:
+   combat reads `:aim-col` to steer the off-centre hitscan and render
+   paints the `+` there. The play loop calls this each frame the mouse is
+   on with the reticle position controls/mouse-aim returned. A nil col/row
+   centres that axis (see reset-reticle), so passing the mouse-aim result
+   straight through keeps a no-dims / no-pointer frame centred."
+  [world col row]
+  (assoc world :aim-col col :aim-row row))
+
+(defn reset-reticle
+  "Centre the movable aim crosshair (#324) by clearing `:aim-col` /
+   `:aim-row` to nil. nil is the centred sentinel both consumers honour:
+   combat's `aim-angle-offset` returns 0 (fire dead ahead) and render's
+   `paint-crosshair` draws at screen centre. The play loop calls this when
+   the mouse is OFF and on a terminal resize (the old absolute cell coords
+   stop meaning the same screen spot under a new size), so keyboard-only
+   play and every mouse-off frame behave exactly like the pre-#324 centre
+   aim."
+  [world]
+  (assoc world :aim-col nil :aim-row nil))

--- a/src/glue/controls.phel
+++ b/src/glue/controls.phel
@@ -294,8 +294,8 @@
   "SGR-extended mouse report (issue #246): ESC [ < b ; Cx ; Cy (M|m).
    Stripped from the drain string before the movement byte-walk so the
    `<` (turn-left) / `>` (turn-right) / digit bytes inside a report can
-   never be mistaken for keyboard movement. controls/mouse-look reads the
-   same reports separately for the positional steering pointer position."
+   never be mistaken for keyboard movement. controls/mouse-aim reads the
+   same reports separately for the reticle position + edge-pan (#324)."
   "/\\x1b\\[<\\d+;\\d+;\\d+[Mm]/")
 
 (defn- strip-mouse-reports
@@ -324,7 +324,7 @@
                  (refresh-move w (php/substr normalised i 1))))))))
 
 ;; =====================================================================
-;; § Mouse look (issue #246)
+;; § Movable aim crosshair (issue #324, was positional steering #318/#320)
 ;;
 ;; init-input! (io) enables xterm SGR-extended mouse reporting
 ;; (`\e[?1006h`) + any-motion tracking (`\e[?1003h`). The terminal then
@@ -338,46 +338,53 @@
 ;;     bit  5   : motion (a drag / bare-move report, `b & 32`)
 ;;     bit  6   : wheel      (`b & 64`)
 ;;
-;; POSITIONAL STEERING (#318): a terminal can only report ABSOLUTE cell
-;; coords and offers NO pointer lock / warp, so a delta-based 1:1 model
-;; loses the pointer the instant a fast flick carries it off the window
-;; (the terminal then stops reporting, the camera freezes, and the OS
-;; pointer races on - #313). Instead the camera turn-RATE is a function of
-;; how far the pointer sits from the terminal CENTER, applied EVERY frame:
-;;     yaw   = steer-rate(pointer_x, cols, mouse-yaw-rate-max)   * sens
-;;     pitch = -steer-rate(pointer_y, rows, mouse-pitch-rate-max) * sens
-;; A central DEADZONE means precise aim (no turn); nudging the pointer
-;; toward an edge starts turning, and HOLDING it off-center keeps turning
-;; (a full 360) because the rate is read from the CACHED position every
-;; frame, not from motion. So the pointer barely has to move and stays in
-;; the window; if it does leave at an edge, the last cached position keeps
-;; turning that way until the player brings it back - recoverable, not the
-;; old freeze.
+;; MOVABLE AIM CROSSHAIR (#324): a `+` reticle follows the pointer 1:1 and
+;; the gun fires toward wherever it points (the off-centre hitscan lives in
+;; core/combat, fed the reticle column). A terminal can only report
+;; ABSOLUTE cell coords and offers NO pointer lock / warp / hide (#313), so
+;; the reticle is the pointer's absolute cell CLAMPED to the viewport:
+;;     aim-col = reticle-axis(pointer_x, cols, sens)
+;;     aim-row = reticle-axis(pointer_y, rows, sens)
+;; Clamped-absolute is the whole point: when the OS pointer wanders off the
+;; window the reticle PINS at the border (it can't follow past the edge),
+;; and an EDGE-PAN turns the camera so the player can still aim beyond the
+;; current view - aiming never freezes mid-screen the way a raw 1:1
+;; mouselook would. The central region is pure 1:1 reticle movement with NO
+;; camera turn; only the OUTER BAND pans:
+;;     yaw   =  edge-pan-rate(aim-col, cols, mouse-yaw-rate-max)   * sens
+;;     pitch = -edge-pan-rate(aim-row, rows, mouse-pitch-rate-max) * sens
+;; Holding the reticle in the band keeps panning every frame with no new
+;; bytes, because the rate is read from the CACHED pointer position - so a
+;; pointer parked at (or past) an edge keeps the camera turning until the
+;; player brings it back.
 ;;
 ;; This stays PURE: it consumes the drained byte string, the previous
-;; pointer position and the live [rows cols], and returns the per-frame
-;; yaw/pitch + fire intent; io/input owns the escape emission + STDIN read
-;; + the periodic mouse re-arm.
+;; pointer position and the live [rows cols], and returns the reticle
+;; position + per-frame edge-pan yaw/pitch + fire intent; io/input owns the
+;; escape emission + STDIN read + the periodic mouse re-arm.
 ;; =====================================================================
 
-(def mouse-deadzone-frac
-  "Fraction of each half-axis around the terminal CENTER where the pointer
-   produces NO turn (#318). 0.10 leaves the central ~10% of each half as a
-   precise-aim deadzone so small in-frame jitter near the crosshair never
-   creeps the camera; past it the steer-rate ramps in."
-  0.10)
+(def mouse-edge-band-frac
+  "Fraction of each half-axis, measured from the screen EDGE inward, where
+   the reticle edge-pans the camera (#324). 0.30 leaves the central ~70% of
+   each half as a pure 1:1 aim region (no camera turn) and pans only in the
+   outer 30% near each border, ramping in from 0 at the band's inner lip to
+   the max rate at the very edge. Picked wide enough that the player can
+   comfortably park the reticle in the band to swing the view, yet tight
+   enough that ordinary centre-screen aiming never creeps the camera."
+  0.30)
 
 (def mouse-yaw-rate-max
-  "Radians of yaw per frame when the pointer is pinned to the far LEFT /
-   RIGHT edge, before the player's sensitivity multiplier (#318). At 60fps
+  "Radians of yaw per frame when the reticle is pinned to the far LEFT /
+   RIGHT edge, before the player's sensitivity multiplier (#324). At 60fps
    0.16 rad/frame sweeps a full 360 in ~0.65s held at the edge, so a player
-   can spin around fast by parking the pointer at an edge yet still aim
-   finely near center (the rate eases in from the deadzone)."
+   can swing the view fast by pushing the reticle to a border yet still aim
+   finely in the centre region (the rate eases in from the band lip)."
   0.16)
 
 (def mouse-pitch-rate-max
-  "Look up/down `:pitch` FRACTION per frame when the pointer is pinned to
-   the top / bottom edge, before sensitivity (#318). The pitch axis is a
+  "Look up/down `:pitch` FRACTION per frame when the reticle is pinned to
+   the top / bottom edge, before sensitivity (#324). The pitch axis is a
    clamped fraction in [-1, 1] (state/clamp-pitch), so 0.06/frame ramps
    from level to fully-up (or down) in ~17 edge-held frames (~0.3s) and
    then saturates."
@@ -390,7 +397,7 @@
 
 (def mouse-wheel-bit
   "Bit 6 of the SGR button code: set on a scroll-wheel report. Wheel
-   events carry no useful look delta, so they are skipped."
+   events carry no useful aim delta, so they are skipped."
   64)
 
 (defn- mouse-button
@@ -432,14 +439,13 @@
 
 (defn- fold-mouse-event
   "Fold one parsed SGR event [b x y final] into the running accumulator
-   `{:fire? :held? :pos}` (#318). A position report advances `:pos` to the
-   reported cell so the steer-rate is read from the latest known pointer
+   `{:fire? :held? :pos}` (#324). A position report advances `:pos` to the
+   reported cell so the reticle + edge-pan read the latest known pointer
    spot; a fresh left press sets `:fire?`; a left press / drag sets
    `:held?`. A scroll-WHEEL tick carries no aim intent, so it is not a fire
-   - but `:pos` still trails it so a following motion steers from the true
-   pointer cell. Unlike the old delta model there is no baseline / re-entry
-   bookkeeping: positional steering only cares WHERE the pointer is, never
-   how far it jumped, so a leave-and-return simply resumes steering from
+   - but `:pos` still trails it so a following motion places the reticle
+   from the true pointer cell. The reticle only cares WHERE the pointer is,
+   never how far it jumped, so a leave-and-return simply re-tracks from
    wherever it reappears."
   [acc b x y final]
   {:fire? (or (:fire? acc) (left-press? b final))
@@ -454,42 +460,72 @@
     (php/< n 0) -1.0
     :else       0.0))
 
-(defn steer-rate
-  "Positional steering rate (#318) for a 1-based pointer cell `p` on an
-   axis `len` cells long, ramping out to `max-rate` at the screen edge.
-   Builds a central DEADZONE (`mouse-deadzone-frac` of the half-axis) where
-   the pointer produces NO turn for precise aim, then an EASE-IN ramp
-   (frac^2, gentle near center) out to `max-rate` at the far edge, signed
-   by which side of center the pointer is on. Returns 0.0 in the deadzone,
-   when `len` is nil, or when `len <= 1` (a degenerate axis), so a missing
-   dimension never auto-steers."
-  [p len ^float max-rate]
+(defn reticle-axis
+  "Map a 1-based pointer cell `p` to the reticle's 0-based viewport cell on
+   an axis `len` cells long, CLAMPED into `[0, len-1]` (#324). The reticle
+   tracks the pointer's ABSOLUTE position scaled around the axis centre by
+   `sens`:
+     center = (len - 1) / 2          ; 0-based middle cell
+     reticle = clamp(center + (p - 1 - center) * sens, 0, len - 1)
+   At `sens` 1.0 this is 1:1 (pointer cell 60 -> reticle col 59, a 20-cell
+   pointer move is a 20-cell reticle move); a higher `sens` moves the
+   reticle further per pointer cell, a lower one less. The clamp PINS the
+   reticle at the first / last cell when the pointer sits at or beyond the
+   window edge, so the OS pointer drifting out of the window leaves the
+   reticle on the border (where edge-pan takes over) instead of losing it.
+   Returns nil when `len` is nil or `<= 1` (a degenerate axis has no
+   viewport to place the reticle in)."
+  [p len ^float sens]
+  (if (or (nil? len) (php/<= len 1))
+    nil
+    (let [center (php// (php/- len 1) 2.0)
+          off    (php/* (php/- (php/- p 1) center) sens)
+          raw    (php/+ center off)]
+      (php/max 0.0 (php/min (php/* 1.0 (php/- len 1)) raw)))))
+
+(defn edge-pan-rate
+  "Edge-pan rate (#324) for a 0-based reticle cell `r` on an axis `len`
+   cells long, ramping out to `max-rate` at the screen edge. The inner
+   centre region (everything but the outer `mouse-edge-band-frac` of each
+   half-axis) produces NO turn - pure 1:1 aim - then an EASE-IN ramp
+   (frac^2, gentle at the band lip) reaches `max-rate` at the far edge cell,
+   signed by which side of centre the reticle is on. Returns 0.0 inside the
+   centre region, when `len` is nil, or when `len <= 1` (a degenerate axis),
+   so a missing dimension never auto-pans. The mirror of the band that
+   `reticle-axis` clamps the reticle into: the reticle can only reach the
+   panning band by being pushed against a border."
+  [r len ^float max-rate]
   (if (or (nil? len) (php/<= len 1))
     0.0
-    (let [center (php// (php/+ 1 len) 2.0)         ; geometric middle cell
-          half   (php/- center 1)                  ; cells from center to edge
-          off    (php/- p center)                  ; signed offset from center
-          dead   (php/* mouse-deadzone-frac half)  ; no-turn radius
-          mag    (php/- (php/abs off) dead)]        ; travel past the deadzone
+    (let [center (php// (php/- len 1) 2.0)        ; 0-based middle cell
+          half   center                            ; cells from centre to edge
+          off    (php/- r center)                  ; signed offset from centre
+          dead   (php/* (php/- 1.0 mouse-edge-band-frac) half) ; no-pan radius
+          mag    (php/- (php/abs off) dead)]       ; travel into the band
       (if (php/<= mag 0)
         0.0
-        (let [span  (php/- half dead)               ; deadzone-edge -> screen-edge
+        (let [span  (php/- half dead)              ; band lip -> screen edge
               frac  (php/min 1.0 (php// mag span))
-              ;; Ease-in (square): fine control near center, full rate at the
-              ;; edge. Squaring keeps the sign via the explicit sign(off).
+              ;; Ease-in (square): gentle at the lip, full rate at the edge.
+              ;; Squaring keeps the sign via the explicit sign(off).
               eased (php/* frac frac)]
           (php/* (php/* max-rate eased) (sign off)))))))
 
-(defn mouse-look
-  "Pure SGR-mouse reader for POSITIONAL mouselook (#318, was #246). Parses
-   the drained byte string `keys` for xterm SGR mouse reports, caches the
-   latest pointer position (carrying `prev-pos` `[x y]` forward when no
-   report arrives this frame), and returns:
+(defn mouse-aim
+  "Pure SGR-mouse reader for the movable aim crosshair (#324, was #246).
+   Parses the drained byte string `keys` for xterm SGR mouse reports,
+   caches the latest pointer position (carrying `prev-pos` `[x y]` forward
+   when no report arrives this frame), and returns:
 
-     {:yaw        signed radians to add to the player's :angle THIS frame,
-                  as a steering RATE from the pointer's distance to center
-      :pitch      signed fraction to add to the player's :pitch (look up
-                  is +, look down is -; clamp via state/clamp-pitch)
+     {:aim-col    reticle column (0-based viewport cell), the gun's aim
+                  point; nil when `dims` is omitted / nil
+      :aim-row    reticle row (0-based viewport cell); nil without `dims`
+      :yaw        signed radians to add to the player's :angle THIS frame,
+                  an edge-pan RATE that is non-zero only while the reticle
+                  sits in the outer band (0 in the centre region)
+      :pitch      signed fraction to add to the player's :pitch (look up is
+                  +, look down is -; clamp via state/clamp-pitch), the
+                  vertical edge-pan
       :fire?      true on a fresh left-button press (rising edge - a press
                   report arrives once, so this maps onto the space-fire
                   path directly)
@@ -497,25 +533,24 @@
                   auto-fire weapons like the :fire-held space path)
       :pos        the pointer position to thread into the next frame}
 
-   Positional steering (#318): a terminal offers NO pointer lock / warp, so
-   instead of a 1:1 delta the camera turn-RATE is a function of how far the
-   cached pointer sits from the terminal CENTER, applied EVERY frame:
-     yaw   = steer-rate(x, cols, mouse-yaw-rate-max)   * sensitivity
-     pitch = -steer-rate(y, rows, mouse-pitch-rate-max) * sensitivity
-   A central deadzone means precise aim; nudging toward an edge turns, and
-   HOLDING the pointer off-center keeps turning because the rate is read
-   from `:pos` every frame - so an empty `keys` string still returns the
-   steering yaw/pitch from the last known position. Pitch y is NEGATED:
-   screen rows grow DOWNWARD, so a pointer ABOVE center (smaller y) looks
-   UP (+pitch).
+   Movable crosshair (#324): a terminal offers NO pointer lock / warp /
+   hide, so the reticle is the pointer's ABSOLUTE cell clamped to the
+   viewport (`reticle-axis`), moving 1:1 (scaled by `sensitivity`). Pushing
+   the reticle into the outer band edge-pans the camera
+   (`edge-pan-rate`), applied EVERY frame from the cached `:pos` - so an
+   empty `keys` string still returns the edge-pan yaw/pitch from the last
+   known position, and a pointer that left the window at an edge keeps the
+   camera turning. Pitch y is NEGATED: screen rows grow DOWNWARD, so a
+   reticle near the TOP looks UP (+pitch).
 
-   `sensitivity` is a positive scalar (1.0 = neutral) multiplied into both
-   axes (0 disables the look but still lets a click fire). `dims` is the
-   live `[rows cols]`; it supplies the axis lengths steer-rate needs.
-   Omitting it (or nil) yields zero yaw/pitch - the steering is inert
-   without knowing where the edges are - while fire intent still parses, so
-   non-loop callers are unaffected. A non-mouse sequence (kitty CSI-u key,
-   arrow, F-key) matches nothing, so the keyboard path is never disturbed."
+   `sensitivity` is a positive scalar (1.0 = neutral) scaling both the
+   reticle speed and the edge-pan rate (0 disables the look but still lets a
+   click fire). `dims` is the live `[rows cols]`; it supplies the axis
+   lengths the reticle + band need. Omitting it (or nil) yields a nil
+   reticle and zero yaw/pitch - the aim is inert without knowing the
+   viewport - while fire intent still parses, so non-loop callers are
+   unaffected. A non-mouse sequence (kitty CSI-u key, arrow, F-key) matches
+   nothing, so the keyboard path is never disturbed."
   [keys prev-pos ^float sensitivity & [dims]]
   (let [matches (php/array)
         rows    (when (some? dims) (get dims 0))
@@ -530,19 +565,23 @@
           n      (php/count bs)]
       (loop [i 0 acc {:fire? false :held? false :pos prev-pos}]
         (if (php/>= i n)
-          (let [pos (:pos acc)
-                ;; Steering reads the FINAL cached position, so a held
-                ;; (motionless) pointer keeps producing yaw/pitch with no
-                ;; new bytes - the core of the escape-proof model.
-                x   (when (some? pos) (get pos 0))
-                y   (when (some? pos) (get pos 1))]
-            {:yaw        (if (some? pos)
-                           (php/* (steer-rate x cols mouse-yaw-rate-max) sensitivity)
+          (let [pos     (:pos acc)
+                ;; The reticle + edge-pan read the FINAL cached position, so
+                ;; a held (motionless) pointer keeps producing the same
+                ;; reticle + pan with no new bytes - the escape-proof model.
+                x       (when (some? pos) (get pos 0))
+                y       (when (some? pos) (get pos 1))
+                aim-col (when (some? pos) (reticle-axis x cols sensitivity))
+                aim-row (when (some? pos) (reticle-axis y rows sensitivity))]
+            {:aim-col    aim-col
+             :aim-row    aim-row
+             :yaw        (if (some? aim-col)
+                           (php/* (edge-pan-rate aim-col cols mouse-yaw-rate-max) sensitivity)
                            0.0)
-             ;; Negate the pitch rate: a pointer ABOVE center (smaller y)
+             ;; Negate the pitch rate: a reticle near the TOP (smaller row)
              ;; must look UP (+pitch) even though rows grow downward.
-             :pitch      (if (some? pos)
-                           (php/- 0 (php/* (steer-rate y rows mouse-pitch-rate-max) sensitivity))
+             :pitch      (if (some? aim-row)
+                           (php/- 0 (php/* (edge-pan-rate aim-row rows mouse-pitch-rate-max) sensitivity))
                            0.0)
              :fire?      (:fire? acc)
              :fire-held? (:held? acc)

--- a/src/io/render/main.phel
+++ b/src/io/render/main.phel
@@ -2508,8 +2508,18 @@
       ;; shade, which mismatched the textured wall and read as a fake light
       ;; box). Fallback to the column's flat wall shade only if the centre
       ;; was never captured (degenerate viewport).
-      (let [c-col       (php/intdiv svw 2)
-            center-cell (or (php/aget center-cap 0)
+      ;; Reticle scene column (#324): the cell whose BG the `+` paints on.
+      ;; The reticle's terminal-coord 0-based column (:aim-col) maps to its
+      ;; scene column by the pixel-double scale; absent (mouse off) it is the
+      ;; scene centre, and the row loop's live `center-cap` capture is reused
+      ;; there verbatim so the mouse-off frame stays byte-identical. Off the
+      ;; centre we fall back to that column's wall shade (the live textured
+      ;; cell was only captured at the centre).
+      (let [aim-col     (get stats :aim-col)
+            c-col       (if (php/=== nil aim-col)
+                          (php/intdiv svw 2)
+                          (php/max 0 (php/min (php/- svw 1) (php/intdiv aim-col px-sc))))
+            center-cell (or (when (php/=== c-col (php/intdiv svw 2)) (php/aget center-cap 0))
                             (buf-get shades-normal c-col))
             center-bg   (php/mb_substr center-cell 0
                                        (php/max 0 (php/- (php/mb_strlen center-cell) 1)))

--- a/src/io/render/paint.phel
+++ b/src/io/render/paint.phel
@@ -96,45 +96,61 @@
 ;; =====================================================================
 
 (defn paint-crosshair
-  "Centre reticle glyph, style from the Crosshair setting (`+` cross /
+  "Aim reticle glyph, style from the Crosshair setting (`+` cross /
    `·` dot / `○` open / hidden when `:off`). Jumps one row up + brightens
    while :fire-anim > 0 so the recoil feels like a kick; a live hit-fx
    overrides the idle glyph with a `✗`/`×` hit-marker (even when `:off`).
 
-   FPS-aim guarantee (#246): the screen-centre crosshair IS the mouse
-   aim point (the OS pointer stays hidden), so when mouselook is ON
-   (`:mouse` true) the `:off` style still paints a minimal centre dot
-   `·` rather than leaving the player with no aim indicator. With the
-   mouse off, `:off` keeps hiding the idle reticle as before (the
-   hit-marker still flashes on a hit regardless).
+   Movable crosshair (#324): the reticle is drawn at the world's reticle
+   cell `(:aim-col, :aim-row)` (0-based viewport cells the player moved the
+   mouse to), so the `+` is the aim point wherever it points. When the
+   reticle is absent (`:aim-col` nil - mouse off / not yet placed) it falls
+   back to the FIXED screen centre `(vw/2 + 1, vh/2)`, byte-identical to the
+   pre-#324 centre crosshair, so keyboard-only / mouse-off frames are
+   unchanged. The firing one-row jump + the hit-marker apply at the reticle
+   position.
+
+   FPS-aim guarantee (#246): the crosshair IS the mouse aim point (the OS
+   pointer stays hidden / unlockable), so when the mouse is ON (`:mouse`
+   true) the `:off` style still paints a minimal dot `·` rather than leaving
+   the player with no aim indicator. With the mouse off, `:off` keeps hiding
+   the idle reticle as before (the hit-marker still flashes on a hit).
 
    `center-bg` is the SGR-only prefix of the cell currently under the
-   crosshair (the wall/door body shade at the centre column). Painting
-   the `+` on that BG keeps the cell's real colour visible underneath
-   instead of clobbering it with the terminal default."
+   reticle (the wall/door body shade at the reticle column). Painting the
+   `+` on that BG keeps the cell's real colour visible underneath instead of
+   clobbering it with the terminal default."
   [parts stats vw vh center-bg]
-  (let [firing? (php/> (or (get stats :fire-anim) 0.0) 0.0)
-        ch-row  (php/+ (php/intdiv vh 2) (if firing? 0 1))
-        ch-col  (php/+ (php/intdiv vw 2) 1)
+  (let [firing?  (php/> (or (get stats :fire-anim) 0.0) 0.0)
+        ;; Reticle cell (0-based) the mouse moved to, or the fixed centre
+        ;; when absent. Cursor coords are 1-based, so add 1. The non-firing
+        ;; idle row is `+1` over the projected centre (centre default
+        ;; `vh/2 + 1`); firing lifts it one row.
+        aim-col  (get stats :aim-col)
+        aim-row  (get stats :aim-row)
+        base-col (if (php/=== nil aim-col) (php/+ (php/intdiv vw 2) 1) (php/+ aim-col 1))
+        base-row (if (php/=== nil aim-row) (php/+ (php/intdiv vh 2) 1) (php/+ aim-row 1))
+        ch-col   base-col
+        ch-row   (php/- base-row (if firing? 1 0))
         ;; Hit-marker (issue #201): a live :hit-fx overrides the reticle
         ;; for its brief ttl - a bold-red ✗ confirms a kill, a bold-yellow
         ;; × confirms a wound. Single-shot feedback (it does not strobe).
-        hit-fx  (get stats :hit-fx)
-        hit?    (and hit-fx (php/> (or (:ttl hit-fx) 0.0) 0.0))
-        kill?   (and hit? (:kill? hit-fx))
+        hit-fx   (get stats :hit-fx)
+        hit?     (and hit-fx (php/> (or (:ttl hit-fx) 0.0) 0.0))
+        kill?    (and hit? (:kill? hit-fx))
         ;; Idle reticle glyph from the crosshair-style setting (#203);
         ;; :off normally draws nothing when idle (nil glyph). But while
         ;; mouselook is on the centre reticle IS the aim point, so :off
         ;; falls back to a minimal dot so the player always has an aim
         ;; indicator (#246). The hit-marker overrides regardless so a hit
         ;; always confirms.
-        mouse?  (boolean (get stats :mouse))
-        style   (or (get stats :crosshair) :cross)
-        idle    (cond (= style :dot)  "·"
-                      (= style :open) "○"
-                      (= style :off)  (if mouse? "·" nil)
-                      :else           "+")
-        glyph   (cond kill? "✗" hit? "×" :else idle)
+        mouse?   (boolean (get stats :mouse))
+        style    (or (get stats :crosshair) :cross)
+        idle     (cond (= style :dot)  "·"
+                       (= style :open) "○"
+                       (= style :off)  (if mouse? "·" nil)
+                       :else           "+")
+        glyph    (cond kill? "✗" hit? "×" :else idle)
         ;; Idle: bold bright-white (NOT the old faint `2`, which read as a
         ;; translucent smudge against the busy half-block floor). Firing:
         ;; bold bright-yellow as a muzzle-kick flash, paired with the
@@ -144,10 +160,10 @@
         ;; hit almost always lands on the same frame the muzzle flash is
         ;; up, so the two yellows never perceptibly collide - a kill (red)
         ;; is the only state that needs to stand apart.
-        ch-att  (cond kill?   "\e[91;1m"
-                      hit?    "\e[93;1m"
-                      firing? "\e[93;1m"
-                      :else   "\e[97;1m")]
+        ch-att   (cond kill?   "\e[91;1m"
+                       hit?    "\e[93;1m"
+                       firing? "\e[93;1m"
+                       :else   "\e[97;1m")]
     (when glyph
       (buf-push parts
                 (str "\e[" ch-row ";" ch-col "H" center-bg ch-att glyph "\e[0m"))))

--- a/tests/commands/play-test.phel
+++ b/tests/commands/play-test.phel
@@ -80,6 +80,22 @@
     ;; Blood fx was pushed.
     (is (>= (count (:fx w')) 1))))
 
+(deftest test-tick-world-reticle-column-aims-the-shot
+  ;; Movable aim crosshair end-to-end (#324): an enemy OFF the centre axis
+  ;; (perp ~0.54 > the 0.5 hit radius) is MISSED with the reticle centred
+  ;; but HIT once the world carries the reticle column over it. Proves
+  ;; :aim-col + :scene-cols thread from the world through tick-world's fire
+  ;; path. Player (2,5) facing east; enemy (4.95, 5.54) projects to col ~73
+  ;; on a 120-wide scene. rng seeded - the pistol hit rolls pain (#309).
+  (rng/seed! 1)
+  (let [base    (-> (new-world open-grid (new-player 2.0 5.0 0.0))
+                    (with-enemies [(assoc (new-enemy 4.95 5.54 3 :caco) :lives 1)])
+                    (assoc :scene-cols 120))
+        centred (tick-world (assoc base :aim-col 60) "" 0.016 (assoc no-edges :fire true))
+        aimed   (tick-world (assoc base :aim-col 73) "" 0.016 (assoc no-edges :fire true))]
+    (is (= 0 (:kills centred)) "centred reticle misses the off-axis enemy")
+    (is (= 1 (:kills aimed))   "reticle over the enemy lands the shot")))
+
 (deftest test-tick-world-tough-kill-arms-hit-stop
   ;; Caco (max-lives 3) dropped to 1 HP so one pistol shot kills it.
   ;; A meaty kill must stamp the hit-stop freeze timer.
@@ -298,8 +314,8 @@
         "a mid-reload frame does not arm the flash")))
 
 ;; ---------------------------------------------------------------------
-;; Mouse look application (issue #246): apply-mouse-look folds the
-;; controls/mouse-look yaw + pitch delta into the player. Fire fields are
+;; Mouse edge-pan application (#324, was #246): apply-mouse-look folds the
+;; controls/mouse-aim yaw + pitch edge-pan into the player. Fire fields are
 ;; NOT applied here (they ride the edges into tick-shooting).
 ;; ---------------------------------------------------------------------
 

--- a/tests/core/combat-test.phel
+++ b/tests/core/combat-test.phel
@@ -1,9 +1,10 @@
 (ns phel-doom-tests.core.combat-test
   (:require phel.test :refer [deftest is])
+  (:require phel-doom.core.rng :as rng)
   (:require phel-doom.core.state :refer [new-world new-player max-lives])
   (:require phel-doom.core.enemy :refer [new-enemy])
   (:require phel-doom.core.combat
-            :refer [arm-berserk armory-reserve closest-attacker attacker-side attacker-octant berserk? berserk-damage-mul berserk-melee-mul berserk-mul-for berserk-seconds can-fire? apply-heat damage-step empty-click-seconds enemy-hit-damage hit-damage-for hit-player-at hit-stop-for hit-stop-tough-seconds hit-stop-boss-seconds invuln? invuln-seconds knockback mag-size pick-loot-weapon player-immune? push-sfx reload reloading? roll-loot-kind tick-armory tick-shooting]))
+            :refer [aim-angle-offset arm-berserk armory-reserve closest-attacker attacker-side attacker-octant berserk? berserk-damage-mul berserk-melee-mul berserk-mul-for berserk-seconds can-fire? apply-heat damage-step empty-click-seconds enemy-hit-damage fire-shot hit-damage-for hit-player-at hit-stop-for hit-stop-tough-seconds hit-stop-boss-seconds invuln? invuln-seconds knockback mag-size pick-loot-weapon player-immune? push-sfx reload reloading? roll-loot-kind tick-armory tick-shooting]))
 
 ;; ---------------------------------------------------------------------
 ;; closest-attacker: selection rule.
@@ -1103,3 +1104,100 @@
   (let [w (-> {} (push-sfx :hit 1.0) (push-sfx :kill 0.6))]
     (is (= [{:name :hit :vol 1.0} {:name :kill :vol 0.6}] (:sfx w))
         "events stay in enqueue order")))
+
+;; ---------------------------------------------------------------------
+;; Off-center hitscan via the movable aim crosshair (#324). The reticle
+;; column is mapped to an angular offset added to the player's facing
+;; (the SAME per-column FOV ray the renderer casts), so a shot lands on
+;; the enemy whose projected sprite column the reticle sits over - not the
+;; fixed screen-centre axis. `aim-angle-offset` is the pure column->radians
+;; map; `fire-shot` reads `:aim-col` / `:scene-cols` off the world to steer
+;; the hitscan.
+;; ---------------------------------------------------------------------
+
+;; A wide-open chamber so the forward ray has room before any wall.
+(def aim-chamber
+  [[1 1 1 1 1 1 1 1 1 1 1 1]
+   [1 0 0 0 0 0 0 0 0 0 0 1]
+   [1 0 0 0 0 0 0 0 0 0 0 1]
+   [1 0 0 0 0 0 0 0 0 0 0 1]
+   [1 0 0 0 0 0 0 0 0 0 0 1]
+   [1 0 0 0 0 0 0 0 0 0 0 1]
+   [1 0 0 0 0 0 0 0 0 0 0 1]
+   [1 0 0 0 0 0 0 0 0 0 0 1]
+   [1 1 1 1 1 1 1 1 1 1 1 1]])
+
+(defn- aim-world [enemies aim-col]
+  ;; Player near the west wall facing east (angle 0). An enemy sits OFF
+  ;; the centre axis (right of facing). `:scene-cols` 120 / `:scene-rows`
+  ;; nil (vertical gate disabled, so the column test stands alone). The
+  ;; pistol is :pierce?, so fire-shot routes through pierce-fire.
+  (-> (new-world aim-chamber (new-player 1.5 4.5 0.0))
+      (assoc :enemies enemies
+             :weapon :pistol
+             :scene-cols 120
+             :aim-col aim-col)))
+
+;; Enemy at angular offset +0.15 rad off the player's facing, ~4 units out:
+;; (5.455, 5.098). On the centre ray its perpendicular distance is ~0.598
+;; > shot-hit-radius (0.5), so a centre-axis shot MISSES; its projected
+;; screen column on a 120-wide scene is ~71 (centre 60), so a reticle at
+;; column 71 aims a ray straight through it.
+(def aim-enemy-x 5.455)
+(def aim-enemy-y 5.098)
+(def aim-enemy-col 71)
+
+(deftest test-fire-shot-misses-off-center-enemy-with-centered-reticle
+  ;; Reticle at screen centre (col 60): the shot keeps the old centre-axis
+  ;; behaviour and the off-axis enemy is NOT hit (no wound flash, full HP).
+  (rng/seed! 1)
+  (let [e   (new-enemy aim-enemy-x aim-enemy-y 3 :caco)
+        w'  (fire-shot (aim-world [e] 60))
+        hit (first (:enemies w'))]
+    (is (= 3 (:lives hit)) "centred reticle leaves the off-axis enemy unharmed")
+    (is (nil? (:hit-fx w')) "no hit-marker when the centred shot misses")))
+
+(deftest test-fire-shot-hits-off-center-enemy-when-reticle-over-it
+  ;; Reticle at the enemy's projected column (71): the hitscan steers to
+  ;; that column and the off-axis enemy takes the pistol's 1 damage (3 -> 2)
+  ;; plus a hit-marker. This FAILS under the old centre-only hitscan.
+  (rng/seed! 1)
+  (let [e   (new-enemy aim-enemy-x aim-enemy-y 3 :caco)
+        w'  (fire-shot (aim-world [e] aim-enemy-col))
+        hit (first (:enemies w'))]
+    (is (= 2 (:lives hit)) "reticle over the enemy lands the shot (3 -> 2)")
+    (is (some? (:hit-fx w')) "a connecting off-centre shot lights the hit-marker")))
+
+(deftest test-fire-shot-reticle-elsewhere-misses
+  ;; Reticle pushed to the FAR side (column 10, left of centre): aims away
+  ;; from the right-side enemy, so it is not hit - the column genuinely
+  ;; selects the target, it is not just "any non-centre column hits".
+  (rng/seed! 1)
+  (let [e   (new-enemy aim-enemy-x aim-enemy-y 3 :caco)
+        w'  (fire-shot (aim-world [e] 10))
+        hit (first (:enemies w'))]
+    (is (= 3 (:lives hit)) "aiming the reticle away from the enemy misses it")))
+
+;; ---------------------------------------------------------------------
+;; aim-angle-offset: pure reticle-column -> radians map. Centre column =>
+;; 0 (no offset, the byte-identical centre-aim default); a column right of
+;; centre => positive offset (turn the shot right), left => negative. nil
+;; column / scene width => 0 so a mouse-off / headless world fires straight
+;; ahead exactly as before.
+;; ---------------------------------------------------------------------
+
+(deftest test-aim-angle-offset-center-is-zero
+  (is (= 0.0 (aim-angle-offset 60 120)) "reticle at centre -> no offset")
+  (is (= 0.0 (aim-angle-offset nil 120)) "nil column -> no offset")
+  (is (= 0.0 (aim-angle-offset 60 nil)) "nil scene width -> no offset"))
+
+(deftest test-aim-angle-offset-sign
+  (is (php/> (aim-angle-offset 90 120) 0.0) "right of centre -> +offset (turn right)")
+  (is (php/< (aim-angle-offset 30 120) 0.0) "left of centre -> -offset (turn left)"))
+
+(deftest test-aim-angle-offset-grows-with-column
+  ;; Further from centre -> larger magnitude (monotone), bounded by the
+  ;; half-FOV at the screen edge.
+  (let [near (aim-angle-offset 70 120)
+        far  (aim-angle-offset 110 120)]
+    (is (php/> far near) "a column nearer the edge offsets the shot more")))

--- a/tests/core/state-test.phel
+++ b/tests/core/state-test.phel
@@ -9,7 +9,7 @@
                                          max-armor max-backpacks max-lives
                                          armor-shard-cap soul-overcap-decay-secs
                                          soulsphere-cap clamp-pitch max-pitch
-                                         eye-height set-floor-z]))
+                                         eye-height set-floor-z set-reticle reset-reticle]))
 
 (def grid [[1 1 1] [1 0 1] [1 1 1]])
 
@@ -367,3 +367,34 @@
   (is (= false (at-backpack-cap? {:backpack-level 0})))
   (is (= false (at-backpack-cap? {:backpack-level 2})))
   (is (= true  (at-backpack-cap? {:backpack-level 3}))))
+
+;; ---------------------------------------------------------------------
+;; Movable aim crosshair reticle (#324). A fresh world starts centred
+;; (nil = combat fires dead ahead, render draws at screen centre);
+;; set-reticle stamps a concrete viewport cell; reset-reticle re-centres.
+;; ---------------------------------------------------------------------
+
+(deftest test-new-world-reticle-starts-centered
+  (let [w (new-world [[1 1 1] [1 0 1] [1 1 1]] (new-player 1.5 1.5 0.0))]
+    (is (nil? (:aim-col w)) "fresh world has no reticle column (centred)")
+    (is (nil? (:aim-row w)) "fresh world has no reticle row (centred)")))
+
+(deftest test-set-reticle-stamps-cell
+  (let [w (set-reticle {} 71 12)]
+    (is (= 71 (:aim-col w)) "reticle column stamped")
+    (is (= 12 (:aim-row w)) "reticle row stamped")))
+
+(deftest test-set-reticle-passes-nil-through
+  ;; A mouse-aim result with no dims / no pointer carries nil cells, which
+  ;; centre the reticle - so feeding it straight through keeps the world
+  ;; centred rather than erroring.
+  (let [w (set-reticle {:aim-col 50 :aim-row 9} nil nil)]
+    (is (nil? (:aim-col w)) "nil column re-centres")
+    (is (nil? (:aim-row w)) "nil row re-centres")))
+
+(deftest test-reset-reticle-clears-to-center
+  ;; Mouse-off / resize: the reticle returns to the centred sentinel so the
+  ;; hitscan + crosshair behave exactly like the pre-#324 centre aim.
+  (let [w (reset-reticle {:aim-col 119 :aim-row 0})]
+    (is (nil? (:aim-col w)) "column cleared to centre")
+    (is (nil? (:aim-row w)) "row cleared to centre")))

--- a/tests/glue/controls-test.phel
+++ b/tests/glue/controls-test.phel
@@ -2,7 +2,7 @@
   (:require phel.test :refer [deftest is])
   (:require phel-doom.glue.controls
             :refer [key-states refresh-from-keys rising-edges initial-key-snapshot
-                    nav-deltas refresh-move mouse-look steer-rate]))
+                    nav-deltas refresh-move mouse-aim reticle-axis edge-pan-rate]))
 
 (def blank-moves
   {:fwd          0
@@ -454,305 +454,288 @@
   (is (= false (:confirm (rising-edges {:sp false :enter false} {:sp false :enter false})))))
 
 ;; ---------------------------------------------------------------------
-;; Mouse look POSITIONAL STEERING (#318): pure SGR-mouse parse -> per-frame
-;; yaw/pitch RATE from the cached pointer's distance to the terminal
-;; CENTER + fire intent. SGR report shape: ESC [ < b ; Cx ; Cy (M|m).
+;; Movable aim crosshair (#324): pure SGR-mouse parse -> reticle position
+;; (1:1 with the pointer, clamped to the viewport) + an edge-pan yaw/pitch
+;; RATE that only fires while the reticle sits in the outer band. Replaces
+;; the positional steer-rate model (#318/#320). SGR report shape:
+;; ESC [ < b ; Cx ; Cy (M|m), Cx/Cy 1-based absolute cells.
 ;;   b = 0  -> left button press (discrete)
-;;   b = 32 -> motion bit set, button 0 = LEFT DRAG (held during move)
-;;   b = 35 -> motion bit set, low bits 3 = bare hover (no button held)
-;; A central DEADZONE produces no turn; past it an ease-in ramp reaches
-;; max-rate at the screen edge. Yaw is signed by which side of center the
-;; pointer x is on; pitch y is NEGATED (rows grow downward, so a pointer
-;; ABOVE center looks UP, +pitch). The steering reads the FINAL cached
-;; position, so a HELD pointer keeps turning with NO new bytes.
+;;   b = 32 -> motion bit, button 0 = LEFT DRAG (held during move)
+;;   b = 35 -> motion bit, low bits 3 = bare hover (no button held)
 ;;
-;; All look tests pass `look-dims` so steer-rate has the axis lengths.
-;; For [30 120]: center-col 60.5, half-col 59.5, deadzone-col 5.95 (10% of
-;; half), span-col 53.55; rate-max yaw 0.16, pitch 0.06 at the far edge.
+;; reticle-axis maps a 1-based pointer cell to a 0-based viewport cell:
+;; clamp(center + (pointer-1 - center)*sens), so it is 1:1 at sens 1 and
+;; PINS at the edge when the pointer leaves the window (absolute-clamped,
+;; the #313 pointer-drift fix). edge-pan-rate is 0 in the inner centre
+;; region and eases (square) to max-rate at the very edge.
+;;
+;; For [30 120]: centre cell (0-based) is 59.5 col / 14.5 row; the edge-pan
+;; band is the outer 30% of each half-axis, so the col band starts at
+;; ~101.15 and the row band at ~24.65; rate-max yaw 0.16, pitch 0.06.
 ;; ---------------------------------------------------------------------
 
 (def look-dims
-  "Live [rows cols] for the positional-steering tests: 30 rows, 120 cols
-   (center cell 60.5 / 15.5; deadzone 10% of each half-axis)."
+  "Live [rows cols] for the reticle tests: 30 rows, 120 cols (centre cell
+   59.5 col / 14.5 row, 0-based)."
   [30 120])
 
-;; Pointer cells used across the suite (all on the 30x120 axes):
+;; Pointer cells (1-based SGR Cx/Cy) used across the suite:
 (def center-pos
-  "Cell at (or one off) the terminal center, inside the deadzone."
+  "Pointer at (or one off) the terminal centre."
   [60 15])
-(def right-edge-pos [120 15])  ; far right edge cell -> max +yaw
-(def left-edge-pos  [1 15])    ; far left edge cell  -> max -yaw
-(def top-edge-pos   [60 1])    ; top edge cell       -> max +pitch (look up)
-(def bottom-edge-pos [60 30])  ; bottom edge cell    -> max -pitch (look down)
+(def right-edge-pos [120 15])  ; far right edge   -> reticle col 119, +yaw
+(def left-edge-pos  [1 15])    ; far left edge    -> reticle col 0,   -yaw
+(def top-edge-pos   [60 1])    ; top edge         -> reticle row 0,   +pitch (look up)
+(def bottom-edge-pos [60 30])  ; bottom edge      -> reticle row 29,  -pitch (look down)
 
 (defn- approx?
   "Float compare with a tolerance, so an eased ramp that lands on
-   0.0309444... still matches the expected value."
+   0.0393... still matches the expected value."
   [^float a ^float b]
   (php/< (php/abs (php/- a b)) 1.0e-9))
 
-;; steer-rate is the core of the model; pin its key points directly.
+;; --- reticle-axis: 1-based pointer cell -> 0-based clamped reticle cell ---
 
-(deftest test-steer-rate-center-is-deadzone
-  ;; A pointer at (or beside) the center cell sits in the deadzone -> 0.
-  (is (= 0.0 (steer-rate 60 120 0.16)) "center -> no turn")
-  (is (= 0.0 (steer-rate 61 120 0.16)) "one cell off center is still deadzone"))
+(deftest test-reticle-axis-is-one-to-one-at-neutral-sensitivity
+  ;; sens 1.0: the reticle tracks the pointer cell exactly (1-based ->
+  ;; 0-based, so Cx 60 -> col 59), moving one cell per pointer cell.
+  (is (= 59.0 (reticle-axis 60 120 1.0)) "pointer cell 60 -> reticle col 59")
+  (is (= 79.0 (reticle-axis 80 120 1.0)) "pointer cell 80 -> reticle col 79")
+  ;; 1:1: a 20-cell pointer move is a 20-cell reticle move.
+  (is (= 20.0 (php/- (reticle-axis 80 120 1.0) (reticle-axis 60 120 1.0)))
+      "20 pointer cells -> 20 reticle cells (1:1)"))
 
-(deftest test-steer-rate-edges-hit-max
-  ;; At the far edge cells the ramp saturates to +/- max-rate.
-  (is (approx? 0.16 (steer-rate 120 120 0.16)) "right edge -> +max")
-  (is (approx? -0.16 (steer-rate 1 120 0.16)) "left edge -> -max"))
+(deftest test-reticle-axis-clamps-to-viewport
+  ;; The reticle never leaves the viewport: the right/left edges clamp to
+  ;; the last/first cell, and a pointer PAST the window pins at that edge
+  ;; (the pointer-drift robustness - aiming never freezes mid-screen).
+  (is (= 119.0 (reticle-axis 120 120 1.0)) "right edge clamps to col 119")
+  (is (= 0.0 (reticle-axis 1 120 1.0)) "left edge clamps to col 0")
+  (is (= 119.0 (reticle-axis 200 120 1.0)) "pointer past the window pins at the edge")
+  (is (= 0.0 (reticle-axis -50 120 1.0)) "pointer left of the window pins at col 0"))
 
-(deftest test-steer-rate-grows-with-offset
-  ;; Magnitude grows monotonically the further the pointer is from center.
-  (let [near (steer-rate 75 120 0.16)
-        mid  (steer-rate 95 120 0.16)
-        far  (steer-rate 115 120 0.16)]
-    (is (php/> near 0) "right of center -> positive")
-    (is (php/> mid near) "further out turns faster")
-    (is (php/> far mid) "further still turns faster")
+(deftest test-reticle-axis-scales-with-sensitivity
+  ;; Sensitivity scales the reticle speed: at 2x the same pointer offset
+  ;; moves the reticle twice as far from centre; at 0.5x half as far.
+  (is (= 98.5 (reticle-axis 80 120 2.0)) "2x sensitivity doubles the offset from centre")
+  (is (= 69.25 (reticle-axis 80 120 0.5)) "0.5x sensitivity halves it"))
+
+(deftest test-reticle-axis-degenerate-axis-is-nil
+  ;; A nil / <=1 axis length has no viewport to clamp into.
+  (is (nil? (reticle-axis 60 nil 1.0)) "nil len -> nil")
+  (is (nil? (reticle-axis 60 1 1.0)) "len 1 -> nil"))
+
+;; --- edge-pan-rate: 0-based reticle cell -> per-frame pan rate ---
+
+(deftest test-edge-pan-rate-center-region-is-zero
+  ;; The inner ~70% centre region is pure 1:1 reticle movement: NO camera
+  ;; turn. Only the outer band pans.
+  (is (= 0.0 (edge-pan-rate 59.5 120 0.16)) "screen centre -> no pan")
+  (is (= 0.0 (edge-pan-rate 75.0 120 0.16)) "still in the centre region -> no pan")
+  (is (= 0.0 (edge-pan-rate 101.0 120 0.16)) "just inside the band edge -> no pan"))
+
+(deftest test-edge-pan-rate-band-pans
+  ;; Past the band threshold the camera pans, saturating to max-rate at the
+  ;; very edge cell; the left edge pans the opposite sign.
+  (is (php/> (edge-pan-rate 110.0 120 0.16) 0.0) "deep in the right band -> +pan")
+  (is (approx? 0.16 (edge-pan-rate 119.0 120 0.16)) "right edge saturates to +max")
+  (is (approx? -0.16 (edge-pan-rate 0.0 120 0.16)) "left edge saturates to -max"))
+
+(deftest test-edge-pan-rate-grows-toward-edge
+  ;; Magnitude grows monotonically the deeper into the band the reticle is.
+  (let [near (edge-pan-rate 105.0 120 0.16)
+        far  (edge-pan-rate 115.0 120 0.16)]
+    (is (php/> near 0.0) "inside the band -> positive")
+    (is (php/> far near) "nearer the edge pans faster")
     (is (php/<= far 0.16) "never exceeds the max rate")))
 
-(deftest test-steer-rate-eases-in
-  ;; Ease-in (square): the response is gentle near the deadzone edge. The
-  ;; midpoint of the post-deadzone span gives frac=0.5 -> eased 0.25, i.e.
-  ;; a QUARTER of max-rate, not half (a linear ramp would give half).
-  ;; span = half-dead = 53.55; midpoint offset = dead + span/2 = 32.725
-  ;; -> x = center + 32.725 = 93.225 ~ cell 93.
-  (let [mid (steer-rate 93 120 0.16)]
-    (is (php/< mid (php/* 0.5 0.16)) "ease-in: mid-span is below the linear half")))
+(deftest test-edge-pan-rate-degenerate-axis-is-zero
+  (is (= 0.0 (edge-pan-rate 60.0 nil 0.16)) "nil len -> 0")
+  (is (= 0.0 (edge-pan-rate 0.0 1 0.16)) "len 1 -> 0"))
 
-(deftest test-steer-rate-degenerate-axis-is-zero
-  ;; A nil or <=1 axis length must never auto-steer.
-  (is (= 0.0 (steer-rate 60 nil 0.16)) "nil len -> 0")
-  (is (= 0.0 (steer-rate 1 1 0.16)) "len 1 -> 0")
-  (is (= 0.0 (steer-rate 1 0 0.16)) "len 0 -> 0"))
+;; --- mouse-aim: the per-frame reticle + edge-pan + fire result ---
 
-;; mouse-look: the per-frame yaw/pitch + fire result.
-
-(deftest test-mouse-look-center-no-bytes-is-zero
-  ;; Pointer cached at center, no input this frame: no turn (deadzone), no
-  ;; fire, and the cached pos is carried forward unchanged. The keyboard
-  ;; path is untouched.
-  (let [r (mouse-look "" center-pos 1.0 look-dims)]
-    (is (= 0.0 (:yaw r)) "center deadzone -> no yaw")
-    (is (= 0.0 (:pitch r)) "center deadzone -> no pitch")
+(deftest test-mouse-aim-center-no-bytes-pins-reticle-center
+  ;; Pointer cached at centre, no input this frame: the reticle sits at the
+  ;; centre cell, no pan (centre region), no fire, pos carried forward.
+  (let [r (mouse-aim "" center-pos 1.0 look-dims)]
+    (is (= 59.0 (:aim-col r)) "reticle at centre col")
+    (is (= 14.0 (:aim-row r)) "reticle at centre row")
+    (is (= 0.0 (:yaw r)) "centre region -> no yaw")
+    (is (= 0.0 (:pitch r)) "centre region -> no pitch")
     (is (= false (:fire? r)))
     (is (= false (:fire-held? r)))
     (is (= center-pos (:pos r)) "cached pointer carried forward")))
 
-(deftest test-mouse-look-right-of-center-yields-positive-yaw
-  ;; A hover (b=35) that leaves the pointer right of center steers +yaw
-  ;; (turn right); magnitude grows with offset, saturating near the edge.
-  (let [mild (mouse-look "\e[<35;90;15M" center-pos 1.0 look-dims)
-        edge (mouse-look "\e[<35;120;15M" center-pos 1.0 look-dims)]
-    (is (php/> (:yaw mild) 0) "right of center -> +yaw")
-    (is (= 0.0 (:pitch mild)) "horizontal pointer at mid-row -> no pitch")
-    (is (php/> (:yaw edge) (:yaw mild)) "nearer the edge turns faster")
-    (is (approx? 0.16 (:yaw edge)) "the edge saturates at max yaw")
-    (is (= [120 15] (:pos edge)) "pos trails the latest report")))
+(deftest test-mouse-aim-tracks-pointer-one-to-one
+  ;; A hover (b=35) moves the reticle to the pointer's cell, 1:1, with no
+  ;; pan while it stays in the centre region.
+  (let [r (mouse-aim "\e[<35;80;15M" center-pos 1.0 look-dims)]
+    (is (= 79.0 (:aim-col r)) "reticle follows the pointer column 1:1")
+    (is (= 14.0 (:aim-row r)) "row unchanged at mid-screen")
+    (is (= 0.0 (:yaw r)) "still centre region -> no pan")
+    (is (= [80 15] (:pos r)) "pos trails the latest report")))
 
-(deftest test-mouse-look-left-of-center-yields-negative-yaw
-  ;; Left of center steers -yaw (turn left), saturating to -max at the edge.
-  (let [mild (mouse-look "\e[<35;30;15M" center-pos 1.0 look-dims)
-        edge (mouse-look "\e[<35;1;15M" center-pos 1.0 look-dims)]
-    (is (php/< (:yaw mild) 0) "left of center -> -yaw")
-    (is (php/< (:yaw edge) (:yaw mild)) "nearer the edge turns faster (more negative)")
-    (is (approx? -0.16 (:yaw edge)) "the edge saturates at -max yaw")))
+(deftest test-mouse-aim-clamps-reticle-at-right-edge-and-pans
+  ;; Pushing the pointer to / past the right edge pins the reticle at the
+  ;; last column AND edge-pans the camera right (the aim-beyond-view move).
+  (let [edge (mouse-aim "\e[<35;120;15M" center-pos 1.0 look-dims)
+        past (mouse-aim "\e[<35;200;15M" center-pos 1.0 look-dims)]
+    (is (= 119.0 (:aim-col edge)) "reticle pinned at the right edge col")
+    (is (php/> (:yaw edge) 0.0) "right edge edge-pans the camera right")
+    (is (= 119.0 (:aim-col past)) "pointer past the window keeps the reticle pinned")
+    (is (php/> (:yaw past) 0.0) "and edge-pan keeps turning - aiming never freezes")))
 
-(deftest test-mouse-look-above-center-yields-positive-pitch
-  ;; A pointer ABOVE center (smaller y) looks UP (+pitch): rows grow
-  ;; downward, so the rate is negated. Saturates at +max at the top edge.
-  (let [mild (mouse-look "\e[<35;60;6M" center-pos 1.0 look-dims)
-        edge (mouse-look "\e[<35;60;1M" center-pos 1.0 look-dims)]
-    (is (php/> (:pitch mild) 0) "above center -> +pitch (look up)")
-    (is (= 0.0 (:yaw mild)) "vertical pointer at mid-col -> no yaw")
-    (is (php/> (:pitch edge) (:pitch mild)) "nearer the top turns faster")
-    (is (approx? 0.06 (:pitch edge)) "the top edge saturates at +max pitch")))
+(deftest test-mouse-aim-left-edge-pans-left
+  (let [r (mouse-aim "\e[<35;1;15M" center-pos 1.0 look-dims)]
+    (is (= 0.0 (:aim-col r)) "reticle pinned at the left edge col")
+    (is (php/< (:yaw r) 0.0) "left edge edge-pans the camera left")))
 
-(deftest test-mouse-look-below-center-yields-negative-pitch
-  ;; A pointer BELOW center (larger y) looks DOWN (-pitch), saturating to
-  ;; -max at the bottom edge.
-  (let [mild (mouse-look "\e[<35;60;24M" center-pos 1.0 look-dims)
-        edge (mouse-look "\e[<35;60;30M" center-pos 1.0 look-dims)]
-    (is (php/< (:pitch mild) 0) "below center -> -pitch (look down)")
-    (is (approx? -0.06 (:pitch edge)) "the bottom edge saturates at -max pitch")))
+(deftest test-mouse-aim-top-edge-looks-up
+  ;; Pointer at the top band: reticle pins at row 0 and pitch is POSITIVE
+  ;; (look up) - rows grow downward, so the top of the screen is +pitch.
+  (let [r (mouse-aim "\e[<35;60;1M" center-pos 1.0 look-dims)]
+    (is (= 0.0 (:aim-row r)) "reticle pinned at the top row")
+    (is (php/> (:pitch r) 0.0) "top band looks UP (+pitch)")
+    (is (= 0.0 (:yaw r)) "vertical pointer at mid-col -> no yaw")))
 
-(deftest test-mouse-look-held-off-center-keeps-turning-without-bytes
-  ;; THE KEY NEW PROPERTY (#318): the terminal sends reports only on
-  ;; MOTION, so a pointer held STILL off-center yields NO new bytes. The
-  ;; camera must keep turning anyway, because the steer-rate is read from
-  ;; the CACHED position every frame, not from a delta. Empty `keys` with a
-  ;; right-of-center cached pointer still returns +yaw.
-  (let [r (mouse-look "" right-edge-pos 1.0 look-dims)]
-    (is (approx? 0.16 (:yaw r)) "held at right edge, no bytes -> still +max yaw")
-    (is (= right-edge-pos (:pos r)) "cached pointer unchanged"))
-  (let [r (mouse-look "" left-edge-pos 1.0 look-dims)]
-    (is (approx? -0.16 (:yaw r)) "held at left edge, no bytes -> still -max yaw"))
-  (let [r (mouse-look "" top-edge-pos 1.0 look-dims)]
-    (is (approx? 0.06 (:pitch r)) "held above center, no bytes -> still +pitch"))
-  (let [r (mouse-look "" bottom-edge-pos 1.0 look-dims)]
-    (is (approx? -0.06 (:pitch r)) "held below center, no bytes -> still -pitch")))
+(deftest test-mouse-aim-bottom-edge-looks-down
+  (let [r (mouse-aim "\e[<35;60;30M" center-pos 1.0 look-dims)]
+    (is (= 29.0 (:aim-row r)) "reticle pinned at the bottom row")
+    (is (php/< (:pitch r) 0.0) "bottom band looks DOWN (-pitch)")))
 
-(deftest test-mouse-look-report-moves-cached-pointer
-  ;; A motion report relocates the cached pointer, and the steering on the
-  ;; SAME frame reflects the NEW position. Pointer was at center; a report
-  ;; lands it at the right edge -> max +yaw this very frame.
-  (let [r (mouse-look "\e[<35;120;15M" center-pos 1.0 look-dims)]
-    (is (approx? 0.16 (:yaw r)) "steering follows the latest reported cell")
-    (is (= [120 15] (:pos r)) "cached pointer advanced to the report"))
-  ;; Two reports in one frame: only the LAST cell drives the rate (no
-  ;; delta accumulation). center -> x=90 -> x=120 ends at the edge = max.
-  (let [r (mouse-look "\e[<35;90;15M\e[<35;120;15M" center-pos 1.0 look-dims)]
-    (is (approx? 0.16 (:yaw r)) "the final report's position sets the rate")
-    (is (= [120 15] (:pos r)) "pos trails the last report")))
+(deftest test-mouse-aim-held-at-edge-keeps-panning-without-bytes
+  ;; The whole point of the model: once the reticle is parked in the edge
+  ;; band, the camera keeps panning every frame with NO new bytes, because
+  ;; the pan rate is read from the cached pointer position. So a pointer
+  ;; that left the window at an edge keeps the camera turning.
+  (let [r (mouse-aim "" right-edge-pos 1.0 look-dims)]
+    (is (php/> (:yaw r) 0.0) "held at the right edge keeps panning right"))
+  (let [r (mouse-aim "" left-edge-pos 1.0 look-dims)]
+    (is (php/< (:yaw r) 0.0) "held at the left edge keeps panning left"))
+  (let [r (mouse-aim "" top-edge-pos 1.0 look-dims)]
+    (is (php/> (:pitch r) 0.0) "held at the top keeps looking up"))
+  (let [r (mouse-aim "" bottom-edge-pos 1.0 look-dims)]
+    (is (php/< (:pitch r) 0.0) "held at the bottom keeps looking down")))
 
-(deftest test-mouse-look-returning-to-center-stops
-  ;; Bringing the pointer back to center stops the turn (no recenter creep,
-  ;; no momentum): a report that lands the pointer in the center deadzone
-  ;; yields zero yaw even though the previous cached pos was at the edge.
-  (let [r (mouse-look "\e[<35;60;15M" right-edge-pos 1.0 look-dims)]
-    (is (= 0.0 (:yaw r)) "back to center -> stop turning")
-    (is (= [60 15] (:pos r)))))
+(deftest test-mouse-aim-returning-to-center-stops-pan
+  ;; Bringing the pointer back to centre re-centres the reticle and stops
+  ;; the pan: precise 1:1 aim resumes with no camera drift.
+  (let [r (mouse-aim "\e[<35;60;15M" right-edge-pos 1.0 look-dims)]
+    (is (= 59.0 (:aim-col r)) "reticle back at centre col")
+    (is (= 0.0 (:yaw r)) "back in the centre region -> pan stops")))
 
-(deftest test-mouse-look-sensitivity-scales-the-rate
-  ;; sensitivity 2.0 doubles, 0.0 zeroes the steering (mouselook off) while
-  ;; leaving fire untouched. At the right edge: 0.16 * 2.0 = 0.32.
-  (is (approx? 0.32 (:yaw (mouse-look "" right-edge-pos 2.0 look-dims))) "2x sensitivity doubles yaw")
-  (is (= 0.0 (:yaw (mouse-look "" right-edge-pos 0.0 look-dims))) "0 sensitivity = no turn")
-  (is (= 0.0 (:pitch (mouse-look "" top-edge-pos 0.0 look-dims))) "0 sensitivity = no pitch")
-  (let [r (mouse-look "\e[<0;60;15M" center-pos 0.0 look-dims)]
-    (is (= true (:fire? r)) "0 sensitivity still lets a click fire")))
+(deftest test-mouse-aim-report-moves-cached-pointer
+  ;; A position report advances the cached pointer to the reported cell so
+  ;; the next frame reads from there; the LAST report wins within a frame.
+  (let [r (mouse-aim "\e[<35;120;15M" center-pos 1.0 look-dims)]
+    (is (= [120 15] (:pos r)) "pos updated to the report"))
+  (let [r (mouse-aim "\e[<35;90;15M\e[<35;120;15M" center-pos 1.0 look-dims)]
+    (is (= [120 15] (:pos r)) "the last report in the frame wins")))
 
-(deftest test-mouse-look-no-dims-is-inert
-  ;; Without dims (no axis lengths) the steering can't know where the edges
-  ;; are, so it yields zero yaw/pitch - while fire intent still parses. So
-  ;; a non-loop caller (or a frame before the size is known) never spins.
-  (let [r (mouse-look "\e[<35;120;15M" center-pos 1.0)]
-    (is (= 0.0 (:yaw r)) "no dims -> no yaw")
-    (is (= 0.0 (:pitch r)) "no dims -> no pitch")
-    (is (= [120 15] (:pos r)) "but pos still tracks the report"))
-  (let [r (mouse-look "\e[<0;60;15M" center-pos 1.0)]
+(deftest test-mouse-aim-sensitivity-scales-reticle-and-pan
+  ;; Sensitivity scales BOTH the reticle speed and the edge-pan rate.
+  (is (= 98.5 (:aim-col (mouse-aim "\e[<35;80;15M" center-pos 2.0 look-dims)))
+      "2x sensitivity moves the reticle twice as far")
+  (is (approx? 0.32 (:yaw (mouse-aim "" right-edge-pos 2.0 look-dims)))
+      "2x sensitivity doubles the edge-pan yaw")
+  (is (= 0.0 (:yaw (mouse-aim "" right-edge-pos 0.0 look-dims)))
+      "0 sensitivity = no pan")
+  ;; Even at 0 sensitivity a click still fires (the look is disabled, not
+  ;; the trigger).
+  (let [r (mouse-aim "\e[<0;60;15M" center-pos 0.0 look-dims)]
+    (is (= true (:fire? r)) "click fires regardless of sensitivity")))
+
+(deftest test-mouse-aim-no-dims-has-no-reticle-or-pan
+  ;; Without [rows cols] there is no viewport to clamp into or band to pan
+  ;; from, so the reticle + pan are inert - but fire intent still parses, so
+  ;; a non-loop caller is unaffected.
+  (let [r (mouse-aim "\e[<35;120;15M" center-pos 1.0)]
+    (is (nil? (:aim-col r)) "no dims -> no reticle column")
+    (is (= 0.0 (:yaw r)) "no dims -> no pan")
+    (is (= 0.0 (:pitch r)) "no dims -> no pitch"))
+  (let [r (mouse-aim "\e[<0;60;15M" center-pos 1.0)]
     (is (= true (:fire? r)) "fire still parses with no dims")))
 
-(deftest test-mouse-look-nil-pos-no-report-is-zero
-  ;; prev-pos nil (no prior report this session) AND no report this frame:
-  ;; the cached pos stays nil, so there is no position to steer from -> a
-  ;; clean zero, never a spin before the first real report.
-  (let [r (mouse-look "" nil 1.0 look-dims)]
-    (is (= 0.0 (:yaw r)) "nil pos -> no yaw")
-    (is (= 0.0 (:pitch r)) "nil pos -> no pitch")
-    (is (= nil (:pos r)) "cached pointer still nil")))
+(deftest test-mouse-aim-nil-pos-no-report-has-no-reticle
+  ;; No cached pointer and no report this frame: nothing to place the
+  ;; reticle from, so no reticle / no pan / no fire.
+  (let [r (mouse-aim "" nil 1.0 look-dims)]
+    (is (nil? (:aim-col r)) "nil pos, no report -> no reticle")
+    (is (= 0.0 (:yaw r)) "nil pos -> no pan")
+    (is (= false (:fire? r)))
+    (is (= nil (:pos r)) "pos stays nil")))
 
-(deftest test-mouse-look-left-press-fires
-  ;; Discrete left press (b=0, final M): :fire? and :fire-held? both set so
-  ;; a click shoots like space. At center the steering stays zero.
-  (let [r (mouse-look "\e[<0;60;15M" center-pos 1.0 look-dims)]
+;; --- fire intent (unchanged from the positional model) ---
+
+(deftest test-mouse-aim-left-press-fires
+  ;; A left-button press (b=0, final M) is a fresh fire rising-edge.
+  (let [r (mouse-aim "\e[<0;60;15M" center-pos 1.0 look-dims)]
     (is (= true (:fire? r)) "left press fires")
-    (is (= true (:fire-held? r)) "press counts as held this frame")
-    (is (= 0.0 (:yaw r)) "press at center adds no turn")
-    (is (= 0.0 (:pitch r)))))
+    (is (= true (:fire-held? r)) "and counts as held")))
 
-(deftest test-mouse-look-left-release-does-not-fire
-  ;; Release (final m): NOT a press, button not down.
-  (let [r (mouse-look "\e[<0;60;15m" center-pos 1.0 look-dims)]
-    (is (= false (:fire? r)) "release is not a press")
+(deftest test-mouse-aim-left-release-does-not-fire
+  ;; A left release (final m) is not a press, so it doesn't fire.
+  (let [r (mouse-aim "\e[<0;60;15m" center-pos 1.0 look-dims)]
+    (is (= false (:fire? r)) "release does not fire")
     (is (= false (:fire-held? r)) "release is not held")))
 
-(deftest test-mouse-look-left-drag-is-held-fire-and-steers
-  ;; Left DRAG (b=32: motion bit + button 0) that lands right of center:
-  ;; steers (+yaw) AND holds the trigger (auto-fire weapons spray while
-  ;; dragged), but is NOT a fresh press edge. Click + drag to shoot stays
-  ;; intact.
-  (let [r (mouse-look "\e[<32;120;15M" center-pos 1.0 look-dims)]
-    (is (= false (:fire? r)) "a drag is not a rising-edge press")
-    (is (= true (:fire-held? r)) "left held during drag = held-fire")
-    (is (approx? 0.16 (:yaw r)) "drag still steers")))
+(deftest test-mouse-aim-left-drag-is-held-fire-and-tracks
+  ;; A left DRAG (b=32: motion bit + button 0) feeds auto-fire weapons and
+  ;; still moves the reticle to the dragged cell.
+  (let [r (mouse-aim "\e[<32;120;15M" center-pos 1.0 look-dims)]
+    (is (= false (:fire? r)) "a drag is not a fresh press edge")
+    (is (= true (:fire-held? r)) "but it holds the trigger for auto-fire")
+    (is (= 119.0 (:aim-col r)) "and the reticle tracks the drag to the edge")))
 
-(deftest test-mouse-look-press-then-move-fires-and-steers
-  ;; A press followed by a hover move in the same frame: fire AND steer
-  ;; from the moved-to cell (the edge -> max yaw).
-  (let [r (mouse-look "\e[<0;60;15M\e[<35;120;15M" center-pos 1.0 look-dims)]
-    (is (= true (:fire? r)) "the press still registers")
-    (is (approx? 0.16 (:yaw r)) "the move still steers from the new cell")))
+(deftest test-mouse-aim-press-then-move-fires-and-tracks
+  (let [r (mouse-aim "\e[<0;60;15M\e[<35;120;15M" center-pos 1.0 look-dims)]
+    (is (= true (:fire? r)) "the press in the frame still fires")
+    (is (= 119.0 (:aim-col r)) "the reticle ends at the moved-to edge cell")))
 
-(deftest test-mouse-look-press-then-release-fires-once
-  ;; A full click in ONE drained frame: left press (M) then its release
-  ;; (m), both at center. :fire? / :fire-held? are OR'd across the events,
-  ;; so the press latches the single rising-edge fire; the trailing release
-  ;; neither re-fires nor un-fires it.
-  (let [r (mouse-look "\e[<0;60;15M\e[<0;60;15m" center-pos 1.0 look-dims)]
-    (is (= true (:fire? r)) "press latches one fire even with a trailing release")
-    (is (= true (:fire-held? r)) "the in-frame press counts as held this frame")
-    (is (= 0.0 (:yaw r)) "click at center adds no turn")
-    (is (= [60 15] (:pos r)) "pos trails the last (release) report"))
-  ;; The NEXT frame, fed only the release tail (button already up), is a
-  ;; clean no-op fire-wise.
-  (let [r (mouse-look "\e[<0;60;15m" center-pos 1.0 look-dims)]
-    (is (= false (:fire? r)) "release-only frame does not fire")
-    (is (= false (:fire-held? r)) "release-only frame is not held")))
+(deftest test-mouse-aim-wheel-tick-adds-no-fire
+  ;; A scroll-wheel tick (b=64) carries no aim intent: no fire.
+  (let [r (mouse-aim "\e[<64;120;15M" center-pos 1.0 look-dims)]
+    (is (= false (:fire? r)) "wheel up does not fire")
+    (is (= false (:fire-held? r)) "wheel is not held-fire")))
 
-(deftest test-mouse-look-wheel-tick-adds-no-turn-no-fire
-  ;; A scroll-wheel report (bit 6 set: b=64) carries no aim intent. It must
-  ;; NOT fire - but :pos still advances to its cell so a following motion
-  ;; steers from the true pointer spot.
-  (let [r (mouse-look "\e[<64;120;15M" center-pos 1.0 look-dims)]
-    (is (= false (:fire? r)) "wheel is not a fire")
-    (is (= false (:fire-held? r)) "wheel is not held-fire")
-    (is (= [120 15] (:pos r)) ":pos advances to the wheel cell")))
+(deftest test-mouse-aim-right-button-does-not-fire
+  (let [r (mouse-aim "\e[<2;60;15M" center-pos 1.0 look-dims)]
+    (is (= false (:fire? r)) "right button is not the fire button")))
 
-(deftest test-mouse-look-right-button-does-not-fire
-  ;; Right-button report (b=2). Only the LEFT button maps to fire.
-  (let [r (mouse-look "\e[<2;60;15M" center-pos 1.0 look-dims)]
-    (is (= false (:fire? r)) "right press is not a fire edge")
-    (is (= false (:fire-held? r)) "right button is not held-fire")))
+(deftest test-mouse-aim-middle-button-does-not-fire
+  (let [r (mouse-aim "\e[<1;60;15M" center-pos 1.0 look-dims)]
+    (is (= false (:fire? r)) "middle button is not the fire button")))
 
-(deftest test-mouse-look-middle-button-does-not-fire
-  ;; Middle-button report (b=1). Same rule - only button 0 fires.
-  (let [r (mouse-look "\e[<1;60;15M" center-pos 1.0 look-dims)]
-    (is (= false (:fire? r)) "middle press is not a fire edge")
-    (is (= false (:fire-held? r)) "middle button is not held-fire")))
+(deftest test-mouse-aim-malformed-sequence-ignored
+  ;; A truncated report (missing the y field) matches nothing, so the
+  ;; reticle stays put and nothing fires.
+  (let [r (mouse-aim "\e[<35;15M" center-pos 1.0 look-dims)]
+    (is (= 59.0 (:aim-col r)) "reticle holds the cached centre")
+    (is (= false (:fire? r)))))
 
-(deftest test-mouse-look-malformed-sequence-ignored
-  ;; A truncated SGR report (missing the y coord + terminator) matches
-  ;; nothing, so the cached pointer is carried forward and steering reads
-  ;; it (here center -> zero).
-  (let [r (mouse-look "\e[<35;15M" center-pos 1.0 look-dims)]
-    (is (= 0.0 (:yaw r)))
-    (is (= 0.0 (:pitch r)))
-    (is (= center-pos (:pos r)) "malformed leaves the cached pointer untouched")))
+(deftest test-mouse-aim-ignores-kitty-key-event
+  ;; A kitty CSI-u KEY event must not be mistaken for a mouse report.
+  (let [r (mouse-aim "\e[97;1:1u" center-pos 1.0 look-dims)]
+    (is (= 59.0 (:aim-col r)) "kitty key leaves the reticle alone")
+    (is (= false (:fire? r)) "kitty key 'a' does not fire")))
 
-(deftest test-mouse-look-ignores-kitty-key-event
-  ;; REGRESSION: a kitty CSI-u key report (e.g. 'a' press = \e[97;1:1u)
-  ;; shares the ESC-[ prefix but is NOT an SGR mouse report. It must NOT
-  ;; move the cached pointer or fire, so the mouse parser can never hijack
-  ;; the keyboard path.
-  (let [r (mouse-look "\e[97;1:1u" center-pos 1.0 look-dims)]
-    (is (= 0.0 (:yaw r)) "kitty key is not pointer motion")
-    (is (= 0.0 (:pitch r)))
-    (is (= false (:fire? r)) "kitty key is not a mouse click")
-    (is (= center-pos (:pos r)))))
-
-(deftest test-mouse-look-ignores-arrow-and-fkey
-  ;; REGRESSION: legacy arrow (\e[C) and F-key (\eOR = F3) sequences are
-  ;; not SGR mouse reports either - no steering change, no fire.
-  (let [arrow (mouse-look "\e[C" center-pos 1.0 look-dims)
-        fkey  (mouse-look "\eOR" center-pos 1.0 look-dims)]
-    (is (= 0.0 (:yaw arrow)) "arrow is not pointer motion")
+(deftest test-mouse-aim-ignores-arrow-and-fkey
+  ;; Arrow + F-key escapes are not SGR mouse reports.
+  (let [arrow (mouse-aim "\e[C" center-pos 1.0 look-dims)
+        fkey  (mouse-aim "\eOR" center-pos 1.0 look-dims)]
+    (is (= 59.0 (:aim-col arrow)) "arrow leaves the reticle alone")
     (is (= false (:fire? arrow)))
-    (is (= 0.0 (:yaw fkey)) "F-key is not pointer motion")
     (is (= false (:fire? fkey)))))
 
-(deftest test-mouse-look-mixed-keyboard-and-mouse-bytes
-  ;; A frame can carry BOTH a WASD byte and a mouse report (drained
-  ;; together). mouse-look only parses the SGR part; the surrounding 'w'/'d'
-  ;; are ignored here (refresh-from-keys handles them) and must not corrupt
-  ;; the cached pointer.
-  (let [r (mouse-look "w\e[<35;120;15Md" center-pos 1.0 look-dims)]
-    (is (approx? 0.16 (:yaw r)) "WASD bytes around the report don't affect steering")
-    (is (= [120 15] (:pos r)))))
+(deftest test-mouse-aim-mixed-keyboard-and-mouse-bytes
+  ;; A drain holding both WASD bytes and an SGR report: mouse-aim only
+  ;; reads the SGR part; the 'w'/'d' are the keyboard path's job.
+  (let [r (mouse-aim "w\e[<35;120;15Md" center-pos 1.0 look-dims)]
+    (is (= 119.0 (:aim-col r)) "the embedded report still moves the reticle")
+    (is (= [120 15] (:pos r)) "pos comes from the SGR part only")))
 
-(deftest test-mouse-look-bytes-do-not-leak-into-key-parsing
+(deftest test-mouse-aim-bytes-do-not-leak-into-key-parsing
   ;; REGRESSION (the inverse guard): an SGR mouse report fed to the
   ;; keyboard parsers must not be mistaken for movement / fire. The
   ;; report's digits and 'M' must not trip key-states or refresh-move.

--- a/tests/io/render-cache-test.phel
+++ b/tests/io/render-cache-test.phel
@@ -135,6 +135,29 @@
             (php/str_contains frame "m\e[93;1m+"))
         "crosshair + follows a real cell's BG SGR, not the bare cursor move")))
 
+(deftest test-movable-crosshair-drawn-at-reticle-cell
+  ;; Movable aim crosshair (#324): with :aim-col / :aim-row set the `+` is
+  ;; drawn at the reticle's 1-based cursor cell (aim+1), not screen centre,
+  ;; and the frame differs from the centred (mouse-off) frame. The reticle
+  ;; col 90 / row 8 on a 120x30 view -> cursor "\e[9;91H...+".
+  (let [centred (frame->string world stats 120 30)
+        moved   (frame->string world (assoc stats :aim-col 90 :aim-row 8) 120 30)]
+    (is (not= centred moved) "a moved reticle renders a different frame")
+    (is (or (php/str_contains moved "\e[9;91H")
+            ;; the firing jump lifts the row by one; this fixture is idle
+            ;; (no :fire-anim), so the idle row stands.
+            false)
+        "the + cursor-moves to the reticle cell (row 9, col 91, 1-based)")))
+
+(deftest test-mouse-off-crosshair-is-centered-default
+  ;; Without :aim-col the reticle falls back to the fixed screen centre, so
+  ;; the frame is byte-identical to the no-reticle stats (the golden path).
+  ;; Re-asserts the centre default at the frame level next to the golden
+  ;; hashes so a regression in the fallback fails close to its cause.
+  (is (= (frame->string world stats 120 30)
+         (frame->string world (assoc stats :aim-col nil :aim-row nil) 120 30))
+      "nil reticle == centred crosshair (mouse-off byte-identity)"))
+
 (defn- arr-mm [a]
   (let [n (php/count a)]
     (loop [i 1 lo (php/aget a 0) hi (php/aget a 0)]


### PR DESCRIPTION
> [!WARNING]
> **WIP / not ready for review.** Draft open so the reticle model can be tracked as it forms.
> **Paused** pending the flat-floor reset (#325): that rips floor-heights out of combat/state/render, which is the base the off-center hitscan + sprite-height agreement build on. Will rebase onto clean flat `main` and finish there (the off-center hitscan is actually *simpler* on a flat codebase - no floor-z sprite-height to thread through the vertical gate).

Replaces the positional mouse steering (#320) with a **movable aim crosshair**: the `+` reticle follows the mouse 1:1 (clamped to the viewport), the pistol fires toward wherever it points, and pushing the reticle into the outer band edge-pans the camera. Chosen over raw 1:1 mouselook because the OS pointer cannot be locked/warped/hidden in iTerm2 (#313): using the pointer's absolute position clamped to the viewport pins the reticle at the border when the pointer wanders out of the window, so edge-pan keeps the camera turning and aiming never freezes.

## Done so far

- **Off-center hitscan** (`src/core/combat.phel`, commit `6f1f7ca`):
  - `aim-angle-offset` - pure map from the reticle's screen column to the per-column FOV ray the renderer casts for it: `atan((aim-col - center) / fov-proj-dist(scene-cols))`. Sharing the engine's `fov-proj-dist` keeps the shot's ray identical to the column the reticle sits on, so the enemy whose projected sprite the `+` covers is the one struck.
  - Every fire path (`shoot` / `pierce` / `spread-shoot` / `beam-impact`), the wall probe (`cast-wall-dist`), and shot-direction knockback now fire along the **aim angle** (`:angle` + offset). A centred / mouse-off world has no `:aim-col`, so the offset is `0.0` and the centre-aim path stays **byte-identical** to the pre-#324 game.
  - TDD: an enemy placed off the centre axis (perp 0.6 > the 0.5 hit radius) is **missed** with a centred reticle, **hit** when the reticle column (71 on a 120-wide scene) is over it, and **missed** again when the reticle aims away (col 10). Plus `aim-angle-offset` unit pins (centre/nil -> 0, sign, monotone growth). All **229 combat tests green**.

## Leftovers (remaining scope, to finish after #325)

1. **Reticle + edge-pan** (`src/glue/controls.phel`): replace the `mouse-look` yaw/pitch-from-position model with `mouse-aim` -> `{:aim-col :aim-row :yaw :pitch :fire? :fire-held? :pos}`.
   - Reticle = `clamp(center + (pointer - center) * sensitivity)` in 0-based viewport cells: 1:1 at sens 1, scales with sensitivity, **pins at the edge** when the pointer leaves the window (absolute-position-clamped, the #313 robustness).
   - Edge-pan: outer ~30% band of each half-axis pans (yaw L/R, pitch T/B) with a square ease-in to a max rate at the very edge; the inner ~70% centre region is pure 1:1 reticle movement with **zero** camera turn. Sensitivity scales the pan rate too. (Constants computed, not yet committed: band 0.30, yaw-max 0.16 rad/frame, pitch-max 0.06/frame - reusing the #320 ease/ramp shape.)
   - Pitch y negated (rows grow down, reticle near the top looks up = +pitch).
2. **State** (`src/core/state.phel`): world carries `:aim-col` / `:aim-row`, initialised to viewport **centre**, reset to centre on resize and when the mouse is **OFF**. Stamp `:scene-cols` (= vw) on the world each frame so combat can do the column->angle math (mirrors the existing `:scene-rows`).
3. **Render** (`src/io/render/paint.phel`): `paint-crosshair` draws the `+` at the reticle `(aim-col, aim-row)` from `stats`, not fixed centre; defaults to centre when absent so the GOLDEN fixture (`test-frame-bytes-pinned`, 4 md5 hashes) stays unchanged. Resolve `center-bg` at the aim column. Keep the crosshair-style setting + the #201 hit-marker, just at the moving position.
4. **Wire** (`src/commands/play.phel`): thread the reticle state, apply edge-pan + the reticle update each frame, feed the reticle column into the fire path.
5. **Ship**: `docs/input.md` replace the positional-steering section with the reticle + edge-pan model (keep the #313 pointer-hide note); `CHANGELOG.md` `### Changed` bullet; full `composer ci` green.

## Invariants held / to hold

- Mouse OFF -> reticle pins to viewport centre, game behaves exactly as today (centre-aim hitscan, centre crosshair). Keyboard play unaffected. Golden render fixture unchanged (verified for the combat half; render half pending).
- Purity: controls/combat/state stay pure (no IO/rand/time); effects only in io/play. Output via print/println.
- Vertical (reticle row) stays informational for now: enemies are full-height billboards, so the column selects the target. Noted for follow-up.

Closes #324