### PR TITLE
docs(level-system): fix stale :walls scope + baked door in layout example (QA)

### DIFF
--- a/docs/level-system.md
+++ b/docs/level-system.md
@@ -52,7 +52,7 @@ Required fields:
 | Field | Meaning |
 |---|---|
 | `:size`     | `[width height]` of grid in cells |
-| `:walls`    | Random wall blobs (procedural path only) |
+| `:walls`    | Random interior wall-blob count - scattered into procgen rooms AND hand-authored `:layout` rooms (skipped only when `:switches` is set) |
 | `:enemy`    | Catalog kw - see [monsters.md](monsters.md) for the type list |
 | `:enemies`  | Int (count of `:enemy`) OR vector of mixed specs (see below) |
 | `:chase`    | Chase AI speed (units/sec) |
@@ -79,7 +79,7 @@ When `:enemies` is a vector, each spec spawns its own count + HP and the enemy c
 
 ### Hand-authored arenas (`:layout`)
 
-`[" ###### " " #....# " " #..@.# " " #....D " " ###### "]` parses via `map/parse-layout`:
+`[" ###### " " #....# " " #..@.# " " #....# " " ###### "]` parses via `map/parse-layout`:
 
 | Char | Meaning |
 |---|---|


### PR DESCRIPTION
## Summary

Fixes the only two confirmed findings from a full QA regression of the freshly-built phar against the Unreleased CHANGELOG. Both are self-contradicting stale docs in `docs/level-system.md`; **no code defects, regressions, or phar breakage were found** (all Unreleased features verified working headless in the built phar, `composer ci` green).

## Fixes

- **`:walls` field description**: said "(procedural path only)", but `build-grid` (`level.phel:720-722`) scatters `:walls` into hand-authored `:layout` rooms too (skipped only on `:switches` levels) - exactly as the prose two paragraphs below already states. Empirically L2's *empty* `showcase-layout` yields ~25 interior wall cells. Corrected.
- **`:layout` example door char**: the example string carried a baked `D` door, but layouts are geometry-only since `place-exit` took over exit placement; the char table directly below lists no `D` and `map/layout-char->cell` has no door entry. Replaced the `D` with the `#` border it had overwritten.

Docs-only.

## QA scope (for context)

13-agent find + adversarial-verify across 9 dimensions: render/perf, settings/persistence, input/mouse, combat/audio, level/map, game-loop fixes, **phar integrity** (boots from a temp dir, runs L1/4/5/7/10 headless via `--god --armory`, settings persist, no PHP errors), docs-sync, full `composer ci`. Two findings dismissed as intended behaviour (phar `--version`=last tag is the standard mid-dev state; the `#166` CHANGELOG entry is accurate in code).
