### PR TITLE
fix(render): default sub-pixel off on macOS Terminal.app (#332)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 
 - Eliminated the per-column closure tax in the raycaster cast loop (issue #345): the DDA march and the `wallx` texture-fraction branch sat in `let`-binding VALUE position, so each compiled to a per-column immediately-invoked PHP closure capturing ~40 locals - 3 closure builds per column, ~720/frame at 240 columns, on the hottest path. The DDA now marches in STATEMENT position into a reused 5-slot `hit-reg` register (the documented `cell-reg` pattern), and `wallx` reads a pure-arithmetic ternary - both compile inline with zero capture. Byte-identical (full suite + golden hashes unchanged); measured -39% on `cast-frame` at 80x24 / 120x30 / 180x40 (2000-iter `default-grid` bench, no-JIT local). Built `engine.php` drops from 5 `function() use(` sites to 2 (both non-per-column). See `docs/performance.md`.
 
+### Fixed
+
+- Sub-pixel auto-off on macOS Terminal.app (#332): Apple Terminal draws the `▀` half-block with row seams, so the default-on sub-pixel scene showed as gray static. Startup now reads `$TERM_PROGRAM` and defaults `Sub-pixel` off on `Apple_Terminal` until the player saves a choice; the in-game toggle and `PHEL_DOOM_SUBPIXEL=1` still force it on. iTerm2 et al. unchanged; render seam + golden hashes untouched.
+
 ## [0.16.0] - 2026-06-27
 
 ### Added

--- a/docs/rendering.md
+++ b/docs/rendering.md
@@ -194,12 +194,14 @@ The cost that killed the earlier full-frame attempt was the per-cell string buil
 
 `▀` half-blocks render pixel-tight in iTerm2, kitty, WezTerm and Ghostty, but **macOS Terminal.app draws block / box glyphs with anti-aliasing and inter-row line gaps**, so the half-block illusion breaks into visible horizontal **row seams** in the 3D view and gappy HUD borders (#332). The colour path is fine: the renderer is 256-colour only (`\e[38;5;Nm` / `\e[48;5;Nm`), which Terminal.app supports, so the gap is glyph rendering, not colour depth.
 
-Two fixes, either one helps:
+**Auto-off on Terminal.app (#332).** On startup `load-settings` reads `$TERM_PROGRAM`; on `Apple_Terminal` a player who has never saved a `Sub-pixel` choice gets it defaulted **off** (`io/input.halfblock-seams?` -> `core/settings.resolve-subpixel`), so the scene is readable out of the box instead of seam-shredded. The in-game toggle still works and, once saved, wins on every terminal. Precedence: `PHEL_DOOM_NO_SUBPIXEL=1` (force off, applied at the render seam) > `PHEL_DOOM_SUBPIXEL=1` (force on) > saved choice > Terminal.app auto-off > default on. iTerm2 / kitty / WezTerm / Ghostty keep sub-pixel on.
 
-1. **`Sub-pixel` setting OFF** (or `PHEL_DOOM_NO_SUBPIXEL=1`): drops to one solid colour per cell, so there are no `▀` sub-pixels to seam. Lower vertical fidelity but clean on Terminal.app. Wired as a persisted player setting (see [settings.md](settings.md)) and ANDed with the env override in `frame->string`'s `subpixel?` gate.
-2. **Terminal.app settings**: Preferences -> Profiles -> Text - set **line spacing to 1.0** (the default above 1.0 is what opens the row gaps) and use a tight monospace font (SF Mono, Menlo, Fira Code). Tightening line height alone removes most seams with Sub-pixel left ON.
+To run full fidelity on Terminal.app instead of the auto-off:
 
-Recommended order: try line spacing 1.0 first (keeps full fidelity); if seams persist, turn Sub-pixel off. iTerm2 / kitty / WezTerm / Ghostty need neither.
+1. **Line spacing 1.0**: Preferences -> Profiles -> Text - set **line spacing to 1.0** (the default above 1.0 is what opens the row gaps) and use a tight monospace font (SF Mono, Menlo, Fira Code). This removes most seams with Sub-pixel left on.
+2. **Re-enable Sub-pixel**: turn the `Sub-pixel` setting back on (persists, see [settings.md](settings.md)) or run with `PHEL_DOOM_SUBPIXEL=1`. The `subpixel?` gate in `frame->string` ANDs the setting with `PHEL_DOOM_NO_SUBPIXEL`.
+
+iTerm2 / kitty / WezTerm / Ghostty need none of this.
 
 ## Pixel-doubled mode (auto, big screens on slow machines)
 

--- a/src/core/settings.phel
+++ b/src/core/settings.phel
@@ -145,6 +145,22 @@
      :truecolor      (boolean (get m :truecolor (:truecolor default-settings)))
      :quad           (boolean (get m :quad (:quad default-settings)))}))
 
+(defn resolve-subpixel
+  "Effective startup `:subpixel` (#332). A terminal that draws the ▀
+   half-block with row seams (macOS Terminal.app) shreds the sub-pixel
+   scene, so a player who has never saved a sub-pixel choice defaults to
+   OFF there. Precedence: env opt-in (`force-on?`) > saved choice
+   (`saved?`) > seam-terminal default-off (`seams?`) > normal default
+   (`value`). The PHEL_DOOM_NO_SUBPIXEL kill-switch lives at the render
+   seam and overrides all of this. Pure: the IO layer supplies the
+   terminal + env booleans."
+  [value saved? seams? force-on?]
+  (cond
+    force-on? true
+    saved?    value
+    seams?    false
+    :else     value))
+
 (defn- wrap [i n]
   (php/% (php/+ (php/% i n) n) n))
 

--- a/src/io/input.phel
+++ b/src/io/input.phel
@@ -56,6 +56,21 @@
   (when (some? (get unhideable-pointer-terminals term))
     "OS arrow is cosmetic; aim is the + crosshair."))
 
+(def halfblock-seam-terminals
+  "TERM_PROGRAM values whose ▀ half-block renders with row seams / inter-row
+   gaps (#332), so the sub-pixel renderer defaults OFF there for a player who
+   has never chosen otherwise. Apple's Terminal anti-aliases ▀ with gaps;
+   iTerm2 / kitty / WezTerm / Ghostty draw it pixel-tight. A small allowlist
+   (only the sure case) - unknown terminals are assumed capable and keep
+   sub-pixel on."
+  #{"Apple_Terminal"})
+
+(defn halfblock-seams?
+  "True when `term` (a $TERM_PROGRAM value) renders the ▀ half-block with
+   seams (#332). Pure; pair with `terminal-program`."
+  [term]
+  (contains? halfblock-seam-terminals term))
+
 (defn terminal-program
   "The terminal identifier from $TERM_PROGRAM (\"\" when unset). Reads the
    environment, so it is side-effecting (not pure)."

--- a/src/io/settings.phel
+++ b/src/io/settings.phel
@@ -1,5 +1,6 @@
 (ns phel-doom.io.settings
-  (:require phel-doom.core.settings :refer [coerce-settings default-settings]))
+  (:require phel-doom.core.settings :refer [coerce-settings default-settings resolve-subpixel])
+  (:require phel-doom.io.input :refer [terminal-program halfblock-seams?]))
 
 ;; ---------------------------------------------------------------------
 ;; Settings persistence in $HOME/.phel-doom-settings.json.
@@ -28,37 +29,60 @@
     (php/aget arr key)
     fallback))
 
+(defn- subpixel-force-on?
+  "PHEL_DOOM_SUBPIXEL=1 forces sub-pixel ON, overriding the macOS
+   Terminal.app auto-off (#332). Mirrors the render-seam PHEL_DOOM_NO_SUBPIXEL
+   kill-switch (which still wins, applied later in io/render)."
+  []
+  (php/=== "1" (php/getenv "PHEL_DOOM_SUBPIXEL")))
+
+(defn- apply-terminal-defaults
+  "Overlay terminal-derived startup defaults onto a coerced settings map.
+   `saved?` says whether the on-disk file carried an explicit sub-pixel
+   choice (honored over the terminal default). Currently only the #332
+   sub-pixel auto-off. Reads $TERM_PROGRAM + env, so it is side-effecting."
+  [settings saved?]
+  (assoc settings :subpixel
+         (resolve-subpixel (:subpixel settings) saved?
+                           (halfblock-seams? (terminal-program))
+                           (subpixel-force-on?))))
+
 (defn load-settings
   "Read the persisted settings file, returning the coerced defaults
    when it's missing or malformed. Enum fields (difficulty / crosshair /
    colorblind) are stored as strings and keyword-ised on the way in;
    coerce-settings clamps + validates the whole map so the result is
-   always complete and safe to apply."
+   always complete and safe to apply. A terminal that mangles the ▀
+   half-block (macOS Terminal.app, #332) flips `:subpixel` off for a player
+   who never saved a choice (see `apply-terminal-defaults`)."
   []
-  (let [path (settings-path)]
-    (if (php/file_exists path)
-      (let [content (php/file_get_contents path)]
-        (if (or (php/=== content false) (php/=== content ""))
-          (coerce-settings default-settings)
-          (let [data (php/json_decode content true)]
-            (if (php/is_array data)
-              (coerce-settings
-               {:music          (read-from data "music"   (:music default-settings))
-                :sfx            (read-from data "sfx"      (:sfx default-settings))
-                :minimap        (read-from data "minimap"  (:minimap default-settings))
-                :difficulty     (keyword (read-from data "difficulty"     "normal"))
-                :crosshair      (keyword (read-from data "crosshair"      "cross"))
-                :timer          (read-from data "timer"          (:timer default-settings))
-                :mouse          (read-from data "mouse"          (:mouse default-settings))
-                :sensitivity    (read-from data "sensitivity"    (:sensitivity default-settings))
-                :high-contrast  (read-from data "high-contrast"  (:high-contrast default-settings))
-                :colorblind     (keyword (read-from data "colorblind"     "none"))
-                :fast-walls     (read-from data "fast-walls" (:fast-walls default-settings))
-                :subpixel       (read-from data "subpixel" (:subpixel default-settings))
-                :truecolor      (read-from data "truecolor" (:truecolor default-settings))
-                :quad           (read-from data "quad" (:quad default-settings))})
-              (coerce-settings default-settings)))))
-      (coerce-settings default-settings))))
+  (let [path             (settings-path)
+        [coerced saved?]
+        (if (php/file_exists path)
+          (let [content (php/file_get_contents path)]
+            (if (or (php/=== content false) (php/=== content ""))
+              [(coerce-settings default-settings) false]
+              (let [data (php/json_decode content true)]
+                (if (php/is_array data)
+                  [(coerce-settings
+                    {:music          (read-from data "music"   (:music default-settings))
+                     :sfx            (read-from data "sfx"      (:sfx default-settings))
+                     :minimap        (read-from data "minimap"  (:minimap default-settings))
+                     :difficulty     (keyword (read-from data "difficulty"     "normal"))
+                     :crosshair      (keyword (read-from data "crosshair"      "cross"))
+                     :timer          (read-from data "timer"          (:timer default-settings))
+                     :mouse          (read-from data "mouse"          (:mouse default-settings))
+                     :sensitivity    (read-from data "sensitivity"    (:sensitivity default-settings))
+                     :high-contrast  (read-from data "high-contrast"  (:high-contrast default-settings))
+                     :colorblind     (keyword (read-from data "colorblind"     "none"))
+                     :fast-walls     (read-from data "fast-walls" (:fast-walls default-settings))
+                     :subpixel       (read-from data "subpixel" (:subpixel default-settings))
+                     :truecolor      (read-from data "truecolor" (:truecolor default-settings))
+                     :quad           (read-from data "quad" (:quad default-settings))})
+                   (php/array_key_exists "subpixel" data)]
+                  [(coerce-settings default-settings) false]))))
+          [(coerce-settings default-settings) false])]
+    (apply-terminal-defaults coerced saved?)))
 
 (defn save-settings!
   "Write `settings` back to the JSON file. Enum fields are stored as

--- a/tests/core/settings-test.phel
+++ b/tests/core/settings-test.phel
@@ -2,7 +2,8 @@
   (:require phel.test :refer [deftest is])
   (:require phel-doom.core.settings :refer [default-settings difficulty-choices
                                             page-fields field-count field-at
-                                            coerce-settings move-cursor adjust
+                                            coerce-settings resolve-subpixel
+                                            move-cursor adjust
                                             navigate valid-difficulty?
                                             music-volume sfx-scalar music-ceiling
                                             mouse-sensitivity mouse-sensitivity-neutral
@@ -160,6 +161,34 @@
   (is (= true  (:quad (coerce-settings {:quad 1}))) "truthy coerced to bool true")
   (is (= false (:quad (coerce-settings {:quad false}))) "explicit false preserved")
   (is (= false (:quad (coerce-settings {}))) "missing -> default false"))
+
+;; ---------------------------------------------------------------------
+;; resolve-subpixel: terminal-aware startup default (#332). Args are
+;; (value saved? seams? force-on?). macOS Terminal.app shreds the ▀
+;; half-block, so a fresh player on a seam terminal defaults OFF.
+;; ---------------------------------------------------------------------
+
+(deftest test-resolve-subpixel-seam-terminal-unsaved-defaults-off
+  ;; Fresh player on Terminal.app: value is the default-on, but no saved
+  ;; choice + seam terminal -> off.
+  (is (= false (resolve-subpixel true false true false))))
+
+(deftest test-resolve-subpixel-non-seam-terminal-keeps-default-on
+  ;; iTerm2 etc.: not a seam terminal, so the default-on value stands.
+  (is (= true (resolve-subpixel true false false false))))
+
+(deftest test-resolve-subpixel-saved-choice-overrides-seam-default
+  ;; A saved choice wins over the seam default: a player who turned
+  ;; sub-pixel back ON on Terminal.app keeps it (true, not the seam's
+  ;; false) — this is what distinguishes `saved?` from `seams?`.
+  (is (= true  (resolve-subpixel true  true true false)) "saved on -> on")
+  (is (= false (resolve-subpixel false true true false)) "saved off -> off"))
+
+(deftest test-resolve-subpixel-env-force-on-beats-everything
+  ;; PHEL_DOOM_SUBPIXEL=1 forces on even on a seam terminal and even over a
+  ;; saved off.
+  (is (= true (resolve-subpixel true  false true true)))
+  (is (= true (resolve-subpixel false true  true true)) "force-on overrides saved off"))
 
 ;; ---------------------------------------------------------------------
 ;; Mouse + Sensitivity (issue #246).

--- a/tests/io/input-test.phel
+++ b/tests/io/input-test.phel
@@ -3,7 +3,7 @@
   (:require phel.string :as str)
   (:require phel-doom.io.input :refer [mouse-enable mouse-disable
                                        init-escapes restore-prelude
-                                       pointer-limit-notice]))
+                                       pointer-limit-notice halfblock-seams?]))
 
 ;; ---------------------------------------------------------------------
 ;; Mouse reporting escape contract (issue #246). The side-effecting
@@ -52,6 +52,14 @@
   (is (some? (pointer-limit-notice "vscode")) "VS Code -> notice")
   (is (nil? (pointer-limit-notice "WezTerm")) "unknown terminal -> no notice")
   (is (nil? (pointer-limit-notice "")) "unset TERM_PROGRAM -> no notice"))
+
+(deftest test-halfblock-seams-only-apple-terminal
+  ;; Only Terminal.app is on the seam allowlist (#332); pixel-tight
+  ;; terminals + unknown/unset keep sub-pixel on.
+  (is (= true  (halfblock-seams? "Apple_Terminal")) "Terminal.app -> seams")
+  (is (= false (halfblock-seams? "iTerm.app")) "iTerm2 draws ▀ tight")
+  (is (= false (halfblock-seams? "WezTerm")) "unknown terminal assumed capable")
+  (is (= false (halfblock-seams? "")) "unset TERM_PROGRAM -> no seams"))
 
 (deftest test-restore-prelude-pops-kitty-then-disables-mouse
   ;; Teardown always disables mouse reporting, regardless of whether it


### PR DESCRIPTION
## Problem

macOS Terminal.app renders the `▀` half-block (the sub-pixel renderer, on by default) with anti-aliased row seams, so the 3D view comes up as **gray static**. iTerm2 / kitty / WezTerm / Ghostty draw `▀` pixel-tight and look correct.

[#332](https://github.com/Chemaclass/phel-doom/issues/332) shipped the manual `Sub-pixel` setting + `PHEL_DOOM_NO_SUBPIXEL`, but left the default **on** — so a fresh Terminal.app player still hits the broken view out of the box.

## Fix

Startup reads `$TERM_PROGRAM`; on `Apple_Terminal`, a player who has **never saved** a sub-pixel choice gets it defaulted **off** — readable out of the box. Explicit choices always win.

Layering (keeps `core/` pure):
- `core/settings.resolve-subpixel` — **pure** decision (booleans only), unit-tested.
- `io/input.halfblock-seams?` + `halfblock-seam-terminals #{"Apple_Terminal"}` — terminal knowledge, beside the existing `unhideable-pointer-terminals`.
- `io/settings.load-settings` — glues `$TERM_PROGRAM` + `PHEL_DOOM_SUBPIXEL` + raw-file key-presence into the decision.

No render-seam or `play.phel` change: the corrected `:subpixel` flows through the existing `frame-stats` → `frame->string` path, so the **byte-exact golden frame hashes are untouched**.

## Precedence

`PHEL_DOOM_NO_SUBPIXEL=1` (force off, render seam) > `PHEL_DOOM_SUBPIXEL=1` (force on) > saved choice > Terminal.app auto-off > default on.

## Tests

- `resolve-subpixel`: seam+unsaved → off, non-seam → on, saved choice overrides the seam default, env force-on beats everything (distinguishing inputs, not coverage filler).
- `halfblock-seams?`: only `Apple_Terminal` is on the allowlist; iTerm2 / unknown / unset → off.

## Docs

`docs/rendering.md` "macOS Terminal.app compatibility": auto-off behaviour + precedence + how to opt back into full fidelity.

Follow-up to #332 (its proposed auto-detect, which was left undone).
