### PR TITLE
perf(raycaster): eliminate per-column closure tax in cast loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 
 ## [Unreleased]
 
+### Performance
+
+- Eliminated the per-column closure tax in the raycaster cast loop (issue #345): the DDA march and the `wallx` texture-fraction branch sat in `let`-binding VALUE position, so each compiled to a per-column immediately-invoked PHP closure capturing ~40 locals - 3 closure builds per column, ~720/frame at 240 columns, on the hottest path. The DDA now marches in STATEMENT position into a reused 5-slot `hit-reg` register (the documented `cell-reg` pattern), and `wallx` reads a pure-arithmetic ternary - both compile inline with zero capture. Byte-identical (full suite + golden hashes unchanged); measured -39% on `cast-frame` at 80x24 / 120x30 / 180x40 (2000-iter `default-grid` bench, no-JIT local). Built `engine.php` drops from 5 `function() use(` sites to 2 (both non-per-column). See `docs/performance.md`.
+
 ## [0.16.0] - 2026-06-27
 
 ### Added

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -26,7 +26,7 @@ Result on the 3-enemy corridor bench (ms/frame, same machine):
 
 Frame output is byte-identical before/after (verified by md5 over a 24-config matrix: angles, sizes, blood, minimap, px2, flat/no-subpixel/no-sprite toggles).
 
-To check for regressions: build and grep the artifact - `grep -c 'function() use(' out/phel_doom/io/render/main.php` should stay at ~21, all of them once-per-frame sites (pickup-painter chain arguments, centre-cell capture, debug snapshot), none inside the per-cell `while` loops.
+To check for regressions: build and grep the artifact - `grep -c 'function() use(' out/phel_doom/io/render/main.php` should stay at ~21, all of them once-per-frame sites (pickup-painter chain arguments, centre-cell capture, debug snapshot), none inside the per-cell `while` loops. The raycaster artifact `out/phel_doom/core/engine.php` should stay at 2 (the once-per-width FOV-table build + the once-per-frame pause-cache probe); the per-column cast loop has been closure-free since issue #345 (the DDA march + `wallx` were lifted out of binding position into the reused `hit-reg` register).
 
 ## Big screens: uniform cadence + crisp walls
 
@@ -237,7 +237,7 @@ Verdict: complexity cost > realistic win.
 After DDA, `cast-frame` was still running `atan` + `cos` per column and dispatching `cast-ray-hit` per ray. Two follow-ups:
 
 1. **Width-keyed memo.** `offset-tables-for` caches per-width `[col -> offset]` + `[col -> cos(offset)]` arrays. Cast-frame reads two `aget`s instead of trig per column.
-2. **Inlined DDA.** `cast-ray-hit` inlined into `cast-frame`. DDA returns PHP arrays, not persistent vectors.
+2. **Inlined DDA.** `cast-ray-hit` inlined into `cast-frame`. The DDA marches in statement position and writes its `[dist hit side hx hy]` result into a reused 5-slot `hit-reg` register (issue #345), so the hot loop neither dispatches a per-ray call nor allocates a persistent vector (nor the per-column closure that binding the march in value position would have cost).
 
 Effect on `cast-frame` (2000-iter bench, `default-grid`):
 

--- a/src/core/engine.phel
+++ b/src/core/engine.phel
@@ -179,87 +179,110 @@
         hys                 (php/array)
         wallxs              (php/array)
         floordxs            (php/array)
-        floordys            (php/array)]
-     ;; DDA traversal is inlined: avoids one fn call per column AND
-     ;; replaces the per-ray Phel-vector `[d h side hx hy]` return
-     ;; with a cheap `php/array` so the hot loop allocates a plain
-     ;; PHP array per ray instead of a persistent vector.
+        floordys            (php/array)
+        ;; Per-cast 5-slot scratch register [dist hit side hx hy]. The
+        ;; DDA writes it in STATEMENT position (see below) and reuses it
+        ;; every column; binding the march's result directly would
+        ;; closure-compile and copy ~40 locals per column (issue #345).
+        hit-reg             (php/array)]
+     ;; Per column: march the DDA in STATEMENT position so the loop
+     ;; compiles to a plain `while` and its `[dist hit side hx hy]`
+     ;; result lands in the reused `hit-reg` register. Binding the
+     ;; march (or the `wallx` `let` branches) in VALUE position would
+     ;; compile each to a per-column PHP closure capturing ~40 locals -
+     ;; the documented closure tax (issue #345, docs/performance.md).
     (loop [col 0]
       (when (php/< col width)
-        (let [a       (php/+ angle (php/aget offsets col))
-              dirx    (php/cos a)
-              diry    (php/sin a)
-              stepx   (if (php/< dirx 0.0) -1 1)
-              stepy   (if (php/< diry 0.0) -1 1)
-              deltax  (if (php/=== dirx 0.0) dda-inf (php/abs (php// 1.0 dirx)))
-              deltay  (if (php/=== diry 0.0) dda-inf (php/abs (php// 1.0 diry)))
-              cx0     (php/intval (php/floor x))
-              cy0     (php/intval (php/floor y))
-              sidex0  (if (php/< dirx 0.0)
-                        (php/* (php/- x cx0) deltax)
-                        (php/* (php/- (php/+ cx0 1.0) x) deltax))
-              sidey0  (if (php/< diry 0.0)
-                        (php/* (php/- y cy0) deltay)
-                        (php/* (php/- (php/+ cy0 1.0) y) deltay))
-              hit-arr (loop [cx cx0 cy cy0 sidex sidex0 sidey sidey0]
-                        (if (php/< sidex sidey)
-                          (let [cx'  (php/+ cx stepx)
-                                dist sidex
-                                hit  (cell-at pgrid cx' cy)]
-                            (cond
-                              (php/> dist max-depth) (php/array max-depth 0 0 cx' cy)
-                              (php/!== 0 hit)        (php/array dist hit 0 cx' cy)
-                              :else                  (recur cx' cy (php/+ sidex deltax) sidey)))
-                          (let [cy'  (php/+ cy stepy)
-                                dist sidey
-                                hit  (cell-at pgrid cx cy')]
-                            (cond
-                              (php/> dist max-depth) (php/array max-depth 0 1 cx cy')
-                              (php/!== 0 hit)        (php/array dist hit 1 cx cy')
-                              :else                  (recur cx cy' sidex (php/+ sidey deltay))))))
-              rawd    (php/aget hit-arr 0)
-              d-corr  (php/* rawd (php/aget cos-offs col))
-              h       (php/aget hit-arr 1)
-              side    (php/aget hit-arr 2)
-              hx      (php/aget hit-arr 3)
-              hy      (php/aget hit-arr 4)
-              ;; Texture U: fractional position along the wall face where
-              ;; the ray hit. Vertical face (side 0) → frac of world-y at
-              ;; the hit; horizontal face (side 1) → frac of world-x.
-              ;; Uses the raw (perpendicular) side distance, not the
-              ;; fish-eye-corrected one. In [0, 1) → texture column.
-              wallx   (if (php/=== side 0)
-                        (let [wy (php/+ y (php/* rawd diry))] (php/- wy (php/floor wy)))
-                        (let [wx (php/+ x (php/* rawd dirx))] (php/- wx (php/floor wx))))
-              ;; Floor-cast basis for this column: the ray direction
-              ;; divided by cos(offset). A floor cell at perpendicular
-              ;; distance `dperp` (a per-ROW constant the renderer knows)
-              ;; sits at world `player + dperp * (floordx, floordy)`, so
-              ;; the renderer needs no per-cell trig — just two mul-adds.
-              inv-cos (php// 1.0 (php/aget cos-offs col))
-              floordx (php/* dirx inv-cos)
-              floordy (php/* diry inv-cos)]
-           ;; Replicate this sample across the next `scale` output
-           ;; columns. `scale` is 1 today (crisp 1:1 walls everywhere),
-           ;; so this fills exactly one cell; the loop keeps the
-           ;; replication capability for any caller that passes scale>1.
-           ;; Inner loop bound by `width` so a non-divisible tail (e.g.
-           ;; width=401, scale=2) doesn't overshoot. When scale>1 the
-           ;; fish-eye correction reuses the SAMPLE column's `offset`
-           ;; for every neighbour cell (the per-cell-accurate
-           ;; alternative would mean N atan + cos calls per sample).
-          (loop [c col fill 0]
-            (when (and (php/< c width) (php/< fill scale))
-              (php/aset dists c d-corr)
-              (php/aset hits c h)
-              (php/aset sides c side)
-              (php/aset hxs c hx)
-              (php/aset hys c hy)
-              (php/aset wallxs c wallx)
-              (php/aset floordxs c floordx)
-              (php/aset floordys c floordy)
-              (recur (php/+ c 1) (php/+ fill 1))))
-          (recur (php/+ col scale)))))
+        (let [a      (php/+ angle (php/aget offsets col))
+              dirx   (php/cos a)
+              diry   (php/sin a)
+              stepx  (if (php/< dirx 0.0) -1 1)
+              stepy  (if (php/< diry 0.0) -1 1)
+              deltax (if (php/=== dirx 0.0) dda-inf (php/abs (php// 1.0 dirx)))
+              deltay (if (php/=== diry 0.0) dda-inf (php/abs (php// 1.0 diry)))
+              cx0    (php/intval (php/floor x))
+              cy0    (php/intval (php/floor y))
+              sidex0 (if (php/< dirx 0.0)
+                       (php/* (php/- x cx0) deltax)
+                       (php/* (php/- (php/+ cx0 1.0) x) deltax))
+              sidey0 (if (php/< diry 0.0)
+                       (php/* (php/- y cy0) deltay)
+                       (php/* (php/- (php/+ cy0 1.0) y) deltay))]
+          ;; DDA march (statement position -> no closure). Each exit
+          ;; writes the 5-slot register; `:else` steps to the next
+          ;; grid-line crossing.
+          (loop [cx cx0 cy cy0 sidex sidex0 sidey sidey0]
+            (if (php/< sidex sidey)
+              (let [cx'  (php/+ cx stepx)
+                    dist sidex
+                    hit  (cell-at pgrid cx' cy)]
+                (cond
+                  (php/> dist max-depth)
+                  (do (php/aset hit-reg 0 max-depth) (php/aset hit-reg 1 0)
+                      (php/aset hit-reg 2 0) (php/aset hit-reg 3 cx') (php/aset hit-reg 4 cy))
+                  (php/!== 0 hit)
+                  (do (php/aset hit-reg 0 dist) (php/aset hit-reg 1 hit)
+                      (php/aset hit-reg 2 0) (php/aset hit-reg 3 cx') (php/aset hit-reg 4 cy))
+                  :else
+                  (recur cx' cy (php/+ sidex deltax) sidey)))
+              (let [cy'  (php/+ cy stepy)
+                    dist sidey
+                    hit  (cell-at pgrid cx cy')]
+                (cond
+                  (php/> dist max-depth)
+                  (do (php/aset hit-reg 0 max-depth) (php/aset hit-reg 1 0)
+                      (php/aset hit-reg 2 1) (php/aset hit-reg 3 cx) (php/aset hit-reg 4 cy'))
+                  (php/!== 0 hit)
+                  (do (php/aset hit-reg 0 dist) (php/aset hit-reg 1 hit)
+                      (php/aset hit-reg 2 1) (php/aset hit-reg 3 cx) (php/aset hit-reg 4 cy'))
+                  :else
+                  (recur cx cy' sidex (php/+ sidey deltay))))))
+          (let [rawd    (php/aget hit-reg 0)
+                d-corr  (php/* rawd (php/aget cos-offs col))
+                h       (php/aget hit-reg 1)
+                side    (php/aget hit-reg 2)
+                hx      (php/aget hit-reg 3)
+                hy      (php/aget hit-reg 4)
+                ;; Texture U: fractional position along the wall face where
+                ;; the ray hit. Vertical face (side 0) -> frac of world-y at
+                ;; the hit; horizontal face (side 1) -> frac of world-x.
+                ;; Uses the raw (perpendicular) side distance, not the
+                ;; fish-eye-corrected one. In [0, 1) -> texture column. Both
+                ;; `if` branches are pure expressions, so this stays a
+                ;; ternary; one frac op reads its result.
+                wcoord  (if (php/=== side 0)
+                          (php/+ y (php/* rawd diry))
+                          (php/+ x (php/* rawd dirx)))
+                wallx   (php/- wcoord (php/floor wcoord))
+                ;; Floor-cast basis for this column: the ray direction
+                ;; divided by cos(offset). A floor cell at perpendicular
+                ;; distance `dperp` (a per-ROW constant the renderer knows)
+                ;; sits at world `player + dperp * (floordx, floordy)`, so
+                ;; the renderer needs no per-cell trig - just two mul-adds.
+                inv-cos (php// 1.0 (php/aget cos-offs col))
+                floordx (php/* dirx inv-cos)
+                floordy (php/* diry inv-cos)]
+             ;; Replicate this sample across the next `scale` output
+             ;; columns. `scale` is 1 today (crisp 1:1 walls everywhere),
+             ;; so this fills exactly one cell; the loop keeps the
+             ;; replication capability for any caller that passes scale>1.
+             ;; Inner loop bound by `width` so a non-divisible tail (e.g.
+             ;; width=401, scale=2) doesn't overshoot. When scale>1 the
+             ;; fish-eye correction reuses the SAMPLE column's `offset`
+             ;; for every neighbour cell (the per-cell-accurate
+             ;; alternative would mean N atan + cos calls per sample).
+            (loop [c col fill 0]
+              (when (and (php/< c width) (php/< fill scale))
+                (php/aset dists c d-corr)
+                (php/aset hits c h)
+                (php/aset sides c side)
+                (php/aset hxs c hx)
+                (php/aset hys c hy)
+                (php/aset wallxs c wallx)
+                (php/aset floordxs c floordx)
+                (php/aset floordys c floordy)
+                (recur (php/+ c 1) (php/+ fill 1))))
+            (recur (php/+ col scale))))))
     {:dists dists :hits hits :sides sides :hxs hxs :hys hys :wallxs wallxs
      :floordxs floordxs :floordys floordys}))
 

--- a/src/core/engine.phel
+++ b/src/core/engine.phel
@@ -180,9 +180,10 @@
         wallxs              (php/array)
         floordxs            (php/array)
         floordys            (php/array)
-        ;; Per-cast 5-slot scratch register [dist hit side hx hy]. The
-        ;; DDA writes it in STATEMENT position (see below) and reuses it
-        ;; every column; binding the march's result directly would
+        ;; Per-cast scratch register, reused every column. Slots:
+        ;; [0]=dist [1]=hit [2]=side [3]=hx [4]=hy. The DDA writes it in
+        ;; STATEMENT position (see below) so the writes land on the real
+        ;; array; binding the march's result in value position would
         ;; closure-compile and copy ~40 locals per column (issue #345).
         hit-reg             (php/array)]
      ;; Per column: march the DDA in STATEMENT position so the loop


### PR DESCRIPTION
## 📚 Description

The `do-cast` per-column body bound the DDA march and the `wallx` texture-fraction branch in `let`-binding VALUE position, so each compiled to an immediately-invoked PHP closure capturing ~40 locals - 3 closure builds per column (~720/frame at 240 cols) on the hottest path (the documented closure tax). This lifts both out of binding position.

## 🔖 Changes

- DDA now marches in STATEMENT position into a reused 5-slot `hit-reg` register (the `cell-reg` pattern); compiles to a plain `while`, no IIFE.
- `wallx` reads a pure-arithmetic ternary (`wcoord` + one frac op) instead of two `let`-branch IIFEs.
- Byte-identical: 2963 tests + golden render hashes unchanged. Bench **-39%** on `cast-frame` (80x24/120x30/180x40, 2000-iter default-grid). Built `engine.php`: `function() use(` 5 -> 2 (both non-per-column).
- Doc-sync: `docs/performance.md` regression grep now covers `engine.php`.

Closes #345