### PR TITLE
ref(pickups): extract pure pickup-* logic to core/pickups.phel

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -20,6 +20,7 @@ src/
 │   ├── projectile.phel              ; enemy fireballs: spawn + march + impacts
 │   ├── level.phel                   ; level catalog + build-world factory
 │   ├── weapons.phel                 ; per-weapon stats + switch/reload
+│   ├── pickups.phel                 ; step-on item rules (hearts, ammo, keys, weapons)
 │   ├── format.phel                  ; render format helpers
 │   ├── settings.phel                ; difficulty + volume + minimap settings
 │   ├── perf.phel                    ; frame cadence + render-scale (uniform)

--- a/docs/game-loop.md
+++ b/docs/game-loop.md
@@ -67,7 +67,7 @@ The pipeline enqueues effects (sfx, hits) into `:sfx` on the world itself; the g
 | `try-reveal-secret` / `try-toggle-switch` | F-key adjacent: secret reveal OR switch toggle + targets | `commands/play` |
 | `mark-visible-cells` | Stamp LOS cells onto `:visited` (fog-of-war reveal) | `core/engine` |
 | `tick-stamina` + `apply-physics` | Drain sprint pool; rotate + translate (with Z step/fall) + ease pending fall + decay counters | `core/physics` |
-| `pickup-*` (x9) | Hearts, armor, armor-shards, ammo, berserk, invuln, soulsphere, backpack, weapon | `commands/play` |
+| `pickup-*` (x10) | Hearts, armor, armor-shards, ammo, berserk, invuln, soulsphere, backpack, weapon, keycards | `core/pickups` |
 | `tick-enemies` | Step alive enemies; tick respawn + AI + hit-flash | `core/enemy`, `core/enemy_ai` |
 | `tick-projectiles` | Spawn bolts from released casters; march + cull; resolve player impacts | `core/projectile` |
 | `reload` | R edge: drain reserve into mag; arm cooldown | `core/combat` |

--- a/docs/state.md
+++ b/docs/state.md
@@ -86,7 +86,7 @@ After `build-world` from `core/level.phel` stamps level metadata, the world also
 :pgrid (to-php-array (map to-php-array grid))
 ```
 
-On grid mutation (door turning into floor, etc.) **both** must update. See `pickup-hearts` and door logic in `commands/play.phel`. `rebuild-pgrid` is called after any grid edit to keep the PHP mirror in sync.
+On grid mutation (door turning into floor, etc.) **both** must update. See `pickup-hearts` in `core/pickups.phel` and door logic in `commands/play.phel`. `rebuild-pgrid` is called after any grid edit to keep the PHP mirror in sync.
 
 ## The player
 

--- a/src/commands/play.phel
+++ b/src/commands/play.phel
@@ -1,21 +1,17 @@
 (ns phel-doom.commands.play
   (:require phel.cli :as cli)
   (:require phel.string :as str)
-  (:require phel-doom.core.state    :refer [advance-game-time at-backpack-cap? backpack-level
-                                            clamp-pitch decay-soul-overcap gain-armor-shard gain-backpack
-                                            gain-life gain-soulsphere
-                                            max-armor max-lives max-stamina turn-player
-                                            rebuild-pgrid reset-reticle
-                                            toggle-debug toggle-map toggle-pause toggle-sound])
+  (:require phel-doom.core.state :refer [advance-game-time backpack-level clamp-pitch decay-soul-overcap max-lives max-stamina turn-player rebuild-pgrid reset-reticle toggle-debug toggle-map toggle-pause toggle-sound])
   (:require phel-doom.core.map      :refer [door? reveal-secret secret? switch? toggle-switch])
   (:require phel-doom.glue.controls :refer [refresh-from-keys key-states rising-edges
                                             initial-key-snapshot nav-deltas mouse-aim])
   (:require phel-doom.core.physics  :refer [apply-physics tick-heartbeat tick-blood-drops tick-stamina])
   (:require phel-doom.core.engine   :refer [mark-visible-cells])
-  (:require phel-doom.core.combat   :refer [ammo-per-box arm-berserk damage-step fire-anim-seconds invuln-seconds push-sfx reload reloading? reload-cooldown-seconds tick-armory tick-shooting])
+  (:require phel-doom.core.pickups :refer [pickup-hearts pickup-armors pickup-ammos pickup-berserks pickup-invulns pickup-soulspheres pickup-armor-shards pickup-backpacks pickup-weapon-pickups pickup-keycards])
+  (:require phel-doom.core.combat :refer [damage-step fire-anim-seconds push-sfx reload reloading? reload-cooldown-seconds tick-armory tick-shooting])
   (:require phel-doom.core.enemy    :refer [advance tick-scare rear-attacker?])
   (:require phel-doom.core.projectile :refer [tick-projectiles tick-tracers])
-  (:require phel-doom.core.weapons  :refer [give-weapon switch-weapon weapon-spec weapon-order weapons])
+  (:require phel-doom.core.weapons :refer [switch-weapon weapon-spec weapon-order weapons])
   (:require phel-doom.io.sound    :refer [play-sfx! mute-for! set-sfx-scalar!])
   (:require phel-doom.io.music    :as music)
   (:require phel-doom.core.settings :refer [navigate music-volume sfx-scalar mouse-sensitivity valid-difficulty? pause-menu-move pause-menu-action])
@@ -262,203 +258,6 @@
     (update world :enemies advance (:grid world) (:pgrid world) (:x p) (:y p) dt
             (or (:chase-speed world) 0.75)
             (not (boss-down? world)))))
-
-(defn- entities-not-at
-  "All entities in `coll` whose integer cell is NOT (px, py). Shared by
-   every step-on pickup to drop the consumed entity from its vector.
-   nil-safe: a missing collection reads as empty."
-  [coll px py]
-  (apply vector
-         (filter (fn [e]
-                   (not (and (= (php/intval (:x e)) px)
-                             (= (php/intval (:y e)) py))))
-                 (or coll []))))
-
-(defn- pickup-hearts
-  "If the player stands on a heart cell, consume it and gain a life."
-  [world]
-  (let [kept (entities-not-at (:hearts world)
-                              (php/intval (:x (:player world)))
-                              (php/intval (:y (:player world))))]
-    (if (= (count kept) (count (or (:hearts world) [])))
-      world
-      (push-sfx (gain-life (assoc world :hearts kept)) :berserk 1.0))))
-
-(defn- pickup-armors
-  "Step-on triggers an armor pickup: bumps :armor by 1, capped at
-   `max-armor` (5) so the player can't farm an indestructible
-   buffer. The next contact-damage hit consumes one armor unit
-   instead of a life (see combat/take-damage). Pickup is always
-   consumed even at cap to match the heart / gain-life pattern."
-  [world]
-  (let [kept (entities-not-at (:armors world)
-                              (php/intval (:x (:player world)))
-                              (php/intval (:y (:player world))))]
-    (if (= (count kept) (count (or (:armors world) [])))
-      world
-      (let [shielded (assoc world :armors kept)]
-        (push-sfx
-         (update shielded :armor (fn [a] (php/min max-armor (php/+ (or a 0) 1))))
-         :door 1.0)))))
-
-(defn- entity-at
-  "Pick the first entity in `coll` at cell (px, py) so the caller can
-   read its optional tags (e.g. an ammo box's `:weapon`). nil when no
-   entity sits on the cell."
-  [coll px py]
-  (loop [es coll]
-    (cond
-      (nil? es)          nil
-      (zero? (count es)) nil
-      :else
-      (let [e (first es)]
-        (if (and (= (php/intval (:x e)) px)
-                 (= (php/intval (:y e)) py))
-          e
-          (recur (next es)))))))
-
-(defn- pickup-ammos
-  "Step-on triggers an ammo-box pickup. Two flavours:
-
-   - Untagged box (level spawn): bumps the ACTIVE weapon's reserve
-     by its `:ammo-per-box`, capped at the weapon's `:reserve-cap`.
-   - Weapon-tagged box (kill-loot, carries `:weapon kw`): bumps
-     THAT weapon's reserve so dropping a chaingun-tagged box while
-     holding the pistol still feeds the chaingun. Top-level
-     `:ammo-reserve` mirror is updated only when the tag matches
-     the currently-held weapon.
-
-   Box is removed so the player can't farm one cell."
-  [world]
-  (let [px     (php/intval (:x (:player world)))
-        py     (php/intval (:y (:player world)))
-        all    (or (:ammo-boxes world) [])
-        on-box (entity-at all px py)
-        kept   (entities-not-at all px py)]
-    (if (nil? on-box)
-      world
-      (let [tagged-w  (:weapon on-box)
-            target    (or tagged-w (:weapon world) :pistol)
-            target-sp (or (get weapons target) (weapon-spec world) {})
-            per-box   (or (:ammo-per-box target-sp) ammo-per-box)
-            base-cap  (or (:reserve-cap target-sp) 0)
-            cap       (php/* base-cap (php/+ 1 (backpack-level world)))
-            stash     (or (:weapon-state world) {})
-            cur       (or (get-in stash [target :reserve]) 0)
-            cur'      (php/min cap (php/+ cur per-box))
-            stash'    (assoc-in stash [target :reserve] cur')
-            refilled  (assoc world :ammo-boxes kept :weapon-state stash')]
-        (push-sfx
-         (if (= target (or (:weapon world) :pistol))
-           (assoc refilled :ammo-reserve cur')
-           refilled)
-         :door 1.0)))))
-
-(defn- pickup-berserks
-  "Step-on consumes the berserk sphere + arms `:berserk-secs` for the
-   2x-damage rage window. Stepping on a second sphere while still
-   berserk refreshes (not stacks) - `arm-berserk` replaces the timer
-   rather than adding to it. Distinct `:berserk` sfx so the pickup is
-   audibly different from a generic door/key tink."
-  [world]
-  (let [kept (entities-not-at (:berserks world)
-                              (php/intval (:x (:player world)))
-                              (php/intval (:y (:player world))))]
-    (if (= (count kept) (count (or (:berserks world) [])))
-      world
-      (push-sfx (arm-berserk (assoc world :berserks kept)) :berserk 1.0))))
-
-(defn- pickup-invulns
-  "Step-on consumes the invulnerability sphere + arms
-   `:invuln-secs` of damage immunity. Refresh-not-add on stack."
-  [world]
-  (let [kept (entities-not-at (:invulns world)
-                              (php/intval (:x (:player world)))
-                              (php/intval (:y (:player world))))]
-    (if (= (count kept) (count (or (:invulns world) [])))
-      world
-      (push-sfx (assoc world
-                       :invulns     kept
-                       :invuln-secs invuln-seconds)
-                :door 1.0))))
-
-(defn- pickup-soulspheres
-  "Step-on consumes a soulsphere + bumps `:lives` toward
-   `soulsphere-cap` via `gain-soulsphere`. Over-cap lives decay back
-   to `max-lives` over time (see `decay-soul-overcap`)."
-  [world]
-  (let [kept (entities-not-at (:soulspheres world)
-                              (php/intval (:x (:player world)))
-                              (php/intval (:y (:player world))))]
-    (if (= (count kept) (count (or (:soulspheres world) [])))
-      world
-      (push-sfx (gain-soulsphere (assoc world :soulspheres kept)) :berserk 1.0))))
-
-(defn- pickup-armor-shards
-  "Step-on consumes an armor shard + adds +1 armor via
-   `gain-armor-shard` (capped at `armor-shard-cap` = 2x max-armor).
-   No decay - shards bank as a permanent buffer (DOOM helmet bonus
-   pattern). Common pickup so the door tink reads as routine
-   loot rather than a special-event sfx."
-  [world]
-  (let [kept (entities-not-at (:armor-shards world)
-                              (php/intval (:x (:player world)))
-                              (php/intval (:y (:player world))))]
-    (if (= (count kept) (count (or (:armor-shards world) [])))
-      world
-      (push-sfx (gain-armor-shard (assoc world :armor-shards kept)) :door 1.0))))
-
-(defn- pickup-backpacks
-  "Stacking pickup (#68 part 3): each step-on bumps `:backpack-level`
-   by 1 up to `max-backpacks`. `weapons/effective-reserve-cap` then
-   returns `base * (1 + level)` so a second backpack expands every
-   weapon's reserve cap from 2x to 3x, a third to 4x. The stack
-   carries across levels via build-world's owned-state argument.
-   At cap the pickup is silently consumed (cell freed) but the
-   level is unchanged."
-  [world]
-  (let [kept (entities-not-at (:backpacks world)
-                              (php/intval (:x (:player world)))
-                              (php/intval (:y (:player world))))]
-    (if (= (count kept) (count (or (:backpacks world) [])))
-      world
-      (let [picked (assoc world :backpacks kept)]
-        (push-sfx
-         (if (at-backpack-cap? picked)
-           picked
-           (gain-backpack picked))
-         :door 1.0)))))
-
-(defn- pickup-weapon-pickups
-  "Step-on consumes a weapon pickup, adds it to :owned-weapons, and
-   auto-switches to it DOOM-style (mid-fight reload-lockout check is
-   bypassed here because the pickup is the trigger, not user input)."
-  [world]
-  (let [px      (php/intval (:x (:player world)))
-        py      (php/intval (:y (:player world)))
-        on-pick (entity-at (:weapon-pickups world) px py)]
-    (if (nil? on-pick)
-      world
-      (let [kept (entities-not-at (:weapon-pickups world) px py)]
-        (push-sfx
-         (give-weapon (assoc world :weapon-pickups kept) (:weapon on-pick))
-         :door 1.0)))))
-
-(defn- pickup-keycards
-  "Step-on consumes the keycard + adds its colour to `:held-keys`.
-   try-move uses the set to gate locked-door passage."
-  [world]
-  (let [px      (php/intval (:x (:player world)))
-        py      (php/intval (:y (:player world)))
-        on-card (entity-at (:keycards world) px py)]
-    (if (nil? on-card)
-      world
-      (let [kept (entities-not-at (:keycards world) px py)]
-        (push-sfx
-         (assoc world
-                :keycards  kept
-                :held-keys (conj (or (:held-keys world) #{}) (:colour on-card)))
-         :door 1.0)))))
 
 (defn- on-door?
   "True when the player's current cell is a door (auto-advances level)."

--- a/src/core/pickups.phel
+++ b/src/core/pickups.phel
@@ -4,10 +4,8 @@
   (:require phel-doom.core.weapons :refer [give-weapon weapon-spec weapons]))
 
 ;; Pure step-on pickup rules, extracted from commands/play.phel (#349).
-;; Each `pickup-*` is a world->world transform: when the player's cell
-;; holds the entity it consumes it and applies the effect, enqueuing sfx
-;; via `push-sfx` (never played inline) so the cluster stays pure.
-;; tick-world threads them every frame.
+;; Sound is enqueued via `push-sfx` (never played inline) so these stay
+;; pure and unit-testable without an audio stub.
 
 (defn- entities-not-at
   "All entities in `coll` whose integer cell is NOT (px, py). Shared by

--- a/src/core/pickups.phel
+++ b/src/core/pickups.phel
@@ -1,0 +1,207 @@
+(ns phel-doom.core.pickups
+  (:require phel-doom.core.state   :refer [at-backpack-cap? backpack-level gain-armor-shard gain-backpack gain-life gain-soulsphere max-armor])
+  (:require phel-doom.core.combat  :refer [ammo-per-box arm-berserk invuln-seconds push-sfx])
+  (:require phel-doom.core.weapons :refer [give-weapon weapon-spec weapons]))
+
+;; Pure step-on pickup rules, extracted from commands/play.phel (#349).
+;; Each `pickup-*` is a world->world transform: when the player's cell
+;; holds the entity it consumes it and applies the effect, enqueuing sfx
+;; via `push-sfx` (never played inline) so the cluster stays pure.
+;; tick-world threads them every frame.
+
+(defn- entities-not-at
+  "All entities in `coll` whose integer cell is NOT (px, py). Shared by
+   every step-on pickup to drop the consumed entity from its vector.
+   nil-safe: a missing collection reads as empty."
+  [coll px py]
+  (apply vector
+         (filter (fn [e]
+                   (not (and (= (php/intval (:x e)) px)
+                             (= (php/intval (:y e)) py))))
+                 (or coll []))))
+
+(defn pickup-hearts
+  "If the player stands on a heart cell, consume it and gain a life."
+  [world]
+  (let [kept (entities-not-at (:hearts world)
+                              (php/intval (:x (:player world)))
+                              (php/intval (:y (:player world))))]
+    (if (= (count kept) (count (or (:hearts world) [])))
+      world
+      (push-sfx (gain-life (assoc world :hearts kept)) :berserk 1.0))))
+
+(defn pickup-armors
+  "Step-on triggers an armor pickup: bumps :armor by 1, capped at
+   `max-armor` (5) so the player can't farm an indestructible
+   buffer. The next contact-damage hit consumes one armor unit
+   instead of a life (see combat/take-damage). Pickup is always
+   consumed even at cap to match the heart / gain-life pattern."
+  [world]
+  (let [kept (entities-not-at (:armors world)
+                              (php/intval (:x (:player world)))
+                              (php/intval (:y (:player world))))]
+    (if (= (count kept) (count (or (:armors world) [])))
+      world
+      (let [shielded (assoc world :armors kept)]
+        (push-sfx
+         (update shielded :armor (fn [a] (php/min max-armor (php/+ (or a 0) 1))))
+         :door 1.0)))))
+
+(defn- entity-at
+  "Pick the first entity in `coll` at cell (px, py) so the caller can
+   read its optional tags (e.g. an ammo box's `:weapon`). nil when no
+   entity sits on the cell."
+  [coll px py]
+  (loop [es coll]
+    (cond
+      (nil? es)          nil
+      (zero? (count es)) nil
+      :else
+      (let [e (first es)]
+        (if (and (= (php/intval (:x e)) px)
+                 (= (php/intval (:y e)) py))
+          e
+          (recur (next es)))))))
+
+(defn pickup-ammos
+  "Step-on triggers an ammo-box pickup. Two flavours:
+
+   - Untagged box (level spawn): bumps the ACTIVE weapon's reserve
+     by its `:ammo-per-box`, capped at the weapon's `:reserve-cap`.
+   - Weapon-tagged box (kill-loot, carries `:weapon kw`): bumps
+     THAT weapon's reserve so dropping a chaingun-tagged box while
+     holding the pistol still feeds the chaingun. Top-level
+     `:ammo-reserve` mirror is updated only when the tag matches
+     the currently-held weapon.
+
+   Box is removed so the player can't farm one cell."
+  [world]
+  (let [px     (php/intval (:x (:player world)))
+        py     (php/intval (:y (:player world)))
+        all    (or (:ammo-boxes world) [])
+        on-box (entity-at all px py)
+        kept   (entities-not-at all px py)]
+    (if (nil? on-box)
+      world
+      (let [tagged-w  (:weapon on-box)
+            target    (or tagged-w (:weapon world) :pistol)
+            target-sp (or (get weapons target) (weapon-spec world) {})
+            per-box   (or (:ammo-per-box target-sp) ammo-per-box)
+            base-cap  (or (:reserve-cap target-sp) 0)
+            cap       (php/* base-cap (php/+ 1 (backpack-level world)))
+            stash     (or (:weapon-state world) {})
+            cur       (or (get-in stash [target :reserve]) 0)
+            cur'      (php/min cap (php/+ cur per-box))
+            stash'    (assoc-in stash [target :reserve] cur')
+            refilled  (assoc world :ammo-boxes kept :weapon-state stash')]
+        (push-sfx
+         (if (= target (or (:weapon world) :pistol))
+           (assoc refilled :ammo-reserve cur')
+           refilled)
+         :door 1.0)))))
+
+(defn pickup-berserks
+  "Step-on consumes the berserk sphere + arms `:berserk-secs` for the
+   2x-damage rage window. Stepping on a second sphere while still
+   berserk refreshes (not stacks) - `arm-berserk` replaces the timer
+   rather than adding to it. Distinct `:berserk` sfx so the pickup is
+   audibly different from a generic door/key tink."
+  [world]
+  (let [kept (entities-not-at (:berserks world)
+                              (php/intval (:x (:player world)))
+                              (php/intval (:y (:player world))))]
+    (if (= (count kept) (count (or (:berserks world) [])))
+      world
+      (push-sfx (arm-berserk (assoc world :berserks kept)) :berserk 1.0))))
+
+(defn pickup-invulns
+  "Step-on consumes the invulnerability sphere + arms
+   `:invuln-secs` of damage immunity. Refresh-not-add on stack."
+  [world]
+  (let [kept (entities-not-at (:invulns world)
+                              (php/intval (:x (:player world)))
+                              (php/intval (:y (:player world))))]
+    (if (= (count kept) (count (or (:invulns world) [])))
+      world
+      (push-sfx (assoc world
+                       :invulns     kept
+                       :invuln-secs invuln-seconds)
+                :door 1.0))))
+
+(defn pickup-soulspheres
+  "Step-on consumes a soulsphere + bumps `:lives` toward
+   `soulsphere-cap` via `gain-soulsphere`. Over-cap lives decay back
+   to `max-lives` over time (see `decay-soul-overcap`)."
+  [world]
+  (let [kept (entities-not-at (:soulspheres world)
+                              (php/intval (:x (:player world)))
+                              (php/intval (:y (:player world))))]
+    (if (= (count kept) (count (or (:soulspheres world) [])))
+      world
+      (push-sfx (gain-soulsphere (assoc world :soulspheres kept)) :berserk 1.0))))
+
+(defn pickup-armor-shards
+  "Step-on consumes an armor shard + adds +1 armor via
+   `gain-armor-shard` (capped at `armor-shard-cap` = 2x max-armor).
+   No decay - shards bank as a permanent buffer (DOOM helmet bonus
+   pattern). Common pickup so the door tink reads as routine
+   loot rather than a special-event sfx."
+  [world]
+  (let [kept (entities-not-at (:armor-shards world)
+                              (php/intval (:x (:player world)))
+                              (php/intval (:y (:player world))))]
+    (if (= (count kept) (count (or (:armor-shards world) [])))
+      world
+      (push-sfx (gain-armor-shard (assoc world :armor-shards kept)) :door 1.0))))
+
+(defn pickup-backpacks
+  "Stacking pickup (#68 part 3): each step-on bumps `:backpack-level`
+   by 1 up to `max-backpacks`. `weapons/effective-reserve-cap` then
+   returns `base * (1 + level)` so a second backpack expands every
+   weapon's reserve cap from 2x to 3x, a third to 4x. The stack
+   carries across levels via build-world's owned-state argument.
+   At cap the pickup is silently consumed (cell freed) but the
+   level is unchanged."
+  [world]
+  (let [kept (entities-not-at (:backpacks world)
+                              (php/intval (:x (:player world)))
+                              (php/intval (:y (:player world))))]
+    (if (= (count kept) (count (or (:backpacks world) [])))
+      world
+      (let [picked (assoc world :backpacks kept)]
+        (push-sfx
+         (if (at-backpack-cap? picked)
+           picked
+           (gain-backpack picked))
+         :door 1.0)))))
+
+(defn pickup-weapon-pickups
+  "Step-on consumes a weapon pickup, adds it to :owned-weapons, and
+   auto-switches to it DOOM-style (mid-fight reload-lockout check is
+   bypassed here because the pickup is the trigger, not user input)."
+  [world]
+  (let [px      (php/intval (:x (:player world)))
+        py      (php/intval (:y (:player world)))
+        on-pick (entity-at (:weapon-pickups world) px py)]
+    (if (nil? on-pick)
+      world
+      (let [kept (entities-not-at (:weapon-pickups world) px py)]
+        (push-sfx
+         (give-weapon (assoc world :weapon-pickups kept) (:weapon on-pick))
+         :door 1.0)))))
+
+(defn pickup-keycards
+  "Step-on consumes the keycard + adds its colour to `:held-keys`.
+   try-move uses the set to gate locked-door passage."
+  [world]
+  (let [px      (php/intval (:x (:player world)))
+        py      (php/intval (:y (:player world)))
+        on-card (entity-at (:keycards world) px py)]
+    (if (nil? on-card)
+      world
+      (let [kept (entities-not-at (:keycards world) px py)]
+        (push-sfx
+         (assoc world
+                :keycards  kept
+                :held-keys (conj (or (:held-keys world) #{}) (:colour on-card)))
+         :door 1.0)))))

--- a/tests/core/pickups-test.phel
+++ b/tests/core/pickups-test.phel
@@ -75,6 +75,19 @@
     (is (= (get-in w' [:weapon-state :pistol :reserve]) (:ammo-reserve w'))
         "top-level :ammo-reserve mirrors the active weapon")))
 
+(deftest test-pickup-ammos-tagged-box-refills-tagged-weapon-not-active
+  ;; A chaingun-tagged box (kill-loot) picked up while holding the pistol
+  ;; feeds the CHAINGUN's reserve and leaves the active pistol + the
+  ;; :ammo-reserve mirror untouched (the mirror only tracks the held weapon).
+  (let [w  (merge (player-at 5.0 5.0)
+                  {:ammo-boxes [{:x 5.0 :y 5.0 :weapon :chaingun}] :weapon :pistol
+                   :weapon-state {:pistol {:reserve 0} :chaingun {:reserve 0}} :ammo-reserve 0})
+        w' (pickup-ammos w)]
+    (is (= 0 (count (:ammo-boxes w'))) "tagged box consumed")
+    (is (php/> (get-in w' [:weapon-state :chaingun :reserve]) 0) "tagged weapon's reserve refilled")
+    (is (= 0 (get-in w' [:weapon-state :pistol :reserve])) "held weapon's reserve untouched")
+    (is (= 0 (:ammo-reserve w')) "ammo-reserve mirror unchanged when tag != active weapon")))
+
 (deftest test-pickup-soulspheres-pushes-lives-over-base-cap
   ;; A soulsphere at full base health still helps: it lifts lives toward
   ;; soulsphere-cap (14), above the 10 base cap a heart would clamp to.
@@ -89,14 +102,16 @@
     (is (php/> (:invuln-secs w') 0.0) "invuln pickup arms the immunity timer")
     (is (= 0 (count (:invulns w'))) "invuln sphere consumed")))
 
-(deftest test-pickup-berserks-and-shards-consume-cell
-  (let [berserked (pickup-berserks (merge (player-at 5.0 5.0) {:berserks [{:x 5.0 :y 5.0}]}))
-        sharded   (pickup-armor-shards (merge (player-at 5.0 5.0)
-                                              {:armor-shards [{:x 5.0 :y 5.0}] :armor 0}))]
-    (is (= 0 (count (:berserks berserked))) "berserk sphere consumed")
-    (is (php/> (:berserk-secs berserked) 0.0) "berserk window armed")
-    (is (= 0 (count (:armor-shards sharded))) "armor shard consumed")
-    (is (php/> (:armor sharded) 0) "shard adds armor")))
+(deftest test-pickup-berserks-arms-rage-window
+  (let [w' (pickup-berserks (merge (player-at 5.0 5.0) {:berserks [{:x 5.0 :y 5.0}]}))]
+    (is (= 0 (count (:berserks w'))) "berserk sphere consumed")
+    (is (php/> (:berserk-secs w') 0.0) "berserk window armed")))
+
+(deftest test-pickup-armor-shards-adds-armor
+  (let [w' (pickup-armor-shards (merge (player-at 5.0 5.0)
+                                       {:armor-shards [{:x 5.0 :y 5.0}] :armor 0}))]
+    (is (= 0 (count (:armor-shards w'))) "armor shard consumed")
+    (is (php/> (:armor w') 0) "shard adds armor")))
 
 (deftest test-pickup-backpacks-raises-level
   (let [w' (pickup-backpacks (merge (player-at 5.0 5.0)

--- a/tests/core/pickups-test.phel
+++ b/tests/core/pickups-test.phel
@@ -1,0 +1,105 @@
+(ns phel-doom-tests.core.pickups-test
+  (:require phel.test :refer [deftest is])
+  (:require phel-doom.core.state :refer [max-armor soulsphere-cap])
+  (:require phel-doom.core.pickups :refer [pickup-hearts pickup-armors pickup-ammos
+                                           pickup-berserks pickup-invulns pickup-soulspheres
+                                           pickup-armor-shards pickup-backpacks
+                                           pickup-weapon-pickups pickup-keycards]))
+
+;; Each pickup-* is a pure world->world step-on transform. A world with the
+;; player standing on cell (5, 5); seed the entity there to trigger, or
+;; elsewhere to assert the no-op branch. push-sfx enqueues onto :sfx (the
+;; purity invariant: sound is queued, never played inline).
+
+(defn- player-at [x y] {:player {:x x :y y}})
+
+(defn- queued-sfx? [world name]
+  (some (fn [ev] (= name (:name ev))) (or (:sfx world) [])))
+
+(deftest test-pickup-hearts-consumes-cell-and-heals-two
+  (let [w  (merge (player-at 5.0 5.0) {:hearts [{:x 5.0 :y 5.0}] :lives 4})
+        w' (pickup-hearts w)]
+    (is (= 0 (count (:hearts w'))) "heart on the player's cell is consumed")
+    (is (= 6 (:lives w')) "a heart heals two half-hearts")
+    (is (queued-sfx? w' :berserk) "pickup enqueues sfx instead of playing inline")))
+
+(deftest test-pickup-hearts-noop-off-cell
+  ;; Heart two cells away: nothing consumed, lives untouched, no sfx.
+  (let [w  (merge (player-at 5.0 5.0) {:hearts [{:x 7.0 :y 7.0}] :lives 4})
+        w' (pickup-hearts w)]
+    (is (= 1 (count (:hearts w'))) "off-cell heart is left in place")
+    (is (= 4 (:lives w')) "no heal off-cell")
+    (is (nil? (:sfx w')) "no sfx enqueued off-cell")))
+
+(deftest test-pickup-armors-adds-one
+  (let [w' (pickup-armors (merge (player-at 5.0 5.0) {:armors [{:x 5.0 :y 5.0}] :armor 0}))]
+    (is (= 1 (:armor w')) "armor pickup bumps :armor by one")
+    (is (= 0 (count (:armors w'))) "armor entity consumed")))
+
+(deftest test-pickup-armors-consumed-but-clamped-at-cap
+  ;; At the cap the pickup is still consumed (cell freed) but armor holds.
+  (let [w' (pickup-armors (merge (player-at 5.0 5.0)
+                                 {:armors [{:x 5.0 :y 5.0}] :armor max-armor}))]
+    (is (= max-armor (:armor w')) "armor never exceeds max-armor")
+    (is (= 0 (count (:armors w'))) "over-cap armor pickup is still consumed")))
+
+(deftest test-pickup-keycards-adds-colour-to-held-keys
+  (let [w' (pickup-keycards (merge (player-at 5.0 5.0)
+                                   {:keycards [{:x 5.0 :y 5.0 :colour :red}] :held-keys #{}}))]
+    (is (contains? (:held-keys w') :red) "keycard colour joins :held-keys")
+    (is (= 0 (count (:keycards w'))) "keycard consumed")))
+
+(deftest test-pickup-keycards-noop-off-cell
+  (let [w  (merge (player-at 5.0 5.0) {:keycards [{:x 1.0 :y 1.0 :colour :blue}] :held-keys #{}})
+        w' (pickup-keycards w)]
+    (is (= #{} (:held-keys w')) "no key gained off-cell")
+    (is (= 1 (count (:keycards w'))) "off-cell keycard untouched")))
+
+(deftest test-pickup-weapon-pickups-owns-and-switches
+  (let [w' (pickup-weapon-pickups (merge (player-at 5.0 5.0)
+                                         {:weapon-pickups [{:x 5.0 :y 5.0 :weapon :shotgun}]
+                                          :owned-weapons #{:pistol} :weapon :pistol}))]
+    (is (contains? (:owned-weapons w') :shotgun) "weapon added to owned set")
+    (is (= :shotgun (:weapon w')) "auto-switches to the picked-up weapon")
+    (is (= 0 (count (:weapon-pickups w'))) "weapon pickup consumed")))
+
+(deftest test-pickup-ammos-untagged-refills-active-weapon
+  ;; Untagged box refills the ACTIVE weapon's reserve and mirrors it into
+  ;; the top-level :ammo-reserve. Start at 0 so any refill is visible.
+  (let [w  (merge (player-at 5.0 5.0)
+                  {:ammo-boxes [{:x 5.0 :y 5.0}] :weapon :pistol
+                   :weapon-state {:pistol {:reserve 0}} :ammo-reserve 0})
+        w' (pickup-ammos w)]
+    (is (= 0 (count (:ammo-boxes w'))) "ammo box consumed")
+    (is (php/> (get-in w' [:weapon-state :pistol :reserve]) 0) "active weapon reserve refilled")
+    (is (= (get-in w' [:weapon-state :pistol :reserve]) (:ammo-reserve w'))
+        "top-level :ammo-reserve mirrors the active weapon")))
+
+(deftest test-pickup-soulspheres-pushes-lives-over-base-cap
+  ;; A soulsphere at full base health still helps: it lifts lives toward
+  ;; soulsphere-cap (14), above the 10 base cap a heart would clamp to.
+  (let [w' (pickup-soulspheres (merge (player-at 5.0 5.0)
+                                      {:soulspheres [{:x 5.0 :y 5.0}] :lives 10}))]
+    (is (php/> (:lives w') 10) "soulsphere lifts lives above the base cap")
+    (is (php/<= (:lives w') soulsphere-cap) "but never past the soulsphere cap")
+    (is (= 0 (count (:soulspheres w'))) "soulsphere consumed")))
+
+(deftest test-pickup-invulns-arms-immunity-window
+  (let [w' (pickup-invulns (merge (player-at 5.0 5.0) {:invulns [{:x 5.0 :y 5.0}]}))]
+    (is (php/> (:invuln-secs w') 0.0) "invuln pickup arms the immunity timer")
+    (is (= 0 (count (:invulns w'))) "invuln sphere consumed")))
+
+(deftest test-pickup-berserks-and-shards-consume-cell
+  (let [berserked (pickup-berserks (merge (player-at 5.0 5.0) {:berserks [{:x 5.0 :y 5.0}]}))
+        sharded   (pickup-armor-shards (merge (player-at 5.0 5.0)
+                                              {:armor-shards [{:x 5.0 :y 5.0}] :armor 0}))]
+    (is (= 0 (count (:berserks berserked))) "berserk sphere consumed")
+    (is (php/> (:berserk-secs berserked) 0.0) "berserk window armed")
+    (is (= 0 (count (:armor-shards sharded))) "armor shard consumed")
+    (is (php/> (:armor sharded) 0) "shard adds armor")))
+
+(deftest test-pickup-backpacks-raises-level
+  (let [w' (pickup-backpacks (merge (player-at 5.0 5.0)
+                                    {:backpacks [{:x 5.0 :y 5.0}] :backpack-level 0}))]
+    (is (= 0 (count (:backpacks w'))) "backpack consumed")
+    (is (= 1 (:backpack-level w')) "first backpack lifts the level to 1")))


### PR DESCRIPTION
## 📚 Description

The 10 step-on `pickup-*` world->world transforms (plus the `entities-not-at` / `entity-at` helpers they share) were pure logic living in the `commands/play` orchestrator, a layering smell per `docs/architecture.md`. This moves them to a new pure `core/pickups.phel` module, leaving `play.phel` to just `:require` and thread them. No behaviour change.

## 🔖 Changes

- New `core/pickups.phel`: 10 public `pickup-*` defns + 2 private helpers; pure (sfx enqueued via `push-sfx`, never played).
- `play.phel`: `:require` the cluster back; trim the now-unused state/combat/weapons `:refer` symbols.
- `tests/core/pickups-test.phel`: direct unit tests (was only covered indirectly via `tick-world`), incl. the tagged-ammo branch.
- Docs synced: architecture tree, game-loop step table (`x9`→`x10`, keycards was missing), state.md.

`clean-code-reviewer` approved after a header-comment trim. Full suite green (3012).

Closes #349