### PR TITLE
ref(rendering): dedupe seam-shading into a frame-math macro

### DIFF
--- a/src/io/render/frame_math.phel
+++ b/src/io/render/frame_math.phel
@@ -239,6 +239,35 @@
    against the sky."
   (build-seam-darken 5))
 
+(defmacro seam-shade!
+  "Resolve one wall/sky/floor seam sub-sample into `pack-reg[slot]`: sky
+   code above the wall top, seam-darkened floor at/below the wall bottom,
+   else the fogged wall texel graduated-darkened near the floor/sky seams.
+   `slot` is the literal pack-reg index, `sub` the sub-row index symbol,
+   `rel` the wall-relative sub-row form. Expands INLINE (no per-cell call,
+   so the frame-local pins stay PHP locals - see main/frame->string) and
+   reads these call-site locals: pack-reg, ts-sub, bs-sub, whs, u, col,
+   fade, tpx, sky-sub-codes, floor-code-at, seam-darken-5/8/16. Was
+   copy-pasted 6x across the px2 + px1 emitters (#350)."
+  [slot sub rel]
+  `(cond
+     (php/< ~sub ts-sub)
+     (php/aset pack-reg ~slot (php/aget sky-sub-codes ~sub))
+     (php/>= ~sub bs-sub)
+     (php/aset pack-reg ~slot (if (php/=== ~sub bs-sub)
+                                (php/aget seam-darken-8 (floor-code-at ~sub col))
+                                (floor-code-at ~sub col)))
+     :else
+     (let [wc# (php/aget fade (php/aget tpx (php/+ (php/* (php/min 63 (php/intdiv (php/* ~rel 64) whs)) 64) u)))]
+       (php/aset pack-reg ~slot
+                 (if (php/>= ~sub (php/- bs-sub 1))
+                   (php/aget seam-darken-16 wc#)
+                   (if (php/>= ~sub (php/- bs-sub 2))
+                     (php/aget seam-darken-8 wc#)
+                     (if (php/=== ~sub ts-sub)
+                       (php/aget seam-darken-5 wc#)
+                       wc#)))))))
+
 (def bg-cell-cache
   "256 pre-baked BG paint cells `\\e[48;5;<code>m ` (escape + one space),
    indexed by 256-colour code. The textured-wall path resolves a faded

--- a/src/io/render/main.phel
+++ b/src/io/render/main.phel
@@ -3,7 +3,7 @@
 (ns phel-doom.io.render.main
   (:require phel-doom.io.render.buffer :refer [buf-mk buf-set buf-get buf-push])
   (:require phel-doom.io.render.palette :refer [sky floor enemy-head enemy-body door-shade boss-door-shade door-code boss-door-code sprite-shadow heart-shade heart-shade-bright heart-glyph heart-glyph-bright armor-shade armor-shade-bright armor-glyph armor-glyph-bright armor-shard-shade armor-shard-shade-bright armor-shard-glyph armor-shard-glyph-bright ammo-shade ammo-shade-bright ammo-glyph ammo-glyph-bright berserk-shade berserk-shade-bright berserk-glyph berserk-glyph-bright invuln-shade invuln-shade-bright invuln-glyph invuln-glyph-bright soulsphere-shade soulsphere-shade-bright soulsphere-glyph soulsphere-glyph-bright backpack-shade backpack-shade-bright backpack-glyph backpack-glyph-bright shotgun-pickup-shade shotgun-pickup-bright shotgun-pickup-glyph shotgun-pickup-glyph-bright chaingun-pickup-shade chaingun-pickup-bright chaingun-pickup-glyph chaingun-pickup-glyph-bright bfg-pickup-shade bfg-pickup-bright bfg-pickup-glyph bfg-pickup-glyph-bright incinerator-pickup-shade incinerator-pickup-bright incinerator-pickup-glyph incinerator-pickup-glyph-bright rocket-pickup-shade rocket-pickup-bright rocket-pickup-glyph rocket-pickup-glyph-bright keycard-blue-shade keycard-blue-bright keycard-blue-glyph keycard-blue-glyph-bright keycard-red-shade keycard-red-bright keycard-red-glyph keycard-red-glyph-bright keycard-yellow-shade keycard-yellow-bright keycard-yellow-glyph keycard-yellow-glyph-bright shade-table shade-code-table shade-table-blood shade-code-table-blood])
-  (:require phel-doom.io.render.frame-math :refer [enemy-shade-string enemy-textured-shade-string boss-col-paint aggro-distance enemy-aggro-head-string build-horizon-gradient build-themed-gradient build-horizon-gradient-codes build-themed-gradient-codes tex-fade-table tex-fade-tc bg-cell-cache halfblock halfblock-tc paint-bg quadblock build-sky-halfblock build-sky-codes-sub seam-darken-16 seam-darken-8 seam-darken-5 collect-enemy-projs layout pulse visuals-for-type enemy-front-visible-at?])
+  (:require phel-doom.io.render.frame-math :refer [enemy-shade-string enemy-textured-shade-string boss-col-paint aggro-distance enemy-aggro-head-string build-horizon-gradient build-themed-gradient build-horizon-gradient-codes build-themed-gradient-codes tex-fade-table tex-fade-tc bg-cell-cache halfblock halfblock-tc paint-bg quadblock build-sky-halfblock build-sky-codes-sub seam-darken-16 seam-darken-8 seam-darken-5 seam-shade! collect-enemy-projs layout pulse visuals-for-type enemy-front-visible-at?])
   (:require phel-doom.io.render.wall-texture-data :refer [wall-tex])
   (:require phel-doom.io.render.enemy-sprite :refer [sprite-for-type-lod sprite-fade sprite-fade-index sprite-col-x sprite-subcol-x enemy-sprite-cell enemy-sprite-quad])
   (:require phel-doom.io.render.hud :refer [minimap-door-pulse minimap-rows minimap-frame hud-debug-line hud-line-str help-menu-string settings-menu-string pause-menu-string])
@@ -1580,74 +1580,10 @@
                         ;; lighter lip at the sky seam. The four sub-row
                         ;; codes resolve into pack-reg slots 1-4 first.
                         (do
-                          (cond
-                            (php/< s4 ts-sub)
-                            (php/aset pack-reg 1 (php/aget sky-sub-codes s4))
-                            (php/>= s4 bs-sub)
-                            (php/aset pack-reg 1 (if (php/=== s4 bs-sub)
-                                                   (php/aget seam-darken-8 (floor-code-at s4 col))
-                                                   (floor-code-at s4 col)))
-                            :else
-                            (let [wc (php/aget fade (php/aget tpx (php/+ (php/* (php/min 63 (php/intdiv (php/* rel 64) whs)) 64) u)))]
-                              (php/aset pack-reg 1
-                                        (if (php/>= s4 (php/- bs-sub 1))
-                                          (php/aget seam-darken-16 wc)
-                                          (if (php/>= s4 (php/- bs-sub 2))
-                                            (php/aget seam-darken-8 wc)
-                                            (if (php/=== s4 ts-sub)
-                                              (php/aget seam-darken-5 wc)
-                                              wc))))))
-                          (cond
-                            (php/< s4b ts-sub)
-                            (php/aset pack-reg 2 (php/aget sky-sub-codes s4b))
-                            (php/>= s4b bs-sub)
-                            (php/aset pack-reg 2 (if (php/=== s4b bs-sub)
-                                                   (php/aget seam-darken-8 (floor-code-at s4b col))
-                                                   (floor-code-at s4b col)))
-                            :else
-                            (let [wc (php/aget fade (php/aget tpx (php/+ (php/* (php/min 63 (php/intdiv (php/* (php/+ rel 1) 64) whs)) 64) u)))]
-                              (php/aset pack-reg 2
-                                        (if (php/>= s4b (php/- bs-sub 1))
-                                          (php/aget seam-darken-16 wc)
-                                          (if (php/>= s4b (php/- bs-sub 2))
-                                            (php/aget seam-darken-8 wc)
-                                            (if (php/=== s4b ts-sub)
-                                              (php/aget seam-darken-5 wc)
-                                              wc))))))
-                          (cond
-                            (php/< s4c ts-sub)
-                            (php/aset pack-reg 3 (php/aget sky-sub-codes s4c))
-                            (php/>= s4c bs-sub)
-                            (php/aset pack-reg 3 (if (php/=== s4c bs-sub)
-                                                   (php/aget seam-darken-8 (floor-code-at s4c col))
-                                                   (floor-code-at s4c col)))
-                            :else
-                            (let [wc (php/aget fade (php/aget tpx (php/+ (php/* (php/min 63 (php/intdiv (php/* (php/+ rel 2) 64) whs)) 64) u)))]
-                              (php/aset pack-reg 3
-                                        (if (php/>= s4c (php/- bs-sub 1))
-                                          (php/aget seam-darken-16 wc)
-                                          (if (php/>= s4c (php/- bs-sub 2))
-                                            (php/aget seam-darken-8 wc)
-                                            (if (php/=== s4c ts-sub)
-                                              (php/aget seam-darken-5 wc)
-                                              wc))))))
-                          (cond
-                            (php/< s4d ts-sub)
-                            (php/aset pack-reg 4 (php/aget sky-sub-codes s4d))
-                            (php/>= s4d bs-sub)
-                            (php/aset pack-reg 4 (if (php/=== s4d bs-sub)
-                                                   (php/aget seam-darken-8 (floor-code-at s4d col))
-                                                   (floor-code-at s4d col)))
-                            :else
-                            (let [wc (php/aget fade (php/aget tpx (php/+ (php/* (php/min 63 (php/intdiv (php/* (php/+ rel 3) 64) whs)) 64) u)))]
-                              (php/aset pack-reg 4
-                                        (if (php/>= s4d (php/- bs-sub 1))
-                                          (php/aget seam-darken-16 wc)
-                                          (if (php/>= s4d (php/- bs-sub 2))
-                                            (php/aget seam-darken-8 wc)
-                                            (if (php/=== s4d ts-sub)
-                                              (php/aget seam-darken-5 wc)
-                                              wc))))))
+                          (seam-shade! 1 s4 rel)
+                          (seam-shade! 2 s4b (php/+ rel 1))
+                          (seam-shade! 3 s4c (php/+ rel 2))
+                          (seam-shade! 4 s4d (php/+ rel 3))
                           (php/aset pack-reg 0
                                     (php/+ (php/* (php/+ (php/* (php/+ (php/* (php/aget pack-reg 1) 256)
                                                                        (php/aget pack-reg 2))
@@ -2074,40 +2010,8 @@
                                 ;; first floor sub-row, and a lighter lip
                                 ;; at the sky seam.
                                   (do
-                                    (cond
-                                      (php/< s2 ts-sub)
-                                      (php/aset pack-reg 1 (php/aget sky-sub-codes s2))
-                                      (php/>= s2 bs-sub)
-                                      (php/aset pack-reg 1 (if (php/=== s2 bs-sub)
-                                                             (php/aget seam-darken-8 (floor-code-at s2 col))
-                                                             (floor-code-at s2 col)))
-                                      :else
-                                      (let [wc (php/aget fade (php/aget tpx (php/+ (php/* (php/min 63 (php/intdiv (php/* rel 64) whs)) 64) u)))]
-                                        (php/aset pack-reg 1
-                                                  (if (php/>= s2 (php/- bs-sub 1))
-                                                    (php/aget seam-darken-16 wc)
-                                                    (if (php/>= s2 (php/- bs-sub 2))
-                                                      (php/aget seam-darken-8 wc)
-                                                      (if (php/=== s2 ts-sub)
-                                                        (php/aget seam-darken-5 wc)
-                                                        wc))))))
-                                    (cond
-                                      (php/< s2b ts-sub)
-                                      (php/aset pack-reg 2 (php/aget sky-sub-codes s2b))
-                                      (php/>= s2b bs-sub)
-                                      (php/aset pack-reg 2 (if (php/=== s2b bs-sub)
-                                                             (php/aget seam-darken-8 (floor-code-at s2b col))
-                                                             (floor-code-at s2b col)))
-                                      :else
-                                      (let [wc (php/aget fade (php/aget tpx (php/+ (php/* (php/min 63 (php/intdiv (php/* (php/+ rel 1) 64) whs)) 64) u)))]
-                                        (php/aset pack-reg 2
-                                                  (if (php/>= s2b (php/- bs-sub 1))
-                                                    (php/aget seam-darken-16 wc)
-                                                    (if (php/>= s2b (php/- bs-sub 2))
-                                                      (php/aget seam-darken-8 wc)
-                                                      (if (php/=== s2b ts-sub)
-                                                        (php/aget seam-darken-5 wc)
-                                                        wc))))))
+                                    (seam-shade! 1 s2 rel)
+                                    (seam-shade! 2 s2b (php/+ rel 1))
                                     (php/aset cell-reg 0
                                               (halfblock (php/aget pack-reg 1) (php/aget pack-reg 2)))))))
                             (let [lvl (buf-get shades-tex-level col)]


### PR DESCRIPTION
## 📚 Description

The wall/sky/floor seam sub-sample `cond` was copy-pasted **6×** in `frame->string` (4 in the px2 emitter, 2 in px1), differing only by sub-row index, `rel` offset, and pack-reg slot. This extracts it into a single `seam-shade!` **macro** in `frame_math.phel`.

A macro, not a fn: the seam code runs per-sub-sample on the hottest per-cell path, where the referred frame-math globals are pinned to frame locals (main.phel:~1400) precisely to dodge `getDefinition` dispatch. A fn call per sub-sample would reintroduce exactly that cost (cf. #345 / #347). The macro expands inline, so the pins stay PHP locals.

## 🔖 Changes

- `frame_math.phel`: new `seam-shade!` macro (`[slot sub rel]`), placed beside the `seam-darken-*` LUTs it reads.
- `main.phel`: 6 copy-pasted conds → 6 `seam-shade!` calls; macro added to the frame-math `:refer`. Net -67 lines.

**Proven byte-identical**: the compiled `out/.../main.php` is unchanged except the macro's gensym temp (`wc` → `wc#`) and shifted `\Phel::location` line numbers. Golden render hashes + full suite (3012) green. `clean-code-reviewer` approved (macro hygiene, expansion offsets, no double-eval).

Part of #350. The `frame->string` emitter extraction (Part B) is deferred: its ~50-local capture surface can't be verified byte-identical against the single-config golden hashes without first widening render-test coverage.