### PR TITLE
chore: minor test + doc cleanup (stale projectile doc, cell + type-spec tests)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -50,7 +50,7 @@ src/core/                    ; pure logic (no IO)
   enemies.phel               enemy catalog + stats
   level.phel                 level 1-10 + build-world
   weapons.phel               weapon catalog + ammo state
-  projectile.phel            projectiles (not used yet)
+  projectile.phel            enemy fireballs: spawn + march + impacts
   perf.phel                  big-screen perf checks
   difficulty.phel            easy/normal/hard/nightmare
   settings.phel              options model (volume, defaults)

--- a/tests/core/enemies-test.phel
+++ b/tests/core/enemies-test.phel
@@ -73,6 +73,12 @@
 (deftest test-type-spec-unknown-returns-nil
   (is (nil? (type-spec :nope))))
 
+(deftest test-type-spec-known-type-resolves-to-named-spec
+  ;; Positive companion to the unknown->nil case: the visual pins above
+  ;; cover :head-code / :face, but not the :name HUD label.
+  (is (= "cyberdemon" (:name (type-spec :cyber))))
+  (is (= "imp" (:name (type-spec :imp)))))
+
 ;; ---------------------------------------------------------------------
 ;; Per-enemy resistances. Catalog carries a `:resists` set for the
 ;; fire-themed monsters so weapons that deal :fire bounce off them.

--- a/tests/core/map-test.phel
+++ b/tests/core/map-test.phel
@@ -1,6 +1,6 @@
 (ns phel-doom-tests.core.map-test
   (:require phel.test :refer [deftest is])
-  (:require phel-doom.core.map :refer [default-grid wall? door?
+  (:require phel-doom.core.map :refer [default-grid wall? door? cell
                                        cell-floor cell-wall cell-door
                                        cell-secret cell-switch-off
                                        cell-switch-on count-secrets passable?
@@ -27,6 +27,26 @@
   (is (= 0 cell-floor))
   (is (= 1 cell-wall))
   (is (= 2 cell-door)))
+
+(deftest test-cell-reads-in-bounds-value
+  ;; cell is the foundational grid accessor (wall? / door? / the raycaster
+  ;; all read through it); pin that it returns the literal at (x, y).
+  (let [g [[1 1 1]
+           [1 0 2]
+           [1 1 1]]]
+    (is (= cell-wall (cell g 0 0)))
+    (is (= cell-floor (cell g 1 1)))
+    (is (= cell-door (cell g 2 1)))))
+
+(deftest test-cell-out-of-bounds-returns-wall
+  ;; OOB reads clamp to cell-wall so the raycaster never escapes the map.
+  ;; Covers each guard: negative x, negative y, over-length col, missing row.
+  (let [g [[0 0]
+           [0 0]]]
+    (is (= cell-wall (cell g -1 0)))
+    (is (= cell-wall (cell g 0 -1)))
+    (is (= cell-wall (cell g 5 0)))
+    (is (= cell-wall (cell g 0 5)))))
 
 (deftest test-door-does-not-block-player-movement
   ;; wall? must let the player walk into a door cell — that's how


### PR DESCRIPTION
## 📚 Description

Low-risk cleanups surfaced during the code-quality sweep. Doc + tests only, no behaviour change.

## 🔖 Changes

- `docs/README.md`: `projectile.phel` was labelled "(not used yet)" but it runs every frame (`tick-projectiles` / `tick-tracers` in the game loop). Relabel it "enemy fireballs: spawn + march + impacts".
- `tests/core/map-test.phel`: direct tests for `cell`, the foundational grid accessor (only transitively covered before) - an in-bounds floor/wall/door read plus all four OOB-clamp-to-`cell-wall` branches.
- `tests/core/enemies-test.phel`: positive `type-spec` `:name` assertion (cyber/imp); the existing visual pins cover `:head-code`/`:face`, only the nil case touched `:name`.

Full suite (3027) green. `clean-code-reviewer` approved.

Closes #353