### PR TITLE
feat(map): per-cell floor-height data (fz) + :pfz hot array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 
 ## [Unreleased]
 
+### Added
+
+- Per-cell floor-height data layer (issue #368, epic #375): worlds now carry `:fz-grid` (per-cell floor heights, quantized 0.25 steps) with a flat PHP hot-array twin `:pfz` (indexed `y * width + x`); layouts can author raised tiers via digit chars `1`/`2`/`3` (fz 0.25/0.5/0.75); `map/floor-z` lookup returns 0.0 out of bounds. Data only — cast/render/physics still assume a flat world, and every shipped level stays flat (zero behavior change; saves round-trip heights without a version bump).
+
 ### Performance
 
 - Trimmed per-frame render allocations on the common pickup-paint path (issue #348): the 8 pickup paint passes (3 keycard colours + 5 weapon-pickup kinds) each ran `(apply vector (filter … (or (:keycards world) [])))` every frame — a closure + lazy seq + materialised vector built even on the overwhelmingly common frame with zero keycards / weapon-pickups. Each pass now guards on `(seq …)`, skipping the filter, the vector build, AND the `paint-pickups-into` call (its `sprites-enabled?` / `pitch-rows` setup) when the source list is empty; the two source lists also bind once instead of re-reading `world` 8×. `pulse` (sin-wave beat sampled 15×/frame) gains `^:pure`. Byte-identical (golden render hashes + full suite unchanged: the empty path returns the threaded buffer untouched, the non-empty path is the same paint call); a new `render-cache` test pins that a visible keycard / weapon-pickup still paints. No bench needed.

--- a/docs/level-system.md
+++ b/docs/level-system.md
@@ -87,10 +87,13 @@ When `:enemies` is a vector, each spec spawns its own count + HP and the enemy c
 | `@` | player spawn |
 | `S` | secret wall (press F to reveal) |
 | `T` | switch (toggles target cells via `:switches` config) |
+| `1` / `2` / `3` | floor raised to fz 0.25 / 0.5 / 0.75 (issue #368; data only until the epic #375 render/physics issues land) |
 
 `:layout` supplies GEOMETRY + spawn (+ secrets / switches) only; it authors neither the interior walls nor the exit. `map/scatter-walls` seeds `:walls` random interior wall blobs into each hand-authored room (skipped on `:switches` levels) and seals any cut-off pocket so the floor stays connected; `map/place-exit` then drops exactly one exit door at a random reachable wall - interior pillar or border edge - on EVERY level, and `lock-the-door` applies the `:door-lock`. So the room disposition AND the way out are randomised per run, and finding the exit is part of the game. Enemy spawn still applies.
 
 Switches: `:switches [{:at [cx cy] :targets [[tx ty] ...]}]`. F near `:at` flips targets wall↔floor.
+
+Floor heights: `build-grid` threads the layout's `:fz-grid` into `new-world` (procgen levels pass nil, which defaults to a flat all-zero grid). Omitting digit chars keeps a level flat - every shipped level is flat today.
 
 
 ### Adding a new room

--- a/docs/map.md
+++ b/docs/map.md
@@ -41,6 +41,22 @@ Every cell is one of these ints. Constants exported so no module uses raw `0/1/2
 
 `wall?` / `passable?` use the same lock colour resolution, so the player can't walk through locked doors but the raycaster still blocks rays on them (stay visually solid until traversed).
 
+## Floor heights (fz)
+
+Issue #368 (variable-floor-heights epic #375): each cell carries a floor height alongside its type. Heights live in a separate `fz-grid` (vector of vectors of floats), not in the cell int.
+
+```phel
+(def fz-step 0.25)        ; height quantum; stairs rise one step per cell
+(quantize-fz 0.3)         ; => 0.25 - snap raw input to the nearest step
+(floor-z fz-grid x y)     ; height at (x, y); out-of-bounds or nil grid = 0.0
+```
+
+Quantization happens in loaders (layout parsing), so stored data is always clean multiples of `fz-step` and `floor-z` stays a bare read.
+
+Layouts author heights with digit chars: `1` / `2` / `3` parse as `cell-floor` with fz 0.25 / 0.5 / 0.75. `parse-layout` returns `{:grid :spawn :fz-grid}`; a digit-free layout yields an all-zero `fz-grid`. Procgen grids carry no heights (flat world).
+
+Data layer only for now: cast, render, and physics still assume a flat world. The epic issues #369-#372 make heights visible and walkable.
+
 ## Random map generation
 
 ```phel
@@ -118,3 +134,5 @@ Minimap: dim `T` (off) / bright `T` (on).
 ```
 
 Off-map = wall means the raycaster skips range checks: keeps stepping until a non-floor cell (or max-depth). One branch saved per ray step.
+
+Floor heights follow the same defensive pattern with a different default: `(floor-z fz-grid 99 99)` returns `0.0` (ground level), as does a nil `fz-grid`, so consumers never see nil.

--- a/docs/state.md
+++ b/docs/state.md
@@ -88,6 +88,8 @@ After `build-world` from `core/level.phel` stamps level metadata, the world also
 
 On grid mutation (door turning into floor, etc.) **both** must update. See `pickup-hearts` in `core/pickups.phel` and door logic in `commands/play.phel`. `rebuild-pgrid` is called after any grid edit to keep the PHP mirror in sync.
 
+The same source-of-truth / hot-twin split applies to floor heights (issue #368): `:fz-grid` is a Phel vector of vectors of floats; `:pfz` is a flat PHP float array indexed `y * width + x` (one `aget` per read in future hot loops). `new-world` takes an optional third `fz-grid` argument (nil = all-zero flat world), and `rebuild-pgrid` re-derives `:pfz` too, defaulting a missing `:fz-grid` to zeros so pre-#368 saves load clean.
+
 ## The player
 
 ```phel
@@ -145,3 +147,5 @@ Float-seconds countdowns on the world, decayed by `decay-timers` in `core/combat
 ## Flat world design
 
 The world has a single flat floor plane (z = 0) and a flat ceiling (z = 1). All gameplay occurs on this plane. This keeps construction simple (one `new-world` call), updates lightweight (`assoc`/`update`), and tests literal (`(is (= expected (tick-world ...)))`). Trade-off: no compiler help on key names, so `frame-stats` centralizes all reads to catch typos.
+
+Issue #368 starts loosening this: worlds now carry per-cell floor heights (`:fz-grid` / `:pfz`, all zeros for every shipped level), but cast, render, and physics still assume the flat plane until the rest of epic #375 lands.

--- a/src/core/level.phel
+++ b/src/core/level.phel
@@ -700,7 +700,7 @@
   (spawn-unique-pickups grid n))
 
 (defn- build-grid
-  "Build `{:grid :spawn}`. Geometry + spawn come from a hand-authored
+  "Build `{:grid :spawn :fz-grid}`. Geometry + spawn come from a hand-authored
    `:layout` (parsed via map/parse-layout) or the procedural `random-grid`.
    For varied rooms, `:walls` random interior wall blobs are scattered in:
    procgen gets them from `random-grid`; a hand-authored room gets them via
@@ -709,7 +709,7 @@
    hand-placed). `map/place-exit` then drops ONE random reachable exit door
    on any wall, locked per `:door-lock` - the way out differs every run."
   [cfg]
-  (let [{:keys [grid spawn]}
+  (let [{:keys [grid spawn fz-grid]}
         (if (:layout cfg)
           (or (parse-layout (:layout cfg))
               (throw (php/new php/InvalidArgumentException
@@ -718,11 +718,15 @@
           (let [[w h] (:size cfg)
                 g     (random-grid w h (:walls cfg))]
             {:grid g :spawn (random-spawn g)}))
-        varied               (if (and (:layout cfg) (not (:switches cfg)) (:walls cfg))
-                               (scatter-walls grid spawn (:walls cfg))
-                               grid)]
-    {:grid  (lock-the-door (place-exit varied spawn) (:door-lock cfg))
-     :spawn spawn}))
+        varied                       (if (and (:layout cfg) (not (:switches cfg)) (:walls cfg))
+                                       (scatter-walls grid spawn (:walls cfg))
+                                       grid)]
+    ;; scatter-walls / place-exit mutate geometry only; a wall dropped on a
+    ;; raised cell keeps its fz (harmless - walls never read floor height).
+    ;; Procgen path carries nil fz-grid; new-world defaults it to flat.
+    {:grid    (lock-the-door (place-exit varied spawn) (:door-lock cfg))
+     :spawn   spawn
+     :fz-grid fz-grid}))
 
 (defn- normalise-enemies
   "Coerce the level's `:enemies` field into a vector of mixed specs
@@ -788,8 +792,10 @@
                        (:grid built))
          [px py]     spawn
          specs       (normalise-enemies cfg)
-         world       (new-world grid (new-player px py (php/* (rng/int! 360)
-                                                              (php// php/M_PI 180.0))))
+         world       (new-world grid
+                                (new-player px py (php/* (rng/int! 360)
+                                                         (php// php/M_PI 180.0)))
+                                (:fz-grid built))
          spawned     (spawn-enemies-mixed grid specs
                                           enemy-min-spawn-dist px py)
          ;; Nightmare: stamp every spawned enemy so respawn picks the

--- a/src/core/map.phel
+++ b/src/core/map.phel
@@ -109,6 +109,32 @@
         cell-wall
         (or (get row x) cell-wall)))))
 
+(def fz-step
+  "Floor-height quantum. All per-cell floor heights (fz) snap to
+   multiples of this step; a staircase is a run of cells rising one
+   step at a time. The physics step-up rule (issue #371) will allow
+   climbing exactly one step."
+  0.25)
+
+(defn ^:pure quantize-fz
+  "Snap a raw floor height to the nearest fz-step multiple. Loaders
+   call this so stored height data is always clean and lookups stay
+   bare reads."
+  [z]
+  (php/* fz-step (php/round (php// z fz-step))))
+
+(defn ^:pure floor-z
+  "Read the floor height at integer (x, y) from an fz-grid.
+   Out-of-bounds reads (and a nil grid) return 0.0 - ground level -
+   so consumers never see nil."
+  [fz-grid x y]
+  (if (or (nil? fz-grid) (< x 0) (< y 0))
+    0.0
+    (let [row (get fz-grid y)]
+      (if (nil? row)
+        0.0
+        (or (get row x) 0.0)))))
+
 (defn ^:pure wall?
   "True when (x, y) blocks player movement. Solid walls, unrevealed
    secrets, AND switch cells (either state) qualify; doors are
@@ -476,10 +502,12 @@
 ;;   'Y' yellow-locked door
 ;;   'X' boss-locked door (unlocks when boss is killed)
 ;;   '@' floor + records [x y] as the player spawn (cell centre)
+;;   '1' '2' '3' floor raised to fz 0.25 / 0.5 / 0.75 (issue #368)
 ;;
-;; parse-layout returns {:grid <vec-of-vec> :spawn [x y]} when the
-;; layout is well-formed, nil when no '@' is found. Used by level.phel
-;; when a level entry carries :layout to bypass the random-grid path.
+;; parse-layout returns {:grid <vec-of-vec> :spawn [x y] :fz-grid
+;; <vec-of-vec>} when the layout is well-formed, nil when no '@' is
+;; found. Used by level.phel when a level entry carries :layout to
+;; bypass the random-grid path.
 ;; ---------------------------------------------------------------------
 
 ;; Layout ASCII -> cell value. Layouts are GEOMETRY ONLY (walls, floor,
@@ -490,37 +518,50 @@
    "." cell-floor
    "@" cell-floor
    "S" cell-secret
-   "T" cell-switch-off})
+   "T" cell-switch-off
+   "1" cell-floor
+   "2" cell-floor
+   "3" cell-floor})
+
+;; Layout ASCII -> floor height. Multiples of fz-step by construction,
+;; so parse-row needs no quantize pass.
+(def ^:private layout-char->fz
+  {"1" 0.25
+   "2" 0.5
+   "3" 0.75})
 
 (defn- parse-row
-  "Convert one layout string into [row-vec maybe-spawn-x]. Returns
-   nil for spawn-x when the row doesn't contain '@'. Unknown chars
-   fall back to floor so a typo doesn't crash."
+  "Convert one layout string into [row-vec fz-row-vec maybe-spawn-x].
+   Returns nil for spawn-x when the row doesn't contain '@'. Unknown
+   chars fall back to flat floor so a typo doesn't crash."
   [s y]
   (let [w (php/strlen s)]
     (loop [x       0
            row     []
+           fz-row  []
            spawn-x nil]
       (if (php/>= x w)
-        [row spawn-x]
+        [row fz-row spawn-x]
         (let [ch    (php/substr s x 1)
               cell  (or (get layout-char->cell ch) cell-floor)
+              fz    (or (get layout-char->fz ch) 0.0)
               spawn (if (= ch "@") x spawn-x)]
-          (recur (php/+ x 1) (conj row cell) spawn))))))
+          (recur (php/+ x 1) (conj row cell) (conj fz-row fz) spawn))))))
 
 (defn parse-layout
-  "Parse a hand-authored ASCII grid into `{:grid :spawn}`. Returns
-   nil when the layout has no '@' (no player spawn)."
+  "Parse a hand-authored ASCII grid into `{:grid :spawn :fz-grid}`.
+   Returns nil when the layout has no '@' (no player spawn)."
   [rows]
   (let [h (count rows)]
     (loop [y     0
            grid  []
+           fz    []
            spawn nil]
       (if (php/>= y h)
         (when (some? spawn)
-          {:grid grid :spawn spawn})
-        (let [[row sx] (parse-row (get rows y) y)
-              spawn'   (if (and (nil? spawn) (some? sx))
-                         [(+ 0.5 sx) (+ 0.5 y)]
-                         spawn)]
-          (recur (php/+ y 1) (conj grid row) spawn'))))))
+          {:grid grid :spawn spawn :fz-grid fz})
+        (let [[row fz-row sx] (parse-row (get rows y) y)
+              spawn'          (if (and (nil? spawn) (some? sx))
+                                [(+ 0.5 sx) (+ 0.5 y)]
+                                spawn)]
+          (recur (php/+ y 1) (conj grid row) (conj fz fz-row) spawn'))))))

--- a/src/core/map.phel
+++ b/src/core/map.phel
@@ -510,9 +510,11 @@
 ;; bypass the random-grid path.
 ;; ---------------------------------------------------------------------
 
-;; Layout ASCII -> cell value. Layouts are GEOMETRY ONLY (walls, floor,
-;; spawn, secrets, switches); the exit door is dropped at a random reachable
-;; wall by place-exit (never authored), so there is no door char here.
+;; Layout ASCII -> cell value. Cell values are GEOMETRY ONLY (walls, floor,
+;; spawn, secrets, switches); digit chars parse as plain floor here, their
+;; height lands separately in the fz-grid (layout-char->fz below). The exit
+;; door is dropped at a random reachable wall by place-exit (never
+;; authored), so there is no door char here.
 (def ^:private layout-char->cell
   {"#" cell-wall
    "." cell-floor

--- a/src/core/state.phel
+++ b/src/core/state.phel
@@ -88,96 +88,115 @@
    cooldown) while not."
   100.0)
 
+(defn- flat-fz [grid]
+  (let [row (into [] (map (fn [_] 0.0) (range 0 (count (first grid)))))]
+    (into [] (map (fn [_] row) (range 0 (count grid))))))
+
+;; Row-major flatten: index y * width + x, one aget in future hot loops.
+(defn- fz->pfz [fz-grid]
+  (to-php-array (apply concat fz-grid)))
+
 (defn rebuild-pgrid
-  "Re-derive `:pgrid` from `:grid`. Call after any in-game mutation
-   of the grid (secret reveal, switch toggle, door open) so the
-   raycaster's hot-path PHP-array view stays in sync with the
-   persistent Phel vector. Without this the 3D view paints the
-   pre-mutation cell (player walks through a wall that still
-   visually looks solid)."
+  "Re-derive `:pgrid` from `:grid` and `:pfz` from `:fz-grid`. Call
+   after any in-game mutation of the grid (secret reveal, switch
+   toggle, door open) so the raycaster's hot-path PHP-array views stay
+   in sync with the persistent Phel vectors. Without this the 3D view
+   paints the pre-mutation cell (player walks through a wall that
+   still visually looks solid). A missing `:fz-grid` defaults to flat
+   zeros so pre-#368 saves load clean."
   [world]
-  (assoc world
-         :pgrid (to-php-array (map to-php-array (:grid world)))))
+  (let [fz (or (:fz-grid world) (flat-fz (:grid world)))]
+    (assoc world
+           :pgrid (to-php-array (map to-php-array (:grid world)))
+           :fz-grid fz
+           :pfz (fz->pfz fz))))
 
 (defn new-world
   {:doc "Bundle map grid and player into the world state. Stores a PHP-native
          copy of the grid under :pgrid so the raycast hot loop can read cells
-         via aget instead of going through Phel's persistent-vector dispatch."
+         via aget instead of going through Phel's persistent-vector dispatch.
+         The optional fz-grid (per-cell floor heights, issue #368) lands under
+         :fz-grid with a flat PHP twin :pfz indexed y * width + x; nil (the
+         2-arity form) derives an all-zeros flat world."
    :see-also ["new-player" "build-world" "rebuild-pgrid"]
    :example "(new-world grid (new-player 5.0 5.0 0.0)) ; => world map"}
-  [grid player]
-  {:grid      grid
-   :pgrid     (to-php-array (map to-php-array grid))
-   :width     (count (first grid))
-   :height    (count grid)
-   :player    player
+  ([grid player] (new-world grid player nil))
+  ([grid player fz-grid]
+   (let [fz (or fz-grid (flat-fz grid))]
+     {:grid      grid
+      :pgrid     (to-php-array (map to-php-array grid))
+      :fz-grid   fz
+      :pfz       (fz->pfz fz)
+      :width     (count (first grid))
+      :height    (count grid)
+      :player    player
    ;; Fog-of-war automap: PHP array keyed by (y * width + x). nil /
    ;; missing = unseen (minimap paints uniform dim block); 1 = visited
    ;; (paints normally). `engine/mark-visible-cells` stamps cells
    ;; within line-of-sight of the player each frame.
-   :visited   (php/array)
-   :full-map? false
+      :visited   (php/array)
+      :full-map? false
    ;; Switches (issue #62): vector of {:at [x y] :targets [[x y] ...]}.
    ;; Level builder populates from the per-level config; play.phel /
    ;; try-toggle-switch reads :at and applies map/toggle-switch on the
    ;; F-key edge.
-   :switches  []
+      :switches  []
    ;; Soulsphere (issue #68). Per-level pickup spawn vector + the
    ;; decay clock for the over-cap portion of `:lives`.
-   :soulspheres        []
-   :soul-decay-secs    0.0
+      :soulspheres        []
+      :soul-decay-secs    0.0
    ;; Armor shards (issue #68): common pickup that adds +1 armor
    ;; over the normal `max-armor` cap, up to `armor-shard-cap`.
    ;; No decay - shards are a permanent buffer (DOOM-style helmet
    ;; bonus) so the player can stockpile them across rooms.
-   :armor-shards       []
-   :show-map  false
-   :paused    false
-   :help?     false
-   :debug?    false
-   :sound-on  true
-   :enemies   []
-   :projectiles []
-   :hit-stop-secs 0.0
-   :hearts    []
-   :armors    []
-   :ammo-boxes []
-   :armor     0
-   :kills     0
-   :streak    0
-   :streak-secs 0.0
-   :lives     max-lives
-   :iframes     0.0
-   :fire-anim   0.0
-   :intro-secs  0.0
-   :flash-secs  0.0
-   :fire-cooldown 0.0
-   :reload-cooldown 0.0
-   :empty-click-secs 0.0
+      :armor-shards       []
+      :show-map  false
+      :paused    false
+      :help?     false
+      :debug?    false
+      :sound-on  true
+      :enemies   []
+      :projectiles []
+      :hit-stop-secs 0.0
+      :hearts    []
+      :armors    []
+      :ammo-boxes []
+      :armor     0
+      :kills     0
+      :streak    0
+      :streak-secs 0.0
+      :lives     max-lives
+      :iframes     0.0
+      :fire-anim   0.0
+      :intro-secs  0.0
+      :flash-secs  0.0
+      :fire-cooldown 0.0
+      :reload-cooldown 0.0
+      :empty-click-secs 0.0
    ;; Powerup timers. Decayed each frame in combat/decay-timers.
    ;; While > 0 the buff is active; render samples them for the
    ;; full-screen tint, combat reads them for damage / vulnerability
    ;; mods.
-   :berserk-secs    0.0
-   :berserks        []
-   :invuln-secs     0.0
-   :invulns         []
+      :berserk-secs    0.0
+      :berserks        []
+      :invuln-secs     0.0
+      :invulns         []
    ;; Backpack stacking (issue #68 part 3). `:backpack-level` 0..N
    ;; replaces the old boolean. Effective reserve cap is `base * (1 +
    ;; level)` so each pickup adds one base's worth. Capped at
    ;; `max-backpacks` so reserve growth has a known ceiling.
-   :backpack-level  0
-   :backpacks       []
+      :backpack-level  0
+      :backpacks       []
    ;; Keycards. :held-keys is a set of collected colour kws
    ;; (e.g. #{:blue}). :keycards is the per-level pickup vector.
-   :held-keys       #{}
-   :keycards        []
+      :held-keys       #{}
+      :keycards        []
    ;; Transient HUD cue: armed by physics/try-move when the player
    ;; bumps a locked door without the matching keycard. Render
    ;; paints 'NEED <COLOUR> KEY' centred over the 3D view while
    ;; the timer is > 0; combat/decay-timers ticks it down.
-   :locked-door-bump-secs    0.0
-   :locked-door-bump-colour  nil
+      :locked-door-bump-secs    0.0
+      :locked-door-bump-colour  nil
    ;; Weapons. :weapon is the active slot. :weapon-state is the
    ;; per-weapon mag/reserve table (catalogue lives in weapons.phel).
    ;; :mag and :ammo-reserve mirror the active weapon's live state so
@@ -191,24 +210,24 @@
    ;; the pre-#324 centre-aim. The play loop stamps concrete cells from
    ;; controls/mouse-aim while the mouse is on and resets them to nil on a
    ;; resize or when the mouse is off (see reset-reticle).
-   :aim-col        nil
-   :aim-row        nil
-   :weapon         :pistol
+      :aim-col        nil
+      :aim-row        nil
+      :weapon         :pistol
    ;; Fresh runs only own the pistol. Shotgun + chaingun must be
    ;; found on the map (level.phel/maybe-spawn-weapon-pickup).
-   :owned-weapons  #{:pistol}
-   :weapon-state   (initial-weapon-state)
-   :mag           10
-   :ammo-reserve  30
-   :heat        0.0
-   :jam-secs    0.0
-   :heartbeat-phase 0.0
-   :heartbeat-tick? false
-   :blood-drops         []
-   :prev-min-enemy-dist 1.0e9
-   :scare-secs          0.0
-   :fx          []
-   :game-time   0.0
+      :owned-weapons  #{:pistol}
+      :weapon-state   (initial-weapon-state)
+      :mag           10
+      :ammo-reserve  30
+      :heat        0.0
+      :jam-secs    0.0
+      :heartbeat-phase 0.0
+      :heartbeat-tick? false
+      :blood-drops         []
+      :prev-min-enemy-dist 1.0e9
+      :scare-secs          0.0
+      :fx          []
+      :game-time   0.0
    ;; Sprint pool + latches. :stamina decays while sprinting (and
    ;; moving), regenerates while not. :sprint-cooldown-secs holds
    ;; regen back for a short window after the player lets go so a
@@ -216,18 +235,18 @@
    ;; latches true when stamina hits 0 mid-sprint and unlatches when
    ;; stamina recovers past sprint-engage-threshold — prevents
    ;; stutter-sprint at empty.
-   :stamina                  max-stamina
-   :sprint-cooldown-secs     0.0
-   :sprint-blocked?          false
-   :moves      {:fwd          0
-                :back         0
-                :strafe-left  0
-                :strafe-right 0
-                :turn-left    0
-                :turn-right   0
-                :sprint       0
-                :pitch-up     0
-                :pitch-down   0}})
+      :stamina                  max-stamina
+      :sprint-cooldown-secs     0.0
+      :sprint-blocked?          false
+      :moves      {:fwd          0
+                   :back         0
+                   :strafe-left  0
+                   :strafe-right 0
+                   :turn-left    0
+                   :turn-right   0
+                   :sprint       0
+                   :pitch-up     0
+                   :pitch-down   0}})))
 
 (defn gain-life
   "Heal one full heart (2 HP), capped at max-lives. Heart pickups grant

--- a/src/core/state.phel
+++ b/src/core/state.phel
@@ -88,6 +88,8 @@
    cooldown) while not."
   100.0)
 
+;; Width read from the first row: grids are rectangular by construction
+;; (random-grid + parse-layout), ragged input is not defended against.
 (defn- flat-fz [grid]
   (let [row (into [] (map (fn [_] 0.0) (range 0 (count (first grid)))))]
     (into [] (map (fn [_] row) (range 0 (count grid))))))

--- a/src/io/savegame.phel
+++ b/src/io/savegame.phel
@@ -70,11 +70,11 @@
 
 (defn world->savestring
   "Pure: serialize `world` to a versioned JSON string. Drops `:pgrid` +
-   `:visited` (rebuilt / reset on load) and `:settings` +
+   `:pfz` + `:visited` (rebuilt / reset on load) and `:settings` +
    `:settings-cursor` (#279 - session-global preference, not run state,
    so a save never carries stale preferences into a later load)."
   [world]
-  (let [clean (dissoc world :pgrid :visited :settings :settings-cursor)
+  (let [clean (dissoc world :pgrid :pfz :visited :settings :settings-cursor)
         o     (php/array)]
     (php/aset o "version" save-version)
     (php/aset o "world"   (encode clean))

--- a/tests/core/level-test.phel
+++ b/tests/core/level-test.phel
@@ -410,3 +410,20 @@
       ;; Random: the exit is not pinned to one spot across seeds.
       (is (php/> (php/count (php/array_unique positions)) 1)
           (str "level " lv " exit position varies with the seed")))))
+
+;; ---------------------------------------------------------------------
+;; Floor heights (issue #368): every shipped level loads flat. Pins the
+;; zero-behavior-change guarantee until levels author raised cells.
+;; ---------------------------------------------------------------------
+
+(deftest test-build-world-fz-defaults-flat-every-level
+  (foreach [lv (range 1 (php/+ num-levels 1))]
+    (rng/seed! (php/* 42 lv))
+    (let [w  (build-world lv 5)
+          fz (:fz-grid w)]
+      (is (= (:height w) (count fz)) (str "level " lv " fz-grid height matches"))
+      (is (= (:width w) (count (first fz))) (str "level " lv " fz-grid width matches"))
+      (is (every? (fn [row] (every? (fn [z] (= 0.0 z)) row)) fz)
+          (str "level " lv " is flat"))
+      (is (= (php/* (:width w) (:height w)) (php/count (:pfz w)))
+          (str "level " lv " pfz sized width*height")))))

--- a/tests/core/map-test.phel
+++ b/tests/core/map-test.phel
@@ -8,7 +8,8 @@
                                        switch-on? toggle-switch
                                        toggle-switch-cell toggle-target-cell
                                        parse-layout place-exit scatter-walls
-                                       random-grid random-spawn seed-secrets])
+                                       random-grid random-spawn seed-secrets
+                                       fz-step quantize-fz floor-z])
   (:require phel-doom.core.rng :as rng))
 
 (deftest test-walls-on-perimeter
@@ -197,6 +198,71 @@
                            "####"])
         g   (:grid out)]
     (is (= cell-floor (get-in g [1 1])))))
+
+;; ---------------------------------------------------------------------
+;; Floor heights (issue #368): per-cell fz data, quantized 0.25 steps.
+;; Data layer only — cast/render/physics still assume a flat world.
+;; ---------------------------------------------------------------------
+
+(deftest test-fz-step-pinned
+  ;; Physics step-up rule + layout digit chars rely on the literal value.
+  (is (= 0.25 fz-step)))
+
+(deftest test-floor-z-reads-heights
+  (let [fz [[0.0 0.25]
+            [0.5 0.75]]]
+    (is (= 0.0 (floor-z fz 0 0)))
+    (is (= 0.25 (floor-z fz 1 0)))
+    (is (= 0.5 (floor-z fz 0 1)))
+    (is (= 0.75 (floor-z fz 1 1)))))
+
+(deftest test-floor-z-oob-returns-zero
+  ;; OOB reads default to ground level so consumers never see nil.
+  ;; Covers each guard: negative x, negative y, over-length col,
+  ;; missing row, and a nil grid (world built without heights).
+  (let [fz [[0.25 0.25]
+            [0.25 0.25]]]
+    (is (= 0.0 (floor-z fz -1 0)))
+    (is (= 0.0 (floor-z fz 0 -1)))
+    (is (= 0.0 (floor-z fz 5 0)))
+    (is (= 0.0 (floor-z fz 0 5)))
+    (is (= 0.0 (floor-z nil 1 1)))))
+
+(deftest test-quantize-fz-snaps-to-quarter-steps
+  ;; Non-round inputs must snap, exact steps must pass through.
+  (is (= 0.25 (quantize-fz 0.3)))
+  (is (= 0.5 (quantize-fz 0.4)))
+  (is (= 0.75 (quantize-fz 0.75)))
+  (is (= 0.0 (quantize-fz 0.0))))
+
+(deftest test-parse-layout-digits-set-floor-height
+  ;; Digit chars author raised floor tiers: geometry stays cell-floor,
+  ;; height lands in :fz-grid.
+  (let [out (parse-layout ["#####"
+                           "#123#"
+                           "#.@.#"
+                           "#####"])
+        g   (:grid out)
+        fz  (:fz-grid out)]
+    (is (= cell-floor (get-in g [1 1])))
+    (is (= cell-floor (get-in g [1 2])))
+    (is (= cell-floor (get-in g [1 3])))
+    (is (= 0.25 (get-in fz [1 1])))
+    (is (= 0.5 (get-in fz [1 2])))
+    (is (= 0.75 (get-in fz [1 3])))
+    (is (= 0.0 (get-in fz [2 1])))
+    (is (= 0.0 (get-in fz [2 2])))))
+
+(deftest test-parse-layout-fz-defaults-flat
+  ;; Digit-free layouts stay flat: :fz-grid present, grid dims, all 0.0.
+  (let [out (parse-layout ["####"
+                           "#.@#"
+                           "####"])
+        g   (:grid out)
+        fz  (:fz-grid out)]
+    (is (= (count g) (count fz)))
+    (is (= (count (first g)) (count (first fz))))
+    (is (every? (fn [row] (every? (fn [z] (= 0.0 z)) row)) fz))))
 
 ;; ---------------------------------------------------------------------
 ;; Secret walls (issue #61): hidden passage cells the player reveals

--- a/tests/core/state-test.phel
+++ b/tests/core/state-test.phel
@@ -270,3 +270,40 @@
   (let [w (reset-reticle {:aim-col 119 :aim-row 0})]
     (is (nil? (:aim-col w)) "column cleared to centre")
     (is (nil? (:aim-row w)) "row cleared to centre")))
+
+;; ---------------------------------------------------------------------
+;; Floor heights (issue #368): :fz-grid source of truth + :pfz flat
+;; PHP twin (indexed y * width + x) for future hot-loop reads.
+;; ---------------------------------------------------------------------
+
+(deftest test-new-world-defaults-flat-fz
+  ;; 2-arg construction (all existing call sites) stays flat: zeros
+  ;; everywhere, :pfz sized width * height.
+  (let [w (new-world grid (new-player 1.0 1.0 0.0))]
+    (is (= [[0.0 0.0 0.0] [0.0 0.0 0.0] [0.0 0.0 0.0]] (:fz-grid w)))
+    (is (= 9 (php/count (:pfz w))))
+    (is (= 0.0 (php/aget (:pfz w) 0)))))
+
+(deftest test-new-world-accepts-fz-grid
+  (let [fz [[0.0 0.0 0.0]
+            [0.0 0.5 0.0]
+            [0.0 0.0 0.0]]
+        w  (new-world grid (new-player 1.0 1.0 0.0) fz)]
+    (is (= fz (:fz-grid w)))
+    ;; Flat index y * width + x: (1, 1) on a 3-wide grid -> 4.
+    (is (= 0.5 (php/aget (:pfz w) 4)))))
+
+(deftest test-rebuild-pgrid-refreshes-pfz
+  ;; :pfz is derived state; any :fz-grid change must re-sync it.
+  (let [w  (new-world grid (new-player 1.0 1.0 0.0))
+        w2 (rebuild-pgrid (assoc-in w [:fz-grid 1 1] 0.75))]
+    (is (= 0.75 (php/aget (:pfz w2) 4)))))
+
+(deftest test-rebuild-pgrid-defaults-missing-fz
+  ;; Old-save path: a decoded world without height data gets flat
+  ;; defaults instead of nil (savestring->world calls rebuild-pgrid).
+  (let [w  (new-world grid (new-player 1.0 1.0 0.0))
+        w2 (rebuild-pgrid (-> w (dissoc :fz-grid) (dissoc :pfz)))]
+    (is (= [[0.0 0.0 0.0] [0.0 0.0 0.0] [0.0 0.0 0.0]] (:fz-grid w2)))
+    (is (= 9 (php/count (:pfz w2))))
+    (is (= 0.0 (php/aget (:pfz w2) 0)))))

--- a/tests/io/savegame-test.phel
+++ b/tests/io/savegame-test.phel
@@ -80,3 +80,15 @@
 
 (deftest test-save-version-is-pinned
   (is (= 1 save-version)))
+
+(deftest test-savestring-roundtrips-floor-heights
+  ;; :fz-grid (source of truth) survives the save; :pfz (derived PHP
+  ;; array) is dropped and rebuilt on load. Raised values only: PHP
+  ;; json_encode collapses 0.0 to int 0, so flat cells prove nothing.
+  (let [fz   [[0.0 0.0 0.0]
+              [0.0 0.25 0.0]
+              [0.0 0.0 0.0]]
+        w    (new-world grid (new-player 1.5 2.5 0.0) fz)
+        back (savestring->world (world->savestring w))]
+    (is (= 0.25 (get-in back [:fz-grid 1 1])) "raised cell survives round-trip")
+    (is (= 0.25 (php/aget (:pfz back) 4)) "pfz rebuilt on load")))


### PR DESCRIPTION
## 📚 Description

Foundation of the variable-floor-heights epic (#375): worlds now carry per-cell floor heights as data, with zero behavior change - cast/render/physics untouched, every shipped level stays flat, full suite green (3112).

## 🔖 Changes

- `map.phel`: `fz-step` (0.25 quantum), `quantize-fz`, `floor-z` lookup (OOB/nil -> 0.0); layout digit chars `1`/`2`/`3` author raised floor tiers; `parse-layout` returns `:fz-grid`
- `state.phel`: `new-world` optional fz-grid arity (nil -> flat zeros); `:pfz` flat PHP float twin indexed `y*width+x`; `rebuild-pgrid` re-derives it and defaults missing `:fz-grid` (pre-#368 saves load clean, no version bump)
- `level.phel`: `build-grid` threads layout `:fz-grid` into `new-world` (procgen passes nil)
- `savegame.phel`: `:pfz` dropped from saves as derived state, rebuilt on load
- Tests: lookup/quantization/parse-layout/new-world/rebuild/save round-trip + all-levels-flat guarantee; docs (`map.md`, `level-system.md`, `state.md`) + CHANGELOG same commit
- clean-code-reviewer pass: no blockers, two comment nits applied as `ref(map)` commit

Closes #368