### PR TITLE
feat(engine): multi-span cast - DDA marches past floor risers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 
 ### Added
 
+- Multi-span raycast (issue #369, epic #375): the DDA now marches past floor-height risers and returns a `:spans` event stream (stride-8 flat array: col, corrected distance, z0, z1, side, hit coords, texture U) alongside the classic per-column arrays — one event per rise boundary, step-downs are backfaces and never emit, blocked risers never leak through walls. Render ignores the stream until #370, so frames stay byte-identical (golden hashes unchanged). Flat worlds pay ZERO cast cost: a build-time `:fz-flat?` flag routes them onto the untouched legacy march (the always-on span march measured +13-16% cast time and was rejected); only tiered worlds run the span-emitting variant.
 - Per-cell floor-height data layer (issue #368, epic #375): worlds now carry `:fz-grid` (per-cell floor heights, quantized 0.25 steps) with a flat PHP hot-array twin `:pfz` (indexed `y * width + x`); layouts can author raised tiers via digit chars `1`/`2`/`3` (fz 0.25/0.5/0.75); `map/floor-z` lookup returns 0.0 out of bounds. Data only — cast/render/physics still assume a flat world, and every shipped level stays flat (zero behavior change; saves round-trip heights without a version bump).
 
 ### Performance

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -201,6 +201,8 @@ change.
 
 Grid-line-to-grid-line march via Wolfenstein DDA: precompute step direction and per-axis delta, advance the smaller side-distance, check the cell. ~5-8 iterations per ray instead of ~35 fixed steps. Side bit and hit-cell coords are free (no second pass). Issue #2.
 
+Multi-span variant (issue #369): tiered worlds (any raised floor cell) run a second march variant that reads the next cell's floor height per continue step and pushes riser span events. That per-step read + the extra loop var measured +13-16% cast-frame time, so the variant is gated behind the build-time `:fz-flat?` world flag - flat worlds (every shipped level today) run the legacy march byte-for-byte. Rule for future march changes: any per-step cost added unconditionally shows up on EVERY frame of EVERY level; gate it or inline it for free.
+
 ## Evaluated and shelved
 
 ### Sprite occlusion z-buffer (issue #4)

--- a/docs/raycaster.md
+++ b/docs/raycaster.md
@@ -52,7 +52,7 @@ Returns raw (uncorrected) distance. Detailed tuple `[dist side hx hy]` is comput
 
 ```phel
 (defn cast-frame [world ^int width ^int scale]
-  ...returns {:dists :hits :sides :hxs :hys :wallxs :floordxs :floordys})
+  ...returns {:dists :hits :sides :hxs :hys :wallxs :floordxs :floordys :spans})
 ```
 
 Cast `width / scale` rays; return the parallel PHP arrays (one per output column).
@@ -62,7 +62,31 @@ Cast `width / scale` rays; return the parallel PHP arrays (one per output column
 - `hxs, hys`: hit cell coordinates
 - `wallxs`: wall-hit fraction in [0, 1) - the texture U coordinate (frac of world-y on a vertical face, world-x on a horizontal face, from the raw perpendicular distance)
 - `floordxs, floordys`: floor-cast basis = ray direction / cos(offset). A floor cell at per-row perpendicular distance `dperp` sits at world `player + dperp * (floordx, floordy)`, so the renderer needs no per-cell trig (two mul-adds + a frac for the texture sample)
+- `spans`: flat riser-event stream for floor heights (see Multi-span cast below); empty on flat frames
 
+## Multi-span cast: floor risers
+
+Issue #369 (epic #375): the DDA no longer treats the first hit as the whole story. While marching, each cell boundary where the floor height (`:pfz`, see map.md) RISES emits one span event - the visible riser face between the two tiers - and the march continues to the real wall (or max-depth) exactly as before. The classic 8 arrays keep holding the final wall hit, which is always the LAST span of a column; on a flat map the stream is empty and the arrays alone describe the frame.
+
+`:spans` is one flat PHP array, stride 8 per event:
+
+| slot | field | meaning |
+|---|---|---|
+| +0 | col | the ray's BASE output column (one event per ray; with scale > 1 the render layer fans out, same as wall samples) |
+| +1 | d-corr | fish-eye corrected distance to the riser boundary |
+| +2 | z0 | floor height of the cell being left (riser bottom) |
+| +3 | z1 | floor height of the cell being entered (riser top) |
+| +4 | side | 0 = x-line, 1 = y-line - same convention as `sides` |
+| +5 | hx, +6 hy | integer coords of the entered (higher) cell |
+| +7 | wallx | texture U in [0, 1) at the crossing, same formula as `wallxs` |
+
+Guarantees and rules:
+
+- **Rise-only.** Step-downs are backfaces (invisible from above) and never emit. The march still tracks the current cell height across drops, so a down-then-up profile emits the second riser with the correct `z0`.
+- **Ordering.** Events arrive in ascending distance within a ray and ascending base col across rays - render can scan the stream once.
+- **Occlusion.** A riser behind a wall/door/secret never emits: blocking cells exit the march before the height check.
+- **No early-out.** The march always reaches the wall/max-depth; deciding that stacked risers fill a screen column needs projection (eye height, pitch), which is render's knowledge (#370). Authorable heights cap at fz 0.75 (layout digits 1-3), so no riser can fill a column by itself.
+- **Cost.** Zero on flat worlds: `new-world` / `rebuild-pgrid` stamp a build-time `:fz-flat?` flag, and do-cast selects the legacy 4-var march (no fz reads, no extra loop var) when it is set - measured, the always-on span march cost +13-16% cast time on flat maps. Tiered worlds run the span march: one subscript + float compare per continue step, plus the event push at each rise.
 
 ## Two key details
 

--- a/docs/state.md
+++ b/docs/state.md
@@ -88,7 +88,7 @@ After `build-world` from `core/level.phel` stamps level metadata, the world also
 
 On grid mutation (door turning into floor, etc.) **both** must update. See `pickup-hearts` in `core/pickups.phel` and door logic in `commands/play.phel`. `rebuild-pgrid` is called after any grid edit to keep the PHP mirror in sync.
 
-The same source-of-truth / hot-twin split applies to floor heights (issue #368): `:fz-grid` is a Phel vector of vectors of floats; `:pfz` is a flat PHP float array indexed `y * width + x` (one `aget` per read in future hot loops). `new-world` takes an optional third `fz-grid` argument (nil = all-zero flat world), and `rebuild-pgrid` re-derives `:pfz` too, defaulting a missing `:fz-grid` to zeros so pre-#368 saves load clean.
+The same source-of-truth / hot-twin split applies to floor heights (issue #368): `:fz-grid` is a Phel vector of vectors of floats; `:pfz` is a flat PHP float array indexed `y * width + x` (one `aget` per read in hot loops). `new-world` takes an optional third `fz-grid` argument (nil = all-zero flat world), and `rebuild-pgrid` re-derives `:pfz` too, defaulting a missing `:fz-grid` to zeros so pre-#368 saves load clean. Both also stamp `:fz-flat?` (true when every cell is at ground level): the raycaster reads it once per frame to pick the zero-cost legacy DDA march on flat worlds and the span-emitting march on tiered ones (issue #369).
 
 ## The player
 

--- a/src/core/engine.phel
+++ b/src/core/engine.phel
@@ -164,16 +164,33 @@
 
 (defn- do-cast
   "Cast every column once; returns the parallel :dists / :hits / :sides
-   / :hxs / :hys map. Pure: no cache lookup, no atom touch. cast-frame
-   wraps this with a paused-frame cache short-circuit."
+   / :hxs / :hys map plus the :spans riser-event stream (issue #369).
+   Pure: no cache lookup, no atom touch. cast-frame wraps this with a
+   paused-frame cache short-circuit."
   [world ^int width ^int scale]
   (let [^array pgrid        (:pgrid world)
         {:keys [x y angle]} (:player world)
+        ;; Floor heights (#369). mapw is the MAP width for y*w+x pfz
+        ;; indexing - NOT the `width` param (viewport columns). The nil
+        ;; guard keeps hand-rolled fixture worlds without :pfz castable
+        ;; (missing reads fall back to 0.0 -> zero span events). `if`
+        ;; not `or`: `or` in binding value closure-compiles.
+        mapw                (:width world)
+        pfz-src             (:pfz world)
+        ^array pfz          (if (php/=== nil pfz-src) (php/array) pfz-src)
+        ;; Tiered world? Only an explicit false flag (set by new-world /
+        ;; rebuild-pgrid when any cell is raised) selects the span
+        ;; march; absent flag (hand-rolled fixtures) = flat fast path.
+        fz-track?           (php/=== false (:fz-flat? world))
         ;; Player cell + its fractional offsets to the four cell
         ;; boundaries are fixed for the whole frame; hoist out of the
         ;; per-column loop (was recomputed via intval/floor per column).
         cx0                 (php/intval (php/floor x))
         cy0                 (php/intval (php/floor y))
+        ;; Height of the player's own cell: every ray starts its
+        ;; riser tracking from here (frame-constant, like the
+        ;; boundary offsets below).
+        fz0                 (get pfz (php/+ (php/* cy0 mapw) cx0) 0.0)
         x-to-lo             (php/- x cx0)
         x-to-hi             (php/- (php/+ cx0 1.0) x)
         y-to-lo             (php/- y cy0)
@@ -193,6 +210,14 @@
         wallxs              (php/array)
         floordxs            (php/array)
         floordys            (php/array)
+        ;; Riser-event stream (#369): flat PHP array, stride 8 per
+        ;; event: [col d-corr z0 z1 side hx hy wallx]. One event per
+        ;; RAY (base col; scale replication is render's job), pushed
+        ;; in ascending distance within a ray and ascending col across
+        ;; rays. Flat frames never touch it after this alloc. A flat
+        ;; stream (not per-column arrays) sidesteps PHP array
+        ;; value-copy semantics AND per-column allocations.
+        spans               (php/array)
         ;; Per-cast scratch register, reused every column. Slots:
         ;; [0]=dist [1]=hit [2]=side [3]=hx [4]=hy. The DDA writes it in
         ;; STATEMENT position (see below) so the writes land on the real
@@ -219,43 +244,97 @@
                        (php/* x-to-hi deltax))
               sidey0 (if (php/< diry 0.0)
                        (php/* y-to-lo deltay)
-                       (php/* y-to-hi deltay))]
+                       (php/* y-to-hi deltay))
+              coff   (php/aget cos-offs col)]
           ;; DDA march (statement position -> no closure). Each exit
           ;; writes the 5-slot register; `:else` steps to the next
-          ;; grid-line crossing.
-          (loop [cx cx0 cy cy0 sidex sidex0 sidey sidey0]
-            (if (php/< sidex sidey)
-              (let [cx'        (php/+ cx stepx)
-                    dist       sidex
-                    ;; cell-at inlined: the `^array` tag lowers `get` to a
-                    ;; native `$row[k] ?? default` subscript, dropping the
-                    ;; per-step dispatch frame the fn call cost.
-                    ^array row (get pgrid cy)
-                    hit        (get row cx' 1)]
-                (cond
-                  (php/> dist max-depth)
-                  (do (php/aset hit-reg 0 max-depth) (php/aset hit-reg 1 0)
-                      (php/aset hit-reg 2 0) (php/aset hit-reg 3 cx') (php/aset hit-reg 4 cy))
-                  (php/!== 0 hit)
-                  (do (php/aset hit-reg 0 dist) (php/aset hit-reg 1 hit)
-                      (php/aset hit-reg 2 0) (php/aset hit-reg 3 cx') (php/aset hit-reg 4 cy))
-                  :else
-                  (recur cx' cy (php/+ sidex deltax) sidey)))
-              (let [cy'        (php/+ cy stepy)
-                    dist       sidey
-                    ^array row (get pgrid cy')
-                    hit        (get row cx 1)]
-                (cond
-                  (php/> dist max-depth)
-                  (do (php/aset hit-reg 0 max-depth) (php/aset hit-reg 1 0)
-                      (php/aset hit-reg 2 1) (php/aset hit-reg 3 cx) (php/aset hit-reg 4 cy'))
-                  (php/!== 0 hit)
-                  (do (php/aset hit-reg 0 dist) (php/aset hit-reg 1 hit)
-                      (php/aset hit-reg 2 1) (php/aset hit-reg 3 cx) (php/aset hit-reg 4 cy'))
-                  :else
-                  (recur cx cy' sidex (php/+ sidey deltay))))))
+          ;; grid-line crossing. TWO variants, selected once per frame:
+          ;; flat worlds run the legacy 4-var march untouched (the
+          ;; span path's per-step fz read + 5th loop var measured
+          ;; +13-16% cast time on flat maps - see #369 bench); tiered
+          ;; worlds run the span march below. The x/y branch bodies
+          ;; are deliberately duplicated in BOTH variants - extracting
+          ;; a helper reintroduces the per-step call frame #345 removed.
+          (if fz-track?
+            ;; Span march (#369): `cfz` tracks the CURRENT cell's floor
+            ;; height. It updates on EVERY continue step (also on drops -
+            ;; a down-then-up profile still shows the second riser); a
+            ;; step whose height RISES pushes one stride-8 span event
+            ;; before recurring. Rise compare is strict float `>`; exact
+            ;; here because all fz values share provenance
+            ;; (loader-quantized to fz-step multiples through fz->pfz).
+            (loop [cx cx0 cy cy0 sidex sidex0 sidey sidey0 cfz fz0]
+              (if (php/< sidex sidey)
+                (let [cx'        (php/+ cx stepx)
+                      dist       sidex
+                      ^array row (get pgrid cy)
+                      hit        (get row cx' 1)]
+                  (cond
+                    (php/> dist max-depth)
+                    (do (php/aset hit-reg 0 max-depth) (php/aset hit-reg 1 0)
+                        (php/aset hit-reg 2 0) (php/aset hit-reg 3 cx') (php/aset hit-reg 4 cy))
+                    (php/!== 0 hit)
+                    (do (php/aset hit-reg 0 dist) (php/aset hit-reg 1 hit)
+                        (php/aset hit-reg 2 0) (php/aset hit-reg 3 cx') (php/aset hit-reg 4 cy))
+                    :else
+                    (let [nfz (get pfz (php/+ (php/* cy mapw) cx') 0.0)]
+                      (when (php/> nfz cfz)
+                        (let [wc (php/+ y (php/* dist diry))]
+                          (php/array_push spans col (php/* dist coff) cfz nfz 0 cx' cy
+                                          (php/- wc (php/floor wc)))))
+                      (recur cx' cy (php/+ sidex deltax) sidey nfz))))
+                (let [cy'        (php/+ cy stepy)
+                      dist       sidey
+                      ^array row (get pgrid cy')
+                      hit        (get row cx 1)]
+                  (cond
+                    (php/> dist max-depth)
+                    (do (php/aset hit-reg 0 max-depth) (php/aset hit-reg 1 0)
+                        (php/aset hit-reg 2 1) (php/aset hit-reg 3 cx) (php/aset hit-reg 4 cy'))
+                    (php/!== 0 hit)
+                    (do (php/aset hit-reg 0 dist) (php/aset hit-reg 1 hit)
+                        (php/aset hit-reg 2 1) (php/aset hit-reg 3 cx) (php/aset hit-reg 4 cy'))
+                    :else
+                    (let [nfz (get pfz (php/+ (php/* cy' mapw) cx) 0.0)]
+                      (when (php/> nfz cfz)
+                        (let [wc (php/+ x (php/* dist dirx))]
+                          (php/array_push spans col (php/* dist coff) cfz nfz 1 cx cy'
+                                          (php/- wc (php/floor wc)))))
+                      (recur cx cy' sidex (php/+ sidey deltay) nfz))))))
+            ;; Legacy flat march: byte-for-byte the pre-#369 loop.
+            (loop [cx cx0 cy cy0 sidex sidex0 sidey sidey0]
+              (if (php/< sidex sidey)
+                (let [cx'        (php/+ cx stepx)
+                      dist       sidex
+                      ;; cell-at inlined: the `^array` tag lowers `get` to a
+                      ;; native `$row[k] ?? default` subscript, dropping the
+                      ;; per-step dispatch frame the fn call cost.
+                      ^array row (get pgrid cy)
+                      hit        (get row cx' 1)]
+                  (cond
+                    (php/> dist max-depth)
+                    (do (php/aset hit-reg 0 max-depth) (php/aset hit-reg 1 0)
+                        (php/aset hit-reg 2 0) (php/aset hit-reg 3 cx') (php/aset hit-reg 4 cy))
+                    (php/!== 0 hit)
+                    (do (php/aset hit-reg 0 dist) (php/aset hit-reg 1 hit)
+                        (php/aset hit-reg 2 0) (php/aset hit-reg 3 cx') (php/aset hit-reg 4 cy))
+                    :else
+                    (recur cx' cy (php/+ sidex deltax) sidey)))
+                (let [cy'        (php/+ cy stepy)
+                      dist       sidey
+                      ^array row (get pgrid cy')
+                      hit        (get row cx 1)]
+                  (cond
+                    (php/> dist max-depth)
+                    (do (php/aset hit-reg 0 max-depth) (php/aset hit-reg 1 0)
+                        (php/aset hit-reg 2 1) (php/aset hit-reg 3 cx) (php/aset hit-reg 4 cy'))
+                    (php/!== 0 hit)
+                    (do (php/aset hit-reg 0 dist) (php/aset hit-reg 1 hit)
+                        (php/aset hit-reg 2 1) (php/aset hit-reg 3 cx) (php/aset hit-reg 4 cy'))
+                    :else
+                    (recur cx cy' sidex (php/+ sidey deltay)))))))
           (let [rawd    (php/aget hit-reg 0)
-                d-corr  (php/* rawd (php/aget cos-offs col))
+                d-corr  (php/* rawd coff)
                 h       (php/aget hit-reg 1)
                 side    (php/aget hit-reg 2)
                 hx      (php/aget hit-reg 3)
@@ -276,7 +355,7 @@
                 ;; distance `dperp` (a per-ROW constant the renderer knows)
                 ;; sits at world `player + dperp * (floordx, floordy)`, so
                 ;; the renderer needs no per-cell trig - just two mul-adds.
-                inv-cos (php// 1.0 (php/aget cos-offs col))
+                inv-cos (php// 1.0 coff)
                 floordx (php/* dirx inv-cos)
                 floordy (php/* diry inv-cos)]
              ;; Replicate this sample across the next `scale` output
@@ -301,7 +380,7 @@
                 (recur (php/+ c 1) (php/+ fill 1))))
             (recur (php/+ col scale))))))
     {:dists dists :hits hits :sides sides :hxs hxs :hys hys :wallxs wallxs
-     :floordxs floordxs :floordys floordys}))
+     :floordxs floordxs :floordys floordys :spans spans}))
 
 (def visit-radius
   "Square radius (cells) around the player scanned each frame for
@@ -426,6 +505,9 @@
            :hys    integer y coord of the hit cell
            :wallxs wall-hit fraction (texture U) in [0, 1)
            :floordxs/:floordys floor-cast basis (ray dir / cos offset)
+           :spans  flat riser-event stream (#369), stride 8 per event:
+                   [col d-corr z0 z1 side hx hy wallx]. One event per
+                   RAY at its base column; empty on flat frames.
 
          `scale` controls the ray-replication factor (see `do-cast`).
 

--- a/src/core/state.phel
+++ b/src/core/state.phel
@@ -98,6 +98,9 @@
 (defn- fz->pfz [fz-grid]
   (to-php-array (apply concat fz-grid)))
 
+(defn- all-flat? [fz-grid]
+  (every? (fn [row] (every? (fn [z] (php/== 0.0 z)) row)) fz-grid))
+
 (defn rebuild-pgrid
   "Re-derive `:pgrid` from `:grid` and `:pfz` from `:fz-grid`. Call
    after any in-game mutation of the grid (secret reveal, switch
@@ -111,7 +114,8 @@
     (assoc world
            :pgrid (to-php-array (map to-php-array (:grid world)))
            :fz-grid fz
-           :pfz (fz->pfz fz))))
+           :pfz (fz->pfz fz)
+           :fz-flat? (all-flat? fz))))
 
 (defn new-world
   {:doc "Bundle map grid and player into the world state. Stores a PHP-native
@@ -129,6 +133,10 @@
       :pgrid     (to-php-array (map to-php-array grid))
       :fz-grid   fz
       :pfz       (fz->pfz fz)
+      ;; Build-time flatness flag: do-cast selects the legacy zero-cost
+      ;; DDA march for flat worlds (the per-step fz read measured
+      ;; +13-16% cast time, see #369).
+      :fz-flat?  (all-flat? fz)
       :width     (count (first grid))
       :height    (count grid)
       :player    player

--- a/src/core/state.phel
+++ b/src/core/state.phel
@@ -99,6 +99,8 @@
   (to-php-array (apply concat fz-grid)))
 
 (defn- all-flat? [fz-grid]
+  ;; Loose ==: savegame JSON decodes 0.0 as int 0; === would misflag
+  ;; loaded flat worlds as tiered.
   (every? (fn [row] (every? (fn [z] (php/== 0.0 z)) row)) fz-grid))
 
 (defn rebuild-pgrid

--- a/tests/core/engine-test.phel
+++ b/tests/core/engine-test.phel
@@ -110,7 +110,10 @@
     (is (= 8 (php/count (:hys c))))
     (is (= 8 (php/count (:wallxs c))))
     (is (= 8 (php/count (:floordxs c))))
-    (is (= 8 (php/count (:floordys c))))))
+    (is (= 8 (php/count (:floordys c))))
+    ;; :spans is a flat EVENT stream, not column-parallel — presence
+    ;; pin only (empty here: chamber floor is flat).
+    (is (php/is_array (:spans c)))))
 
 (deftest test-cast-frame-floor-basis-fisheye-corrected
   ;; :floordxs/:floordys are the ray direction divided by cos(offset),
@@ -182,6 +185,155 @@
         (is (php/!== nil (php/aget (:dists c) i)))
         (is (php/!== nil (php/aget (:hits  c) i)))
         (recur (php/+ i 1))))))
+
+;; ---------------------------------------------------------------------
+;; Multi-span cast (issue #369): the DDA marches past floor-height
+;; risers (:pfz from #368) and emits a flat span-event stream under
+;; :spans, stride 8: [col d-corr z0 z1 side hx hy wallx]. Only RISES
+;; emit (step-downs are backfaces); the existing 8 arrays stay the
+;; final wall hit. Render ignores :spans until #370.
+;; ---------------------------------------------------------------------
+
+(def corridor-grid
+  ;; 9-wide east corridor, player at (1.5, 1.5) facing east (angle 0).
+  [[1 1 1 1 1 1 1 1 1]
+   [1 0 0 0 0 0 0 0 1]
+   [1 1 1 1 1 1 1 1 1]])
+
+(def flat9 [0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0])
+
+(defn- corridor-world [mid-fz]
+  (new-world corridor-grid (new-player 1.5 1.5 0.0) [flat9 mid-fz flat9]))
+
+(defn- span-at
+  ;; Read field i of event e from the stride-8 flat stream.
+  [spans e i]
+  (php/aget spans (php/+ (php/* e 8) i)))
+
+(deftest test-cast-frame-flat-world-spans-empty
+  ;; 2-arity worlds (all existing call sites) cast with zero span events.
+  (let [w (new-world chamber-grid (new-player 2.5 2.5 0.0))
+        c (cast-frame w 8 1)]
+    (is (php/is_array (:spans c)))
+    (is (= 0 (php/count (:spans c))))))
+
+(deftest test-cast-frame-single-riser-emits-one-span
+  ;; fz 0 -> 0.25 at x=3: one riser event at the x=3.0 boundary,
+  ;; dist 1.5 from the player at x=1.5. The 0.25 -> 0 step-down at
+  ;; x=4 is a backface and must NOT emit.
+  (let [w  (corridor-world [0.0 0.0 0.0 0.25 0.0 0.0 0.0 0.0 0.0])
+        c  (cast-frame w 1 1)
+        sp (:spans c)]
+    (is (= 8 (php/count sp)) "exactly one stride-8 event")
+    (is (= 0 (span-at sp 0 0)) "base col")
+    (is (< (php/abs (php/- (span-at sp 0 1) 1.5)) 0.01) "corrected dist")
+    (is (= 0.0 (span-at sp 0 2)) "z0 = height left")
+    (is (= 0.25 (span-at sp 0 3)) "z1 = height entered")
+    (is (= 0 (span-at sp 0 4)) "x-line -> side 0")
+    (is (= 3 (span-at sp 0 5)) "hx = entered cell x")
+    (is (= 1 (span-at sp 0 6)) "hy = entered cell y")
+    (is (< (php/abs (php/- (span-at sp 0 7) 0.5)) 0.02) "wallx mid-face")))
+
+(deftest test-cast-frame-staircase-emits-ascending-spans
+  ;; Three risers in a row: events come back in ascending distance
+  ;; order and chain z0/z1 (each event's z0 is the previous z1). The
+  ;; 0.75 -> 0 drop at x=6 emits nothing; the far wall still lands in
+  ;; the classic arrays.
+  (let [w  (corridor-world [0.0 0.0 0.0 0.25 0.5 0.75 0.0 0.0 0.0])
+        c  (cast-frame w 1 1)
+        sp (:spans c)]
+    (is (= 24 (php/count sp)) "three events, no step-down event")
+    (is (< (span-at sp 0 1) (span-at sp 1 1)))
+    (is (< (span-at sp 1 1) (span-at sp 2 1)))
+    (is (= (span-at sp 0 3) (span-at sp 1 2)) "z chains 0.25")
+    (is (= (span-at sp 1 3) (span-at sp 2 2)) "z chains 0.5")
+    (is (= 1 (php/aget (:hits c) 0)) "final wall hit unchanged")))
+
+(deftest test-cast-frame-riser-behind-wall-no-span
+  ;; The ray stops at the wall BEFORE reaching the raised cells, so no
+  ;; event leaks from occluded geometry.
+  (let [g [[1 1 1 1 1 1 1 1 1]
+           [1 0 0 1 0 0 1 0 1]
+           [1 1 1 1 1 1 1 1 1]]
+        w (new-world g (new-player 1.5 1.5 0.0)
+                     [flat9 [0.0 0.0 0.0 0.0 0.5 0.5 0.0 0.0 0.0] flat9])
+        c (cast-frame w 1 1)]
+    (is (= 0 (php/count (:spans c))))
+    (is (< (php/abs (php/- (php/aget (:dists c) 0) 1.5)) 0.01)
+        "wall hit unchanged")))
+
+(deftest test-cast-frame-step-down-only-no-span
+  ;; Player stands ON the raised tier; the only height change ahead is
+  ;; a drop. Backface -> zero events.
+  (let [w (corridor-world [0.25 0.25 0.25 0.0 0.0 0.0 0.0 0.0 0.0])
+        c (cast-frame w 1 1)]
+    (is (= 0 (php/count (:spans c))))))
+
+(deftest test-cast-frame-span-z0-is-player-cell-fz
+  ;; cfz must initialize from the PLAYER's cell height, not 0.0: on a
+  ;; 0.25 tier a rise to 0.5 is a quarter-height riser (z0 0.25), not a
+  ;; half-height one. Also pins that a later step-down updated nothing.
+  (let [w  (corridor-world [0.25 0.25 0.5 0.0 0.0 0.0 0.0 0.0 0.0])
+        c  (cast-frame w 1 1)
+        sp (:spans c)]
+    (is (= 8 (php/count sp)))
+    (is (= 0.25 (span-at sp 0 2)) "z0 = player tier height")
+    (is (= 0.5 (span-at sp 0 3)))
+    (is (< (php/abs (php/- (span-at sp 0 1) 0.5)) 0.01) "boundary x=2.0")))
+
+(deftest test-cast-frame-south-riser-side-1
+  ;; y-line branch parity + pfz indexed with MAP width (3), not the
+  ;; viewport width (1): a vertical corridor cast south. Riser at
+  ;; (1, 3), boundary y=3.0, dist 1.5.
+  (let [g  [[1 1 1]
+            [1 0 1]
+            [1 0 1]
+            [1 0 1]
+            [1 0 1]
+            [1 1 1]]
+        fz [[0.0 0.0 0.0]
+            [0.0 0.0 0.0]
+            [0.0 0.0 0.0]
+            [0.0 0.25 0.0]
+            [0.0 0.0 0.0]
+            [0.0 0.0 0.0]]
+        w  (new-world g (new-player 1.5 1.5 (/ php/M_PI 2.0)) fz)
+        c  (cast-frame w 1 1)
+        sp (:spans c)]
+    (is (= 8 (php/count sp)))
+    (is (< (php/abs (php/- (span-at sp 0 1) 1.5)) 0.01))
+    (is (= 1 (span-at sp 0 4)) "y-line -> side 1")
+    (is (= 1 (span-at sp 0 5)) "hx")
+    (is (= 3 (span-at sp 0 6)) "hy")
+    (is (< (php/abs (php/- (span-at sp 0 7) 0.5)) 0.02) "wallx mid-face")))
+
+(deftest test-cast-frame-fz-does-not-change-wall-outputs
+  ;; Byte-identity guard behind the golden render hashes: raised floors
+  ;; must not perturb ANY of the 8 classic outputs.
+  (let [wa (new-world corridor-grid (new-player 1.5 1.5 0.0))
+        wb (corridor-world [0.0 0.0 0.0 0.25 0.5 0.75 0.0 0.0 0.0])
+        a  (cast-frame wa 8 1)
+        b  (cast-frame wb 8 1)]
+    (is (php/== (:dists a) (:dists b)))
+    (is (php/== (:hits a) (:hits b)))
+    (is (php/== (:sides a) (:sides b)))
+    (is (php/== (:hxs a) (:hxs b)))
+    (is (php/== (:hys a) (:hys b)))
+    (is (php/== (:wallxs a) (:wallxs b)))
+    (is (php/== (:floordxs a) (:floordxs b)))
+    (is (php/== (:floordys a) (:floordys b)))))
+
+(deftest test-cast-frame-scale-2-spans-once-per-ray
+  ;; scale=2 replicates WALL samples across output columns, but each
+  ;; ray emits its span once, tagged with the ray's BASE column.
+  (let [w  (corridor-world [0.0 0.0 0.0 0.25 0.0 0.0 0.0 0.0 0.0])
+        c  (cast-frame w 8 2)
+        sp (:spans c)]
+    (is (= 32 (php/count sp)) "4 rays x one event each")
+    (is (= 0 (span-at sp 0 0)))
+    (is (= 2 (span-at sp 1 0)))
+    (is (= 4 (span-at sp 2 0)))
+    (is (= 6 (span-at sp 3 0)))))
 
 ;; ---------------------------------------------------------------------
 ;; Paused-frame cast cache: while `:paused` is truthy AND the player

--- a/tests/core/state-test.phel
+++ b/tests/core/state-test.phel
@@ -307,3 +307,24 @@
     (is (= [[0.0 0.0 0.0] [0.0 0.0 0.0] [0.0 0.0 0.0]] (:fz-grid w2)))
     (is (= 9 (php/count (:pfz w2))))
     (is (= 0.0 (php/aget (:pfz w2) 0)))))
+
+(deftest test-new-world-flags-flat-fz
+  ;; do-cast picks the legacy zero-cost DDA march when the world is
+  ;; flat; the flag must be computed at build time, not per frame.
+  (let [flat   (new-world grid (new-player 1.0 1.0 0.0))
+        raised (new-world grid (new-player 1.0 1.0 0.0)
+                          [[0.0 0.0 0.0] [0.0 0.25 0.0] [0.0 0.0 0.0]])
+        zeroed (new-world grid (new-player 1.0 1.0 0.0)
+                          [[0.0 0.0 0.0] [0.0 0.0 0.0] [0.0 0.0 0.0]])]
+    (is (= true (:fz-flat? flat)) "2-arity default is flat")
+    (is (= false (:fz-flat? raised)) "any raised cell clears the flag")
+    (is (= true (:fz-flat? zeroed)) "explicit all-zero grid is still flat")))
+
+(deftest test-rebuild-pgrid-refreshes-fz-flat-flag
+  ;; Savegame load path: the flag is derived state and must re-derive
+  ;; with :pfz (a loaded raised world may carry no flag at all).
+  (let [w  (new-world grid (new-player 1.0 1.0 0.0))
+        w2 (rebuild-pgrid (-> w
+                              (assoc-in [:fz-grid 1 1] 0.75)
+                              (dissoc :fz-flat?)))]
+    (is (= false (:fz-flat? w2)))))

--- a/tests/io/savegame-test.phel
+++ b/tests/io/savegame-test.phel
@@ -92,3 +92,11 @@
         back (savestring->world (world->savestring w))]
     (is (= 0.25 (get-in back [:fz-grid 1 1])) "raised cell survives round-trip")
     (is (= 0.25 (php/aget (:pfz back) 4)) "pfz rebuilt on load")))
+
+(deftest test-savestring-flat-world-stays-flat-on-load
+  ;; JSON decodes 0.0 as int 0; the rebuilt :fz-flat? flag must still
+  ;; read the loaded world as flat or every old save silently pays the
+  ;; span-march cast tax (#369).
+  (let [back (savestring->world (world->savestring
+                                 (new-world grid (new-player 1.5 2.5 0.0))))]
+    (is (= true (:fz-flat? back)))))


### PR DESCRIPTION
## 📚 Description

Epic #375 step 2: the raycaster marches past floor-height risers and reports every rise as a span event, so raised tiers behind steps become renderable (#370 consumes the stream). Flat worlds are routed onto the untouched legacy march via a build-time flag - zero cost for every shipped level, golden hashes byte-identical.

## 🔖 Changes

- `engine.phel`: `:spans` flat stride-8 event stream (`[col d-corr z0 z1 side hx hy wallx]`), rise-only (step-downs are backfaces), occlusion-safe, ordered; dual march variants selected once per frame via `:fz-flat?`
- `state.phel`: `new-world`/`rebuild-pgrid` stamp `:fz-flat?`; loose `==` in the flatness scan survives JSON int-0 decode (savegame test pins it)
- Perf (Faramir bench, 2000-iter median, no-JIT): always-on span march cost +13-16% flat cast -> rejected; post-fix flat delta +4.1%/+1.2%/+2.3% at 80/120/180 (noise band); tiered worst-case +~38% cast (cast is ~6% of frame). `engine.php` closure count stays 2
- Deviation from issue text: no in-cast early-out - column-fill decisions need projection (eye-z/pitch), which is render's job in #370; authorable fz caps at 0.75
- 9 engine tests + 2 state tests + flat-save round-trip; docs (`raycaster.md`, `state.md`, `performance.md`) + CHANGELOG same commit
- clean-code-reviewer: approve; two minors applied as `ref(state)` commit

Closes #369