### PR TITLE
fix(enemy): route chase up stairs via a player BFS flow-field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 
 ### Fixed
 
+- Enemies route up stairs instead of stalling at a platform edge (issue #405, epic #375): the chase was a greedy angle-offset walk (offsets up to ±135° off the straight line at the player), so a monster pressed against a tall multi-`fz-step` tier face never found a stair mouth off to the side - it bunched at the edge and never climbed to a player on a raised tier. On a tiered world `advance` now builds one BFS flow-field per frame (`chase-dist-field`) from the player over the one-`fz-step`-climbable cell graph and `step-toward` heads toward its next waypoint (`chase-waypoint`), so the enemy routes AROUND the ledge to the stairs and climbs. The field is built once and shared by every enemy (O(cells), not per-enemy); flat worlds build no field and keep the greedy chase byte-identical (guarded by the full existing chase suite, all nil-field). New tests pin the routing (a grounded enemy east of the platform is sent away from the impassable face) and an end-to-end climb out of a 180°-exit tier trap greedy provably cannot escape.
 - Sub-pixel auto-off on macOS Terminal.app (#332): Apple Terminal draws the `▀` half-block with row seams (gray static). Startup reads `$TERM_PROGRAM` and defaults Sub-pixel off on `Apple_Terminal` until the player saves a choice; the in-game toggle and `PHEL_DOOM_SUBPIXEL=1` still force it on. iTerm2 et al. unchanged; render seam + golden hashes untouched.
 
 ## [0.16.0] - 2026-06-27

--- a/docs/monsters.md
+++ b/docs/monsters.md
@@ -118,7 +118,9 @@ Casters still melee on contact (touch ignores range), so cornering is dangerous.
 
 `step-toward`: heading = atan2(enemy→target), step `speed * dt` along heading, slide ±45° / ±90° / ±135° on wall collision. Stop at 0.6 units (no pile-up). Arrival at `:lkp` = 0.9 units → `:dormant`.
 
-**Chase on flat ground**: each candidate step checks walls but no height gates apply since the ground is flat. The coarse slide cascade applies to wall collisions, so the enemy takes the open path available. This is simpler and stays byte-identical to before the verticality systems.
+**Stair-aware routing on tiered worlds (#405)**: the raw heading is greedy - it only tries offsets up to ±135°, so a monster pressed against a tall (multi-`fz-step`) tier face never finds a stair mouth off to the side and stalls at the edge. On a tiered world `advance` builds one BFS flow-field per frame, `chase-dist-field`, flooding OUT from the player's cell over the enemy-traversable graph (a move A→B is an edge when B is in bounds, not a wall, and the rise `floor-z(B) - floor-z(A)` clears one `fz-step`, the same gate as `step-clears?`). Because the flood expands on the reverse edge, a 3-step platform face never propagates reachability up its wall while a 1-step stair mouth does. `step-toward` then aims at `chase-waypoint` - the climbable neighbour with the smallest distance-to-player - so the enemy descends the gradient AROUND the ledge to the stairs and climbs. The field is built ONCE per frame and shared by every enemy (O(cells), not per-enemy). When there is no reachable waypoint the enemy falls back to the greedy heading.
+
+**Chase on flat ground**: each candidate step checks walls but no height gates apply since the ground is flat. No `fz-grid` means no flow-field is built (`advance` passes nil), so `step-toward` takes the greedy heading and stays byte-identical to before the verticality systems.
 
 ### Breaking contact
 

--- a/src/core/enemy.phel
+++ b/src/core/enemy.phel
@@ -117,6 +117,75 @@
                      (floor-z fz-grid (php/intval ex) (php/intval ey)))
               fz-step)))
 
+(defn ^:pure chase-dist-field
+  "BFS distance-to-player field for stair-aware chase (issue #405).
+   Floods OUT from the player's cell over the enemy-traversable graph:
+   a move A->B is an edge when B is in bounds, not a `wall?`, and the
+   rise `floor-z(B) - floor-z(A)` clears one `fz-step` - the same gate
+   as `step-clears?`/physics (#371). The flood expands B->A on the
+   REVERSE edge, so a multi-step platform face never propagates
+   reachability up its wall while a one-step stair mouth does; an enemy
+   then descends the gradient AROUND a ledge to the stairs instead of
+   pressing into the edge. Returns `{:dist <php-array idx->steps> :w W}`
+   keyed `y*W + x`; unreachable cells are absent. Only tiered worlds
+   build this (nil `fz-grid` keeps the greedy chase, see `step-toward`)."
+  [grid fz-grid ^int px ^int py]
+  (let [w    (count (first grid))
+        h    (count grid)
+        dist (php/array)
+        q    (php/array)]
+    (php/aset dist (php/+ (php/* py w) px) 0)
+    (php/array_push q px py)
+    (loop [head 0]
+      (if (php/>= head (php/count q))
+        {:dist dist :w w}
+        (let [bx (php/aget q head)
+              by (php/aget q (php/+ head 1))
+              bd (php/aget dist (php/+ (php/* by w) bx))
+              bz (floor-z fz-grid bx by)]
+          (loop [ns [[(php/- bx 1) by] [(php/+ bx 1) by] [bx (php/- by 1)] [bx (php/+ by 1)]]]
+            (when (not (empty? ns))
+              (let [ax (first (first ns))
+                    ay (second (first ns))
+                    ai (php/+ (php/* ay w) ax)]
+                ;; Reverse edge: A->B is the move an enemy WOULD make, so
+                ;; the climb gate reads `bz - floor-z(A)` (rise onto B).
+                (when (and (php/>= ax 0) (php/< ax w) (php/>= ay 0) (php/< ay h)
+                           (not (wall? grid ax ay))
+                           (not (php/array_key_exists ai dist))
+                           (php/<= (php/- bz (floor-z fz-grid ax ay)) fz-step))
+                  (php/aset dist ai (php/+ bd 1))
+                  (php/array_push q ax ay)))
+              (recur (rest ns))))
+          (recur (php/+ head 2)))))))
+
+(defn ^:pure chase-waypoint
+  "Next cell an enemy at (ex, ey) should step to under a `chase-dist-field`:
+   the in-bounds, non-`wall?`, one-`fz-step`-climbable neighbour with the
+   smallest distance-to-player (the next cell on the shortest stair-aware
+   path). Returns `[nx ny]` or nil when no reachable neighbour exists, in
+   which case `step-toward` falls back to the greedy heading."
+  [field grid fz-grid ^int ex ^int ey]
+  (let [dist (:dist field)
+        w    (:w field)
+        ez   (floor-z fz-grid ex ey)]
+    (loop [ns   [[(php/- ex 1) ey] [(php/+ ex 1) ey] [ex (php/- ey 1)] [ex (php/+ ey 1)]]
+           best nil
+           bd   nil]
+      (if (empty? ns)
+        best
+        (let [ax (first (first ns))
+              ay (second (first ns))
+              ai (php/+ (php/* ay w) ax)]
+          (if (and (not (wall? grid ax ay))
+                   (php/array_key_exists ai dist)
+                   (php/<= (php/- (floor-z fz-grid ax ay) ez) fz-step))
+            (let [d (php/aget dist ai)]
+              (if (or (nil? bd) (php/< d bd))
+                (recur (rest ns) [ax ay] d)
+                (recur (rest ns) best bd)))
+            (recur (rest ns) best bd)))))))
+
 (defn- try-step
   "Attempt to step `dist` units from (ex, ey) along `angle`. Returns
    [nx ny] if the destination cell is open (not a `wall?`) AND its
@@ -147,11 +216,15 @@
 (defn- step-toward
   "Walk one frame of `speed` * dt toward (target-x, target-y). The enemy
    slides around obstacles via pick-step's offset cascade instead of
-   bumping forever. Heads straight at the player; a floor-height rise
-   bigger than one fz-step blocks the same way a wall does (issue #371),
-   so a monster climbs stairs but can't scale a taller ledge. `fz-grid`
-   nil (flat worlds / legacy callers) keeps the pre-#371 wall-only gate."
-  [enemy grid fz-grid ^float target-x ^float target-y ^float dt ^float speed]
+   bumping forever. A floor-height rise bigger than one fz-step blocks
+   the same way a wall does (issue #371), so a monster climbs stairs but
+   can't scale a taller ledge. When a `field` (BFS `chase-dist-field`,
+   #405) is present the enemy heads toward its next waypoint cell so the
+   chase ROUTES around a tall tier face to the stair mouth rather than
+   pressing into it; with no field (flat worlds / legacy callers) OR no
+   reachable waypoint it falls back to the direct heading, so those paths
+   are byte-identical to the pre-#405 greedy chase."
+  [enemy grid fz-grid field ^float target-x ^float target-y ^float dt ^float speed]
   (let [ex   (:x enemy)
         ey   (:y enemy)
         dx   (php/- target-x ex)
@@ -159,7 +232,12 @@
         dist (php/sqrt (php/+ (php/* dx dx) (php/* dy dy)))]
     (if (php/<= dist stop-dist)
       enemy
-      (let [hit (pick-step grid fz-grid ex ey (php/* speed dt) (php/atan2 dy dx))]
+      (let [wp      (when field (chase-waypoint field grid fz-grid (php/intval ex) (php/intval ey)))
+            desired (if wp
+                      (php/atan2 (php/- (php/+ (second wp) 0.5) ey)
+                                 (php/- (php/+ (first wp) 0.5) ex))
+                      (php/atan2 dy dx))
+            hit     (pick-step grid fz-grid ex ey (php/* speed dt) desired)]
         (if hit
           (assoc enemy :x (first hit) :y (second hit))
           enemy)))))
@@ -578,8 +656,11 @@
 
    `fz-grid` (issue #371) gates step-toward's movement the same way
    physics/try-move gates the player: nil (legacy callers, flat worlds)
-   is a no-op so pre-#371 chase behaviour is unchanged."
-  [e grid pgrid fz-grid ^float player-x ^float player-y ^float dt ^float speed all-enemies revive?]
+   is a no-op so pre-#371 chase behaviour is unchanged. `field` is the
+   shared per-frame `chase-dist-field` (#405, nil on flat worlds) that
+   lets the chase route up stairs; `advance` builds it once and threads
+   it through here to `step-toward`."
+  [e grid pgrid fz-grid field ^float player-x ^float player-y ^float dt ^float speed all-enemies revive?]
   (cond
     (:alive e)                (let [;; Per-frame AI pipeline. Order matters:
                                     ;;
@@ -624,7 +705,7 @@
                                                   (let [target (target-pos wandered player-x player-y)
                                                         mul    (or (get type-speed-mul (:type wandered)) 1.0)]
                                                     (if target
-                                                      (step-toward wandered grid fz-grid (:x target) (:y target) dt (php/* speed mul))
+                                                      (step-toward wandered grid fz-grid field (:x target) (:y target) dt (php/* speed mul))
                                                       wandered))
                                                   wandered)
                                     flash'      (php/max 0.0 (php/- (or (:hit-flash-secs wandered) 0.0) dt))]
@@ -674,7 +755,9 @@
    for the LOS observe pass. The 9-arity form additionally carries
    `fz-grid` (issue #371) so enemies get the same step-up rule as the
    player and can chase up stairs; both shorter forms pass `fz-grid`
-   nil, which is a no-op gate (flat worlds / legacy callers).
+   nil, which is a no-op gate (flat worlds / legacy callers). On a
+   tiered world the 9-arity also builds the shared `chase-dist-field`
+   once (#405) so the chase routes to the stairs, not into a tier edge.
 
    `revive?`, when false, freezes every dead enemy in place — used on
    L10 once the boss is down so neither the cyberdemon nor its capped
@@ -684,9 +767,14 @@
   ([es g pg x y delta sp rev?]
    (advance es g pg nil x y delta sp rev?))
   ([es g pg fz x y delta sp rev?]
-   (apply vector
-          (map (fn [e] (tick-one e g pg fz x y delta sp es rev?))
-               es))))
+   ;; #405: one BFS flow-field from the player, shared across every enemy
+   ;; this frame, so a monster routes to the stairs instead of stalling at
+   ;; a tall tier edge. Tiered worlds only (nil fz -> nil field -> the
+   ;; greedy chase, byte-identical); O(cells) once per frame, not per enemy.
+   (let [field (when fz (chase-dist-field g fz (php/intval x) (php/intval y)))]
+     (apply vector
+            (map (fn [e] (tick-one e g pg fz field x y delta sp es rev?))
+                 es)))))
 
 (def scare-trigger-dist
   "World-units. When the nearest alive enemy crosses inbound under this

--- a/tests/core/enemy-test.phel
+++ b/tests/core/enemy-test.phel
@@ -1,8 +1,9 @@
 (ns phel-doom-tests.core.enemy-test
   (:require phel.test :refer [deftest is])
   (:require phel-doom.core.rng :as rng)
-  (:require phel-doom.core.map :refer [fz-step])
-  (:require phel-doom.core.enemy :refer [default-wander-fraction new-enemy promote-wanderers push-back-enemy spawn-enemies spawn-enemies-mixed shoot pierce spread-shoot splash beam-impact advance tick-scare rear-attacker? type-speed-mul vertical-hit?]))
+  (:require phel-doom.core.map :refer [fz-step parse-layout floor-z])
+  (:require phel-doom.core.level :refer [showcase-layout])
+  (:require phel-doom.core.enemy :refer [default-wander-fraction new-enemy promote-wanderers push-back-enemy spawn-enemies spawn-enemies-mixed shoot pierce spread-shoot splash beam-impact advance tick-scare rear-attacker? type-speed-mul vertical-hit? chase-dist-field chase-waypoint]))
 
 (def open-grid
   "Bordered 10x10 open arena, no interior walls."
@@ -284,6 +285,88 @@
   (let [fz  (step-fz [0.0 0.0 (php/* 2.0 fz-step) 0.0 0.0])
         es' (advance [(new-enemy 1.9 1.5)] step-grid nil fz 3.5 1.5 0.5 0.75 true)]
     (is (< (:x (first es')) 2.0))))
+
+;; ---------------------------------------------------------------------
+;; Stair-aware chase routing (issue #405, epic #375). Greedy chase only
+;; tries offsets up to 135 degrees off the straight line at the player,
+;; so a monster pressed against a tall (multi-fz-step) tier face never
+;; finds a stair mouth off to the side - it stalls at the edge. The
+;; per-frame BFS `chase-dist-field` from the player over the one-step-
+;; climbable graph gives each enemy a next-waypoint cell, so it routes to
+;; the stairs and climbs. Tiered worlds only; flat worlds keep greedy
+;; (guarded byte-identical by every advance test above, all nil-field).
+;; ---------------------------------------------------------------------
+
+(deftest test-chase-field-routes-around-a-tall-tier-face
+  ;; Showcase: player on the 0.75 platform (cell 10,6); an enemy on the
+  ;; ground east of it (cell 14,6) is one cell from the platform's tall
+  ;; east face (13,6 = 0.75, a 3-fz-step rise = impassable). The field
+  ;; must send it to a DIFFERENT neighbour (toward the south stair mouth),
+  ;; never straight west into the face the greedy chase would pick.
+  (let [{:keys [grid fz-grid]} (parse-layout showcase-layout)
+        field                  (chase-dist-field grid fz-grid 10 6)
+        wp                     (chase-waypoint field grid fz-grid 14 6)
+        w                      (:w field)]
+    (is (php/array_key_exists (php/+ (php/* 6 w) 13) (:dist field))
+        "the tier-face cell (13,6) IS in the field - reachable across the platform")
+    (is (not (nil? wp))
+        "the grounded enemy has a routed path to the player")
+    (is (not= wp [13 6])
+        "the waypoint never steps into the impassable tier face (greedy's choice)")))
+
+;; A tier trap greedy provably CANNOT escape: the enemy sits in a 1-wide
+;; shaft directly south of a 0.75 platform cliff; its only open exit is
+;; due south (180 degrees from the northward player), and greedy's offset
+;; cascade tops out at 135 degrees, so greedy stalls forever. The stair
+;; up to the platform is reached only by going south, around, and up.
+(def trap-grid
+  [[1 1 1 1 1 1 1 1]
+   [1 0 0 0 0 0 0 1]
+   [1 0 1 0 1 0 0 1]
+   [1 0 1 0 1 0 0 1]
+   [1 0 1 0 1 0 0 1]
+   [1 0 1 0 1 0 0 1]
+   [1 0 1 0 1 0 0 1]
+   [1 0 0 0 0 0 0 1]
+   [1 1 1 1 1 1 1 1]])
+(def trap-fz
+  ;; col 3 shaft: rows 2,3 = stair (.25,.5) up from the top corridor to
+  ;; the rows 4,5 platform (.75); row 6 is the grounded enemy, walled off
+  ;; from a direct climb by the .75 cliff at (3,5).
+  (let [q fz-step h (php/* 2.0 fz-step) f (php/* 3.0 fz-step)]
+    [[0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0]
+     [0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0]
+     [0.0 0.0 0.0 q   0.0 0.0 0.0 0.0]
+     [0.0 0.0 0.0 h   0.0 0.0 0.0 0.0]
+     [0.0 0.0 0.0 f   0.0 0.0 0.0 0.0]
+     [0.0 0.0 0.0 f   0.0 0.0 0.0 0.0]
+     [0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0]
+     [0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0]
+     [0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0]]))
+
+(deftest test-advance-escapes-180-degree-tier-trap-and-climbs
+  ;; Player on the platform (3.5, 4.5); enemy in the shaft below (3.5, 6.5).
+  ;; Greedy would press north into the cliff and never step due-south, so
+  ;; it stalls. The flow-field routes it SOUTH first (a move greedy can
+  ;; never make), then around and up the stair to the player's tier.
+  (let [step    (fn [es n]
+                  (loop [es es i 0]
+                    (if (php/>= i n) es
+                        (recur (advance es trap-grid nil trap-fz 3.5 4.5 0.05 3.0 true) (php/+ i 1)))))
+        early   (first (step [(new-enemy 3.5 6.5)] 8))
+        climbed (first (step [(new-enemy 3.5 6.5)] 800))]
+    (is (php/> (:y early) 6.5)
+        "routes SOUTH away from the northward player - a move greedy's <=135deg cascade cannot make")
+    (is (php/> (floor-z trap-fz (php/intval (:x climbed)) (php/intval (:y climbed))) 0.0)
+        "eventually climbs onto the stair/platform to reach the player")))
+
+(deftest test-advance-greedy-fallback-on-flat-world-still-chases
+  ;; Byte-identity sentinel: with a nil fz-grid the field is never built,
+  ;; so step-toward takes the pre-#405 greedy heading. A flat chase still
+  ;; closes on the player (mirrors test-advance-moves-enemy-toward-player,
+  ;; here via the 9-arity with fz-grid nil).
+  (let [es' (advance [(new-enemy 5.0 5.0)] open-grid nil nil 8.0 5.0 0.5 0.75 true)]
+    (is (php/> (:x (first es')) 5.0) "flat 9-arity chase still advances toward the player")))
 
 (deftest test-advance-leaves-dead-enemies-untouched
   (let [es' (advance [{:x 5.0 :y 5.0 :alive false}] open-grid 8.0 5.0 0.5 0.75 true)]


### PR DESCRIPTION
## 📚 Description

Enemies bunched against a raised platform's tall edge and stalled instead of walking to the staircase and climbing to reach a player on a higher tier (#405). The chase was a greedy angle-offset walk (offsets up to ±135° off the straight line at the player), so a monster pressed against a tall multi-`fz-step` tier face never found a stair mouth off to the side.

## 🔖 Changes

- `advance` builds one BFS `chase-dist-field` per frame from the player over the one-`fz-step`-climbable cell graph (reverse-edge flood, same climb gate as `step-clears?`); `step-toward` heads toward `chase-waypoint` - the climbable neighbour nearest the player - so the chase routes AROUND the ledge to the stairs and climbs.
- Field built once and shared by every enemy (O(cells), not per-enemy), tiered worlds only. Flat worlds build no field and keep the greedy chase byte-identical (full existing chase suite green, all nil-field).
- New deterministic tests: routing avoids the impassable tier face, and an end-to-end climb out of a 180°-exit tier trap greedy provably cannot escape. `docs/monsters.md` + CHANGELOG updated.

Closes #405