### PR TITLE
feat(combat): screen-shake on heavy-weapon fire + blast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 - View / head bob while walking (#411): opt-in **View bob** setting (0-100%, off by default) nods the whole scene on a distance-driven walk cycle so moving reads as walking. Cosmetic, never moves where a shot lands; byte-identical at rest.
 - Weapon idle bob + sway while walking (#412): the first-person gun dips on each footfall and sways on the **View bob** walk cycle. Off by default, byte-identical at rest.
 - Weapon-fire extralight (#413): firing briefly brightens surrounding walls, a muzzle-light stand-in. Rides the near-death haze scalar, can't overlap the red damage flash; not firing is byte-identical.
+- Screen-shake on heavy weapons (#414): the shake that fired only on damage taken now also kicks when you launch or detonate a splash weapon. The kick scales with splash-radius, so the BFG (3.0) shakes harder than the rocket (2.0), and a connecting blast rumbles harder than a whiff. Hitscan weapons never shake.
 
 ### Changed
 

--- a/docs/combat.md
+++ b/docs/combat.md
@@ -11,6 +11,9 @@ Hitscan + damage timing + i-frames. `src/core/combat.phel`. Pure: no side effect
 | `shot-knockback-dist` | 1.0 | Push distance per wounding hit |
 | `touch-damage-dist` | 0.7 | Contact damage range |
 | `iframe-seconds` | 1.0 | Post-hit invulnerability window |
+| `shake-damage-secs` | 0.25 | Screen-shake on taking a hit |
+| `shake-fire-secs` | 0.08 | Screen-shake base for a splash-weapon launch (x splash-radius/2) |
+| `shake-blast-secs` | 0.16 | Screen-shake base for a connecting splash blast (x splash-radius/2) |
 | `fire-anim-seconds` | 0.13 | Muzzle flash visibility |
 | `fx-ttl-seconds` | 0.7 | Blood splatter lifetime |
 | `flash-seconds` | 0.05 | White impact jolt |

--- a/docs/state.md
+++ b/docs/state.md
@@ -45,6 +45,7 @@ Pure data shapes that every other module operates on. `src/core/state.phel`.
  :kills      <int>
  :lives      <int, 0..max-lives>
  :iframes    <float seconds>  ; post-hit invulnerability
+ :shake-secs <float seconds>  ; screen-shake kick (damage + heavy-weapon fire/blast)
  :fire-anim  <float seconds>  ; muzzle flash visibility
  :intro-secs <float seconds>  ; level intro splash countdown
  :flash-secs <float seconds>  ; 1-frame white impact flash
@@ -135,6 +136,7 @@ Float-seconds countdowns on the world, decayed by `decay-timers` in `core/combat
 | Timer | Set by | Drives |
 |---|---|---|
 | `:iframes` | `take-damage` (1.0s) | Red palette flush + immunity window |
+| `:shake-secs` | `take-damage` (0.25s), heavy-weapon fire/blast (splash-radius-scaled) | Cursor-home offset screen-shake |
 | `:flash-secs` | `take-damage` (0.05s) | 1-frame all-white impact |
 | `:fire-anim` | `fire-shot` (0.09s) | Muzzle flash visibility |
 | `:intro-secs` | `build-world` (1.5s) | "LEVEL N · NAME" splash overlay |

--- a/src/commands/play.phel
+++ b/src/commands/play.phel
@@ -454,6 +454,7 @@
    :armor       (:armor world)
    :max-lives   max-lives
    :iframes     (:iframes world)
+   :shake-secs  (:shake-secs world)
    :fire-anim   (:fire-anim world)
    ;; Crosshair hit-marker FX (issue #201): {:kill? :ttl} or nil. Set in
    ;; the combat step on a connecting shot, decayed each frame.

--- a/src/core/combat.phel
+++ b/src/core/combat.phel
@@ -68,6 +68,23 @@
    multiple lives across consecutive frames."
   1.0)
 
+(def shake-damage-secs
+  "Screen-shake duration when the player takes a hit. Matches the old
+   iframe-derived jolt (the first ~0.25s of the i-frame window) so the
+   damage feel is unchanged now that shake is its own timer (#414)."
+  0.25)
+
+(def shake-fire-secs
+  "Base screen-shake for launching a splash weapon (rocket/BFG) that
+   whiffs. Scaled by the weapon's :splash-radius so the BFG kicks harder
+   than the rocket."
+  0.08)
+
+(def shake-blast-secs
+  "Base screen-shake when a splash weapon's blast connects - the felt
+   kick of an explosion. Scaled by :splash-radius like the launch kick."
+  0.16)
+
 (def fire-anim-seconds
   "Visibility duration of the recoil kick + muzzle flash + tracer after a
    shot. Long enough that the gun's bounce reads even if the frame rate
@@ -341,6 +358,12 @@
   [world k ^float dt]
   (php/max 0.0 (php/- (or (get world k) 0.0) dt)))
 
+(defn- ^:pure add-shake
+  ;; Kick the screen-shake timer, keeping whichever is longer so a fresh
+  ;; jolt never cuts an in-progress rumble short.
+  [world ^float secs]
+  (assoc world :shake-secs (php/max (or (:shake-secs world) 0.0) secs)))
+
 (defn- stamp-hit-fx
   ;; Stamp the crosshair hit-marker for a connecting shot: a kill marker
   ;; when `killed?`, else a wound marker, both lit for hit-marker-seconds.
@@ -373,6 +396,7 @@
   (let [streak-secs' (decay-timer world :streak-secs dt)]
     (assoc world
            :iframes               (decay-timer world :iframes dt)
+           :shake-secs            (decay-timer world :shake-secs dt)
            :fire-anim             (decay-timer world :fire-anim dt)
            :intro-secs            (decay-timer world :intro-secs dt)
            :flash-secs            (decay-timer world :flash-secs dt)
@@ -533,7 +557,7 @@
                       (update :lives (fn [l] (php/max 0 (php/- l dmg))))
                       (update :damage-taken (fn [d] (php/+ (or d 0) lost)))))]
     (push-sfx
-     (assoc (knockback damaged att)
+     (assoc (add-shake (knockback damaged att) shake-damage-secs)
             :iframes    iframe-seconds
             :flash-secs flash-seconds
             :hurt-side  (attacker-side att (:x p) (:y p) (:angle p))
@@ -912,12 +936,18 @@
         ;; Cosmetic flying projectile: a green BFG ball or a rocket.
         tracered     (spawn-shot-tracer juiced
                                         (if (php/=== (:weapon world) :bfg) :bfg-ball :rocket)
-                                        ix iy)]
+                                        ix iy)
+        ;; Felt kick (#414): the launch alone rumbles; a connecting blast
+        ;; rumbles harder. Both scale by splash-radius so the BFG (3.0)
+        ;; out-shakes the rocket (2.0).
+        kicked       (add-shake tracered
+                                (php/* (if killed? shake-blast-secs shake-fire-secs)
+                                       (php// radius 2.0)))]
     ;; bfg has no wound-only signal (splash returns just a kill count), so
     ;; a kill is the hit proxy: a killing blast attenuates by the impact
     ;; distance, a wall hit / whiff plays at full volume.
     (enqueue-shot-sfx
-     (apply-heat (let [bw (push-blood-fx (assoc tracered :fire-anim fire-anim-seconds) hit-pos
+     (apply-heat (let [bw (push-blood-fx (assoc kicked :fire-anim fire-anim-seconds) hit-pos
                                          (when killed? (corpse-type-at woken hit-pos)))]
                    ;; bfg has no wound-only signal, so a kill is the hit
                    ;; proxy for the marker too (no marker on a whiff).

--- a/src/core/state.phel
+++ b/src/core/state.phel
@@ -163,6 +163,7 @@
     :streak-secs 0.0
     :lives     max-lives
     :iframes     0.0
+    :shake-secs  0.0
     :fire-anim   0.0
     :intro-secs  0.0
     :flash-secs  0.0

--- a/src/io/render/main.phel
+++ b/src/io/render/main.phel
@@ -2371,15 +2371,15 @@
    the full-screen clear that would otherwise flicker each frame.
    While :flash-secs > 0 the whole viewport flashes white — a 1-frame
    impact jolt that lands before the red i-frame wash. Screen-shake:
-   the first ~0.25s of the i-frame window offsets the cursor-home
-   anchor by ±1 col so the next frame paints one cell off, reading
-   as a snap-shake on damage. When :debug? is set, also samples
+   while :shake-secs > 0 the cursor-home anchor is offset by up to 2 cols
+   so the next frame paints a cell off, reading as a snap-shake. The
+   timer is kicked by taking a hit and by firing / detonating a heavy
+   splash weapon (#414). When :debug? is set, also samples
    microtime around `frame->string` and updates `perf-snapshot` so the
    next frame's HUD can paint the F3 overlay; the work is gated so
    the off path pays nothing beyond a single key read."
   [world stats cols rows]
-  (let [iframes (or (get stats :iframes) 0.0)
-        shake?  (php/> iframes 0.75)
+  (let [shake?  (php/> (or (get stats :shake-secs) 0.0) 0.0)
         t       (or (get stats :game-time) 0.0)
         debug?  (get stats :debug?)
         shake-x (if shake?

--- a/tests/core/combat-test.phel
+++ b/tests/core/combat-test.phel
@@ -1293,3 +1293,51 @@
   ;; haze-shift is an int index into the shade table; the extralight
   ;; subtrahend must be too, not a float.
   (is (php/is_int (fire-extralight fire-anim-seconds fire-anim-seconds))))
+
+;; ---------------------------------------------------------------------
+;; Screen-shake (#414): a dedicated :shake-secs timer kicked by taking a
+;; hit AND by firing / detonating a heavy (splash) weapon.
+
+(deftest test-shake-kicked-on-damage-taken
+  (let [w  {:lives 10 :armor 0 :player (new-player 5.0 5.0 0.0)}
+        w1 (hit-player-at w 6.0 5.0 3)]
+    (is (php/> (or (:shake-secs w1) 0.0) 0.0) "taking a hit kicks the screen-shake timer")))
+
+(deftest test-shake-kicked-on-bfg-fire
+  (let [w1 (fire-shot (assoc (boss-world) :weapon :bfg :owned-weapons #{:pistol :bfg}))]
+    (is (php/> (or (:shake-secs w1) 0.0) 0.0) "firing the BFG kicks the screen")))
+
+(deftest test-shake-kicked-on-rocket-fire
+  (let [w1 (fire-shot (assoc (boss-world) :weapon :rocket :owned-weapons #{:pistol :rocket}))]
+    (is (php/> (or (:shake-secs w1) 0.0) 0.0) "firing a rocket kicks the screen")))
+
+(deftest test-bfg-shakes-harder-than-rocket
+  ;; Kick scales with :splash-radius, so the BFG (3.0) out-shakes the
+  ;; rocket (2.0): the heavier weapon reads as heavier.
+  (let [bfg    (fire-shot (assoc (boss-world) :weapon :bfg :owned-weapons #{:pistol :bfg}))
+        rocket (fire-shot (assoc (boss-world) :weapon :rocket :owned-weapons #{:pistol :rocket}))]
+    (is (php/> (:shake-secs bfg) (:shake-secs rocket)) "BFG kick outlasts the rocket kick")))
+
+(deftest test-no-shake-on-plain-hitscan-fire
+  ;; A non-splash weapon (boss-world's default shotgun) has no launch or
+  ;; blast kick.
+  (let [w1 (fire-shot (boss-world))]
+    (is (= 0.0 (or (:shake-secs w1) 0.0)) "shotgun fire does not shake the screen")))
+
+(deftest test-shake-decays-through-damage-step
+  ;; damage-step routes through decay-timers, the sole consumer of the
+  ;; timer. A non-round dt so the test exercises the subtraction, not a
+  ;; coincidental multiple.
+  (let [base (assoc (new-world [[1 1 1] [1 0 1] [1 1 1]] (new-player 1.5 1.5 0.0))
+                    :lives 5 :iframes 0.0 :enemies [] :shake-secs 0.25)
+        w1   (damage-step base 0.1)]
+    (is (php/< (:shake-secs w1) 0.25) "shake timer ticks down each frame")
+    (is (php/>= (:shake-secs w1) 0.0) "and clamps at zero")))
+
+(deftest test-shake-refresh-keeps-the-longer-value
+  ;; A fresh, smaller kick must not cut an in-progress rumble short:
+  ;; add-shake takes the max. Pre-load a big shake, fire a smaller blast
+  ;; kick, and confirm the big one survives (overwrite would drop it).
+  (let [w0 (assoc (boss-world) :weapon :bfg :owned-weapons #{:pistol :bfg} :shake-secs 0.5)
+        w1 (fire-shot w0)]
+    (is (= 0.5 (:shake-secs w1)) "the larger in-progress shake is kept")))


### PR DESCRIPTION
## 📚 Description

The built screen-shake previously fired only on damage taken. This wires it to heavy weapons: launching or detonating a splash weapon (rocket/BFG) now kicks the screen so heavy weapons have felt weight.

## 🔖 Changes

- New dedicated `:shake-secs` timer (was derived from the `:iframes` damage window); decayed in `decay-timers`, read by `render!`.
- Kick set on taking a hit (0.25s, matches the old feel) and on firing/detonating a splash weapon, scaled by `:splash-radius` (BFG 3.0 out-shakes rocket 2.0); a connecting blast rumbles harder than a whiff. Hitscan weapons never shake.
- `add-shake` keeps the longer of the current/new timer so a fresh kick never cuts an in-progress rumble short.
- Tests for each trigger + decay + the keep-longer rule; docs (`state.md`, `combat.md`) + CHANGELOG.

Closes #414