### PR TITLE
fix: reject corrupt save/demo payloads as a friendly miss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 
 ### Fixed
 
+- Corrupt save / demo files fail as a friendly miss instead of crashing: a hand-edited or truncated save that is valid JSON but the wrong shape (missing `world`, a scalar, a truncated map) used to throw mid-game on load (F9) or hand back a grid-less junk world. `savestring->world` now returns `nil` (the documented "NO SAVE" path) unless the decoded value is a map carrying `:grid`, and `decode` stays total on a malformed payload; a `--demo` file with a non-array `frames` is likewise rejected as `nil`. Valid saves round-trip byte-for-byte as before.
 - Enemy counts rebalanced by room size + threat weight (HP x per-hit damage): L5 no longer stacks five boss-tier cyberdemons (now 2 + imp fodder) that out-gunned the L10 boss; sparse large halls (L4, L6, L9) populated so difficulty ramps smoothly. L1 + L10 untouched.
 - L2 demon room no longer a bare box: scatters random interior wall pillars (`:walls`) for cover + per-run variety, pocket-sealed into one connected region with a single exit on a random reachable wall (no dead-ends).
 - Sub-pixel auto-off on macOS Terminal.app (#332): Apple Terminal draws `▀` with row seams, so startup defaults Sub-pixel off on `Apple_Terminal` until the player saves a choice; the in-game toggle and `PHEL_DOOM_SUBPIXEL=1` still force it on.

--- a/src/io/demo.phel
+++ b/src/io/demo.phel
@@ -98,9 +98,17 @@
   (let [d (php/json_decode s true)]
     (if (and (php/is_array d)
              (php/=== demo-version (php/aget d "version")))
-      {:seed   (php/aget d "seed")
-       :frames (mapv (fn [p] [(php/aget p 0) (php/aget p 1)])
-                     (php/aget d "frames"))}
+      (let [fr (php/aget d "frames")]
+        ;; A present-but-non-array "frames" is malformed: mapv over a
+        ;; scalar throws. Reject it as nil per the docstring instead of
+        ;; crashing the --demo launch. A missing "frames" (nil) stays an
+        ;; empty replay, unchanged.
+        (if (and (some? fr) (not (php/is_array fr)))
+          nil
+          {:seed   (php/aget d "seed")
+           :frames (if (php/is_array fr)
+                     (mapv (fn [p] [(php/aget p 0) (php/aget p 1)]) fr)
+                     [])}))
       nil)))
 
 ;; --- file IO --------------------------------------------------------

--- a/src/io/savegame.phel
+++ b/src/io/savegame.phel
@@ -62,9 +62,17 @@
         (php/=== tag "$k") (keyword (php/aget x 1))
         (php/=== tag "$s") (set (map decode (php/aget x 1)))
         (php/=== tag "$m") (let [o (php/aget x 1)]
-                             (reduce (fn [m k] (assoc m (keyword k) (decode (php/aget o k))))
-                                     {}
-                                     (php/array_keys o)))
+                             ;; A well-formed "$m" carries a PHP-array payload.
+                             ;; A hand-corrupted / truncated save can drop it
+                             ;; (["$m"] with no index 1 -> nil); guard so decode
+                             ;; stays total (array_keys nil would throw) and a
+                             ;; malformed map degrades to {} for the caller to
+                             ;; reject, rather than crashing the load.
+                             (if (php/is_array o)
+                               (reduce (fn [m k] (assoc m (keyword k) (decode (php/aget o k))))
+                                       {}
+                                       (php/array_keys o))
+                               {}))
         :else              (mapv decode x)))
     x))
 
@@ -84,8 +92,9 @@
 
 (defn savestring->world
   "Pure: parse a save string back into a world (pgrid rebuilt, fog
-   reset, input hold counters zeroed). Returns nil on malformed JSON or
-   a version mismatch so the caller can surface a friendly miss.
+   reset, input hold counters zeroed). Returns nil on malformed JSON, a
+   version mismatch, or a corrupt `world` payload (missing / wrong-shaped
+   - the file is user-editable) so the caller can surface a friendly miss.
    `:moves` is always reset to `empty-moves`: new saves don't carry it,
    and saves written before the seconds-based counters stored int FRAME
    counts (e.g. :fwd 15) that the dt-decay would reinterpret as ~15
@@ -94,10 +103,19 @@
   (let [data (php/json_decode s true)]
     (if (and (php/is_array data)
              (php/=== save-version (php/aget data "version")))
-      (-> (decode (php/aget data "world"))
-          (assoc :visited (php/array))
-          (assoc :moves empty-moves)
-          (rebuild-pgrid))
+      (let [w (decode (php/aget data "world"))]
+        ;; A real world decodes to a map carrying a :grid. A missing /
+        ;; scalar / vector "world" (corrupt or truncated save) decodes to
+        ;; nil / a scalar / a vector - threading that through assoc +
+        ;; rebuild-pgrid would either crash or fabricate a grid-less junk
+        ;; world that detonates later. Reject it as a friendly miss (nil),
+        ;; matching this fn's documented contract.
+        (if (and (map? w) (some? (:grid w)))
+          (-> w
+              (assoc :visited (php/array))
+              (assoc :moves empty-moves)
+              (rebuild-pgrid))
+          nil))
       nil)))
 
 (defn- save-dir []

--- a/tests/io/demo-test.phel
+++ b/tests/io/demo-test.phel
@@ -17,6 +17,11 @@
     (php/aset o "frames" (php/array))
     (is (= nil (demo/json->demo (php/json_encode o))))))
 
+(deftest test-json-demo-rejects-nonarray-frames
+  ;; version matches but "frames" is a scalar (corrupt demo file): must be
+  ;; nil (documented "malformed"), not a crash from mapping over a scalar.
+  (is (= nil (demo/json->demo "{\"version\":1,\"seed\":7,\"frames\":5}"))))
+
 (deftest test-record-mode-flags
   (demo/start-record! 1)
   (is (demo/recording?))

--- a/tests/io/savegame-test.phel
+++ b/tests/io/savegame-test.phel
@@ -130,5 +130,21 @@
   (is (= nil (savestring->world "not json at all")))
   (is (= nil (savestring->world ""))))
 
+(deftest test-load-rejects-corrupt-world
+  ;; JSON parses AND the version matches, but the "world" payload is the
+  ;; wrong shape (hand-corrupted / truncated save - the file is explicitly
+  ;; user-editable). Each must surface as a friendly miss (nil), never a
+  ;; crash or a grid-less junk world, matching savestring->world's contract.
+  (is (= nil (savestring->world "{\"version\":1}")) "missing world -> nil")
+  (is (= nil (savestring->world "{\"version\":1,\"world\":5}")) "scalar world -> nil")
+  (is (= nil (savestring->world "{\"version\":1,\"world\":[1,2]}")) "vector world -> nil")
+  (is (= nil (savestring->world "{\"version\":1,\"world\":[\"$m\",{\"kills\":[\"$k\",\"imp\"]}]}"))
+      "map world without :grid -> nil"))
+
+(deftest test-decode-tolerates-truncated-map-tag
+  ;; A "$m" tag whose payload array was dropped must decode to {} rather
+  ;; than throwing (array_keys on nil), so a corrupt save loads as a miss.
+  (is (= {} (decode (php/array "$m")))))
+
 (deftest test-save-version-is-pinned
   (is (= 1 save-version)))


### PR DESCRIPTION
## 📚 Description

Two save/replay file decoders promised a friendly `nil` in their docstrings but actually crashed (or returned a mis-shaped world) on valid-JSON-but-wrong-shape input. Since there is no `try`/`catch` anywhere in `src/`, those were live crashes: a hand-edited or truncated save under `~/.phel-doom` would throw mid-game on load (F9) instead of showing the "NO SAVE" cue, and a missing `world` key silently handed back a grid-less junk world that detonated later, far from the cause.

Behavior change is confined to the error path: valid saves and demos round-trip byte-for-byte as before. Rendering is untouched (golden frame hashes unchanged).

## 🔖 Changes

- `src/io/savegame.phel`: `decode` hardened to stay total on a malformed `$m` payload; `savestring->world` now returns `nil` unless the decoded value is a map carrying `:grid`, matching the documented contract.
- `src/io/demo.phel`: `json->demo` rejects a present-but-non-array `frames` as `nil` (the documented nil-fallback to normal play); a missing `frames` still yields an empty replay unchanged.
- Tests: +6 regression assertions across `tests/io/savegame-test.phel` and `tests/io/demo-test.phel` (missing/scalar/vector/truncated-map world, decode totality, non-array frames).
- `CHANGELOG.md`: entry under `## [Unreleased]` → Fixed.

Verification: `composer ci` green (format-check, lint, **3166 tests / 0 failed**, build); the four golden md5 hashes in `tests/io/render-cache-test.phel` are byte-identical to `main` (only cold serialization paths touched).

Found and fixed during a parallel code-quality sweep; the six behavior-preserving refactor lanes ship separately in #438.
