### PR TITLE
ref: #439 follow-up - dead consts, doc-sync, harden layering guard

### DIFF
--- a/docs/combat.md
+++ b/docs/combat.md
@@ -20,7 +20,6 @@ Hitscan + damage timing + i-frames. `src/core/combat.phel`. Pure: no side effect
 | `heat-per-shot` | 0.30 | Overheat per shot (dormant - no weapon overheats) |
 | `jam-seconds` | 0.7 | Jam lockout duration (dormant) |
 | `mag-size` | 10 | Pistol default magazine capacity |
-| `max-reserve` | 50 | Pistol default reserve cap |
 | `reload-cooldown-seconds` | 1.2 | Pistol reload duration |
 | `armory-reserve` | 9999 | --armory cheat reserve cap |
 

--- a/docs/rendering.md
+++ b/docs/rendering.md
@@ -81,7 +81,7 @@ Top:    \e[48;5;<wall>;38;5;<sky-at-row>m▀      (wall BG, sky FG)
 Bottom: \e[48;5;<floor-at-row>;38;5;<wall>m▀    (floor BG, wall FG)
 ```
 
-Sky and floor codes are sampled from gradients at the seam row, not flat constants. Flat codes produced dark dots. `build-horizon-gradient-codes` and `build-themed-gradient-codes` pre-bake code-only twins of the string gradients per frame.
+Sky and floor codes are sampled from gradients at the seam row, not flat constants. Flat codes produced dark dots. `build-horizon-gradient` (fed a code table) and `build-themed-gradient-codes` pre-bake code-only twins of the string gradients per frame.
 
 These whole-cell edge bands apply to non-textured columns (boss door, blood-band, glyph-mode enemy columns, or with textures/subpixel off). Textured columns - stone walls and doors alike - trace their wall top/bottom at sub-row precision instead - see the next section.
 
@@ -172,7 +172,7 @@ Door texels are xterm-256 colour-CUBE codes (not grayscale ramp), which two piec
 - `tex-fade-table` fog already fades cube codes hue-true (toward the neutral grey haze tint via `fade-256-fog`, or toward black under `PHEL_DOOM_FLAT_FOG=1`).
 - The sub-row seam accents darken through `seam-darken-16/-8/-5` LUTs (in `frame_math`) instead of plain `code - n` arithmetic: subtracting from a cube code jumps hue (amber 166 - 16 = green 150). For grayscale-ramp codes the LUTs reproduce the old subtraction exactly.
 
-Door fog is the wall formula with two nav-cue exceptions: the level floors at 8 (a door never fades to black) and ignores the near-death haze. The door rides the fog level steady-brighter (`door-tex-boost`, a constant +3 levels) instead of swapping paint strings. The old 4 rad/s sin-wave throb was dropped for a calmer 3D view (see [Calm 3D view](#calm-3d-view-no-decorative-blinks)); the door stays at its bright frame, which keeps it findable down the arena without the flashing. Blood-band door columns keep the flat striped `door-shade` (the seam mixer's sky/floor codes are grayscale-only), as do glyph-enemy columns and all-flat fallback modes.
+Door fog is the wall formula with two nav-cue exceptions: the level floors at 8 (a door never fades to black) and ignores the near-death haze. The door rides the fog level steady-brighter (`door-tex-boost`, a constant +3 levels) instead of swapping paint strings. The old 4 rad/s sin-wave throb was dropped for a calmer 3D view (see [Calm 3D view](#calm-3d-view-no-decorative-blinks)); the door stays at its bright frame, which keeps it findable down the arena without the flashing. Blood-band door columns keep the flat striped `door-shade-now` (the seam mixer's sky/floor codes are grayscale-only), as do glyph-enemy columns and all-flat fallback modes.
 
 ## Textured floor (floor-casting)
 

--- a/docs/state.md
+++ b/docs/state.md
@@ -54,7 +54,7 @@ Pure data shapes that every other module operates on. `src/core/state.phel`.
  :game-time  <float seconds>  ; pause-aware clock for render pulses
  :bob-phase  <float radians>  ; head-bob walk cycle (#411); 0.0 at rest, advanced by distance in apply-physics
  :mag           <int 0..mag-size>     ; rounds in the loaded magazine
- :ammo-reserve  <int 0..max-reserve>  ; spare ammo pool; drained on reload
+ :ammo-reserve  <int 0..reserve-cap>  ; spare ammo pool (per-weapon cap); drained on reload
  :reload-cooldown  <float seconds>    ; drives the reload drop animation
  :empty-click-secs <float seconds>    ; dry-fire CLICK prompt timer
  :heat          <float 0..1>          ; pistol heat; ≥ 1 triggers jam

--- a/src/io/render/frame_math.phel
+++ b/src/io/render/frame_math.phel
@@ -693,7 +693,7 @@
    code strings (e.g. \"237\") instead of full SGR paint cells.
    Used to sample the floor gradient code at a specific row so the ▀
    half-block edge cell can blend the exact floor shade of that row
-   into the bottom-half BG, eliminating the flat floor-code seam.
+   into the bottom-half BG, eliminating the flat floor seam.
    Optional `horizon-offset` (scene rows, default 0) shears the horizon
    for look up/down; pr=0 leaves output unchanged."
   [^int vh ^int base-code stripe? & [horizon-offset]]

--- a/src/io/render/main.phel
+++ b/src/io/render/main.phel
@@ -73,11 +73,6 @@
    texture, sampled per wall cell by (u, v)."
   (:px wall-tex))
 
-(def wall-tex-w
-  "Wall texture width/height (square, 64). Both the U and V sample wrap
-   into [0, wall-tex-w)."
-  (:w wall-tex))
-
 (def floor-tex-mid
   "Mid-grey the floor texture is contrast-compressed toward (~texture mean)."
   242)

--- a/src/io/render/palette.phel
+++ b/src/io/render/palette.phel
@@ -81,18 +81,10 @@
          :door-red       (mk (:red t) "▌")
          :door-yellow    (mk (:yellow t) "▌")}))))
 
-;; Color CODES used for half-block edge anti-aliasing. The outer
-;; column loop composes 'top edge' and 'bottom edge' cells by
-;; combining a wall code with the sky / floor code into a single
-;; ▀ glyph (upper-half block — FG paints top half, BG paints
-;; bottom half). The eye reads it as a sub-cell wall boundary
-;; instead of a staircase.
-(def floor-code       "239")
-
 (def floor-theme-codes
   "Per-theme floor gradient base code: the bright screen-edge shade that
    `build-themed-gradient` fades to black at the horizon. `:base` is the
-   original neutral grey (matches `floor-code`); each other key tints one
+   original neutral grey (239); each other key tints one
    episode's ground so a level reads as a distinct place. The gradient
    LUT is rebaked only when the base changes (on level load), so per-level
    themes cost nothing on the hot path (#417)."

--- a/tests/core/combat-test.phel
+++ b/tests/core/combat-test.phel
@@ -5,7 +5,7 @@
   (:require phel-doom.core.enemy :refer [new-enemy])
   (:require phel-doom.core.loot :refer [pick-loot-weapon roll-loot-kind])
   (:require phel-doom.core.combat
-            :refer [aim-angle-offset arm-berserk armory-reserve closest-attacker attacker-side attacker-octant berserk? berserk-damage-mul berserk-melee-mul berserk-mul-for berserk-seconds can-fire? apply-heat damage-step empty-click-seconds enemy-hit-damage fire-anim-seconds fire-extralight fire-shot hit-damage-for hit-player-at hit-stop-for hit-stop-tough-seconds hit-stop-boss-seconds invuln? invuln-seconds knockback mag-size muzzle-extralight-steps muzzle-flash-fraction player-immune? push-sfx reload reloading? tick-armory tick-shooting]))
+            :refer [aim-angle-offset arm-berserk armory-reserve closest-attacker attacker-side attacker-octant berserk? berserk-damage-mul berserk-melee-mul berserk-mul-for berserk-seconds can-fire? apply-heat damage-step empty-click-seconds fire-anim-seconds fire-extralight fire-shot hit-damage-for hit-player-at hit-stop-for hit-stop-tough-seconds hit-stop-boss-seconds invuln? knockback mag-size muzzle-extralight-steps muzzle-flash-fraction player-immune? push-sfx reload reloading? tick-armory tick-shooting]))
 
 ;; ---------------------------------------------------------------------
 ;; closest-attacker: selection rule.

--- a/tests/core/difficulty-test.phel
+++ b/tests/core/difficulty-test.phel
@@ -1,6 +1,6 @@
 (ns phel-doom-tests.core.difficulty-test
   (:require phel.test :refer [deftest is])
-  (:require phel-doom.core.difficulty :refer [normalise scale-cfg spec-for])
+  (:require phel-doom.core.difficulty :refer [normalise scale-cfg])
   (:require phel-doom.core.enemies :refer [default-lives-for]))
 
 (deftest test-normalise-defaults-to-normal-on-nil

--- a/tests/core/enemy_ai_test.phel
+++ b/tests/core/enemy_ai_test.phel
@@ -7,8 +7,7 @@
                                             lkp-arrival-dist
                                             apply-pain tick-pain pain-chance-of
                                             pain-stagger-secs default-pain-chance
-                                            type-pain-chance
-                                            attack-spec default-attack-spec
+                                            default-attack-spec
                                             caster-spec caster?
                                             attack-spec-of in-attack-range?
                                             maybe-start-attack tick-attack

--- a/tests/core/projectile-test.phel
+++ b/tests/core/projectile-test.phel
@@ -2,7 +2,7 @@
   (:require phel.test :refer [deftest is])
   (:require phel-doom.core.state :refer [new-world new-player])
   (:require phel-doom.core.projectile
-            :refer [spawn-from-enemies step resolve-hits tick-projectiles tick-tracers hit-radius projectile-ttl spawn-offset]))
+            :refer [spawn-from-enemies step resolve-hits tick-projectiles tick-tracers projectile-ttl spawn-offset]))
 
 ;; A roomy open arena so bolts have floor to travel across. Wall ring,
 ;; floor interior.

--- a/tests/io/palette-test.phel
+++ b/tests/io/palette-test.phel
@@ -41,7 +41,7 @@
 ;; the neutral :base grey so an un-themed level is unchanged.
 
 (deftest test-theme-floor-code-known-theme
-  (is (= 239 (theme-floor-code :base)) ":base is the neutral grey (matches floor-code)")
+  (is (= 239 (theme-floor-code :base)) ":base is the neutral grey (239)")
   (is (= 124 (theme-floor-code :hell)) "a named theme resolves to its own floor code"))
 
 (deftest test-theme-floor-code-unknown-falls-back-to-base

--- a/tools/check-layers.sh
+++ b/tools/check-layers.sh
@@ -1,19 +1,26 @@
 #!/usr/bin/env bash
 # Enforce the io/ -> glue/ -> core/ dependency direction (docs/architecture.md,
-# .claude/rules/io-boundaries.md): core/ must not require io/ or glue/, and
-# glue/ must not require io/. Realizes the "enforceable via (:require ...)
-# inspection" invariant that was previously reviewer-only.
+# .claude/rules/io-boundaries.md): the pure layers never reference a layer above
+# them - core/ references only core/, glue/ only glue//core/, and neither the
+# io/ nor the orchestration (commands/, demo/) layers. Greps whole .phel bodies
+# (not just :require) so qualified refs + :as aliases are caught too; fail-closed.
 set -uo pipefail
+
+# A missing/renamed dir would make grep exit non-zero, which the `if`s below read
+# as "no violation" - silently disarming the guard. Fail loud on a restructure.
+for d in src/core src/glue; do
+  [ -d "$d" ] || { echo "check-layers: expected directory $d not found (restructure?)"; exit 2; }
+done
 
 fail=0
 
-if grep -rnE 'phel-doom\.(io|glue)' src/core/; then
-  echo "LAYERING VIOLATION: src/core/ must not require io/ or glue/ (see above)."
+if grep -rnE --include='*.phel' 'phel-doom\.(io|glue|commands|demo)' src/core/; then
+  echo "LAYERING VIOLATION: src/core/ must reference only core/ (see above)."
   fail=1
 fi
 
-if grep -rnE 'phel-doom\.io' src/glue/; then
-  echo "LAYERING VIOLATION: src/glue/ must not require io/ (see above)."
+if grep -rnE --include='*.phel' 'phel-doom\.(io|commands|demo)' src/glue/; then
+  echo "LAYERING VIOLATION: src/glue/ must not reference io/ or the orchestration layer (see above)."
   fail=1
 fi
 


### PR DESCRIPTION
Follow-up to #439, from a second independent 8-lane review that confirmed #439's changes are sound and caught the residue below. All behavior-preserving; `composer ci` green (format, lint, check-layers, 3161 tests, build).

## Changes
- **Dead code #439 missed** (its sweep was src-only): dead consts `floor-code` (twin of the removed `sky-code`, superseded by `floor-theme-codes :base 239`) + `wall-tex-w`, plus 6 unused `:refer` in test files.
- **Doc-sync**: 4 stale references to symbols #439 deleted (`build-horizon-gradient-codes`, `max-reserve`, `door-shade`) across `rendering.md` / `combat.md` / `state.md` (same-commit doc rule).
- **`check-layers.sh` hardened**: fixed a fail-open bug (a renamed `src/core`/`src/glue` silently self-disarmed the guard), scoped grep to `*.phel`, extended to the orchestration layer. Verified it now fails loud on a simulated `core->io` violation.

## Deferred (unchanged, re-confirmed by the second review)
Palette + enemy stat-table are parallel data not logic dup; overheat subsystem + save back-compat live; catalog-completeness test needs per-type design intent; 3 test-only-public symbols + the hud menu-scaffold dedup want a test-first pass.
