### PR TITLE
ref: adopt phel 0.49 map-invert + reduce-kv

### DIFF
--- a/src/commands/play.phel
+++ b/src/commands/play.phel
@@ -1002,10 +1002,9 @@
    :secrets-found (php/+ (:secrets-found carry) (or (:secrets-found result) 0))
    :secrets-total (php/+ (:secrets-total carry) (or (:secrets-total result) 0))
    :dmg           (php/+ (:dmg carry)           (or (:damage-taken result) 0))
-   :kbw           (let [rkbw (or (:kills-by-weapon result) {})]
-                    (reduce (fn [m w] (assoc m w (php/+ (or (get m w) 0) (get rkbw w))))
-                            (:kbw carry)
-                            (keys rkbw)))})
+   :kbw           (reduce-kv (fn [m w n] (assoc m w (php/+ (or (get m w) 0) n)))
+                             (:kbw carry)
+                             (or (:kills-by-weapon result) {}))})
 
 (defn- carry-on [carry-kills carry-time carry-stats result]
   [(php/+ carry-kills (:kills result))

--- a/src/core/level.phel
+++ b/src/core/level.phel
@@ -1,7 +1,7 @@
 (ns phel-doom.core.level
   (:require phel-doom.core.rng :as rng)
   (:require phel-doom.core.state      :refer [max-backpacks max-lives new-player new-world with-enemies])
-  (:require phel-doom.core.map        :refer [cell-door cell-door-blue cell-door-boss cell-door-red cell-door-yellow count-secrets parse-layout place-exit random-grid random-spawn scatter-walls seed-secrets])
+  (:require phel-doom.core.map        :refer [cell-door lock-cells count-secrets parse-layout place-exit random-grid random-spawn scatter-walls seed-secrets])
   (:require phel-doom.core.enemy      :refer [default-wander-fraction promote-wanderers spawn-enemies-mixed])
   (:require phel-doom.core.enemy-ai   :refer [aggression-for])
   (:require phel-doom.core.enemies    :refer [default-lives-for])
@@ -626,14 +626,12 @@
                                (or (:pickup-mul cfg) 1.0)))))
 
 (defn- lock-cell-for
-  "Map a lock-colour kw to the matching locked-door cell value."
+  "Map a lock-colour kw to the matching locked-door cell value, falling
+   back to a plain door for an unknown colour. Reads map/lock-cells so
+   this direction cannot drift from the cell -> colour direction render
+   and passable? use."
   [colour]
-  (cond
-    (php/=== colour :blue)   cell-door-blue
-    (php/=== colour :red)    cell-door-red
-    (php/=== colour :yellow) cell-door-yellow
-    (php/=== colour :boss)   cell-door-boss
-    :else                    cell-door))
+  (get lock-cells colour cell-door))
 
 (defn- lock-the-door
   "Replace the FIRST cell-door in `grid` with the locked variant for

--- a/src/core/map.phel
+++ b/src/core/map.phel
@@ -74,10 +74,16 @@
    Drives door-lock + passable? + render door tint. `:boss` is a
    synthetic 'colour' — no keycard ever spawns for it; the kw is
    granted automatically by combat when the boss dies."
-  {3 :blue
-   4 :red
-   5 :boss
-   9 :yellow})
+  {cell-door-blue   :blue
+   cell-door-red    :red
+   cell-door-boss   :boss
+   cell-door-yellow :yellow})
+
+(def lock-cells
+  "Inverse of `lock-colours`: keycard kw -> locked-door cell value.
+   Derived, so the two directions cannot drift apart - level.phel used to
+   carry the forward direction as its own hand-written cond."
+  (map-invert lock-colours))
 
 (def default-grid
   "16×16 starter map kept around for deterministic tests."

--- a/src/io/render/main.phel
+++ b/src/io/render/main.phel
@@ -2492,9 +2492,9 @@
    (so the caller can drop the row). end-row-text clips it to the box
    width, so a long loadout never overflows."
   [kbw]
-  (let [m      (or kbw {})
-        kept   (filter (fn [p] (php/> (get p 1) 0))
-                       (map (fn [w] [w (or (get m w) 0)]) (keys m)))
+  (let [kept   (reduce-kv (fn [acc w n] (if (php/> n 0) (conj acc [w n]) acc))
+                          []
+                          (or kbw {}))
         ;; Most-used weapon first, so the width clip drops the least-used
         ;; rather than the headline weapon's count.
         sorted (sort-by (fn [p] (php/- 0 (get p 1))) kept)]

--- a/src/io/savegame.phel
+++ b/src/io/savegame.phel
@@ -36,11 +36,11 @@
 (defn- encode-map [m]
   ;; All world map keys are keywords -> store by name, decode re-kws.
   (php/array "$m"
-             (reduce (fn [o k]
-                       (php/aset o (name k) (encode (get m k)))
-                       o)
-                     (php/array)
-                     (keys m))))
+             (reduce-kv (fn [o k v]
+                          (php/aset o (name k) (encode v))
+                          o)
+                        (php/array)
+                        m)))
 
 (defn encode
   "Pure: Phel value -> JSON-safe PHP structure (tagged for keywords /


### PR DESCRIPTION
## 📚 Description

**There is no phel version to bump** - `composer.json` pins `^0.49` and the lock resolves **v0.49.0**, the latest release (2026-07-22, landed in #436). So this is the feature half: adopting two 0.48/0.49 additions that have real sites here, rather than churning code to name-drop the rest.

## 🔖 Changes

- `map-invert` (0.49): `map/lock-cells` now derives the colour → cell direction from `lock-colours`, replacing `level.phel`'s hand-written 5-arm `cond`. That was a second source of truth for one table - the same defect class as the settings-persistence bug fixed in #441. #439 examined this and left it alone on purpose: Phel's `reduce` yields map *values*, not entries, and there was no `zipmap`, so hand-inverting read worse than the `cond`. `map-invert` removes the objection. `lock-colours` also keys off the cell constants now instead of raw `3`/`4`/`5`/`9`.
- `reduce-kv` (0.48): replaces three `reduce` over `(keys m)` walks that re-looked-up the value they were already iterating - `savegame/encode-map`, the `:kbw` tally in `play/merge-run-stats`, and `render/weapon-kills-line` (which also sheds an `(or … 0)` that could never fire).

**Deliberately not adopted**: `while` would turn `drain-stdin!`'s do-while into a while (its body always runs once today) for no readability win; `random-sample` draws from the unseeded global rng, which would break demo/replay determinism.

No behaviour change; golden frame hashes unchanged. 3191 tests green.

Note for later: `symfony/console` 7.4 → 8.1 is available (major), out of scope here.