### PR TITLE
fix: a death retry keeps the rack you entered the level with

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 
 ## [Unreleased]
 
+### Fixed
+
+- Dying no longer strips your arsenal (#453). Both death-screen retries (`r` fresh map, `R` same seed) restarted the level you died on with the pistol and backpack 0, so an L7 retry met archviles with a starting weapon and no way back up: kill loot only refills weapons you already own, and a level seeded only its own debut weapon, so L8-L10 had nothing on the floor at all. A retry now re-enters with the rack you ENTERED that level carrying - weapons, backpack stack and the gun in hand - while kills, time, lives and ammo still reset. Entry rather than death rack on purpose: weapon-pickup cells are drawn from the run PRNG before the ammo boxes, so rebuilding with a weapon the player grabbed during the fatal attempt would shift every later spawn and break the identical replay `R` promises. Levels also seed the weapons you are owed rather than only their own debut drop - most recent debut first, two at most - so `--level=N` starts with a usable rack too.
+
 ## [0.17.0] - 2026-08-16
 
 ### Added

--- a/docs/game-loop.md
+++ b/docs/game-loop.md
@@ -111,4 +111,6 @@ The pipeline enqueues effects (sfx, hits) into `:sfx` on the world itself; the g
 - `r` (restart, fresh): new PRNG seed, new level sequence.
 - `R` (replay, same): reuse the captured seed, replay identical levels.
 
+Both restart the level you died on, and both carry the loadout back: owned weapons, backpack stack, and the gun in hand (`retry-loadout`). It is the rack you ENTERED the level with, not the one you died holding: weapon-pickup cells are drawn from the run PRNG before the ammo boxes, so rebuilding with a weapon grabbed during the fatal attempt would shift every later spawn and `R` would no longer replay an identical level. A weapon you picked up on that attempt is back on the floor where it was. Ammo does not carry - mags and reserves come back fresh from `build-world`. Kills, time and lives reset, so a retry is a fresh attempt at the level rather than a checkpoint.
+
 Lets the player practice a tough spawn or die-on level. See [input.md](input.md) for key flow and [rendering.md](rendering.md) for render pipeline.

--- a/docs/level-system.md
+++ b/docs/level-system.md
@@ -120,7 +120,7 @@ Per build: grid (hand-authored or random), player spawn + angle, enemies from mi
 - Heart: only if `lives < max-lives`.
 - Armor (50%), berserk (1/8), invuln (1/12), soulsphere (1/10), backpack (L2+, 1/5).
 - 3 armor shards per level.
-- Keycard if locked (not `:boss`); weapon drops if not owned: shotgun (L2), chaingun (L3), chainsaw (L4), rocket (L5), incinerator (L6), BFG (L7).
+- Keycard if locked (not `:boss`). Weapon drops: every weapon whose debut level has passed and the player does not own, most recent debut first, capped at 2 per level. Debuts: shotgun (L2), chaingun (L3), chainsaw (L4), rocket (L5), incinerator (L6), BFG (L7). The level's own debut weapon is by definition the most recent, so the cap never drops it; the rest of the rule covers a player who arrives with an empty rack (`--level=N`, or a retry) and would otherwise find nothing on the floor.
 - Ammo boxes: `max(2, ceil(total_hp / 8))` where `total_hp = sum(count * lives)`.
 
 Stamps: `:enemy` (primary type fallback), `:level-name`, `:difficulty`, `:intro-secs` (1.5s).

--- a/src/commands/play.phel
+++ b/src/commands/play.phel
@@ -1078,6 +1078,32 @@
   [settings]
   (boolean (:minimap settings)))
 
+(defn retry-loadout
+  "What a death-screen retry (`r` / `R`) re-enters the level with: the
+   rack the player ENTERED that level carrying, never the one they died
+   holding (#453).
+
+   Before this, both retry branches recurred with `#{:pistol}` and
+   backpack 0, so dying on L7 restarted L7 with the pistol against
+   archviles - unwinnable, since kill loot only refills weapons already
+   owned (docs/combat.md) and a level seeded only its own debut weapon.
+
+   Entry, not death, for determinism: `build-world` seeds weapon pickups
+   from the owned set and draws their cells from the run's PRNG BEFORE the
+   ammo boxes, so a retry that owned one weapon more would draw one cell
+   fewer and shift every later spawn. `R` promises an identical replay
+   (docs/game-loop.md), and entry values are the ones the level was built
+   from, so rebuilding with them is identical by construction. A weapon
+   grabbed during the fatal attempt is back on the floor where it was.
+
+   Ammo is not carried either: the caller passes a nil weapon-state, so
+   build-world seeds fresh mags and reserves. Kills, time and lives still
+   reset - a retry is a fresh attempt at the level, not a checkpoint."
+  [owned bp-level weapon]
+  {:owned-weapons  (or owned #{:pistol})
+   :backpack-level (or bp-level 0)
+   :weapon         (or weapon :pistol)})
+
 (defn- run-levels
   "Outer loop driving one full run. Each iteration captures a fresh
    PRNG seed before calling build-world so the player can replay the
@@ -1093,7 +1119,9 @@
    refill in combat/tick-armory keeps the pool topped up so every
    weapon stays testable without grinding for boxes. `start-level`
    (from --level / -l) sets where the run begins — 1..num-levels,
-   clamped. Death + retry reset to L1 (the start-level only seeds
+   clamped. A death retry re-enters the level you died on with the
+   loadout carried (`retry-loadout`); a victory restart resets to L1
+   with a fresh rack (the start-level only seeds
    the initial loop entry). `demo-phase` (nil for normal play, 1..4 for
    the tech-talk showcase) applies a per-phase world transform after
    build-world (see phel-doom.demo.phases/apply-phase). `max-rows` /
@@ -1190,13 +1218,20 @@
         (and (map? result) (:game-over result))
         (let [[k t stats]     (carry-on carry-kills carry-time carry-stats result)
               [kind new-seed] (handle-end death-loop k t (run-summary stats) result seed false)
-              died-on         (or (:level result) 1)]
+              died-on         (or (:level result) 1)
+              ;; The rack survives the death screen (#453); the ammo does
+              ;; not - a nil weapon-state means build-world seeds fresh
+              ;; mags for the gun that comes back in hand. Fed from THIS
+              ;; iteration's bindings (what the level was built with), not
+              ;; from `result` (what the player died holding), so the
+              ;; same-seed replay rebuilds the identical level.
+              kit             (retry-loadout owned bp-level weapon)]
           (cond
             ;; r: try the level you died on again with a fresh map.
-            (= kind :fresh) (recur died-on max-lives 0 0 empty-run-stats (rng/fresh-seed) 0 #{:pistol} nil nil (restart-show-map? init-settings) true init-settings)
+            (= kind :fresh) (recur died-on max-lives 0 0 empty-run-stats (rng/fresh-seed) (:backpack-level kit) (:owned-weapons kit) (:weapon kit) nil (restart-show-map? init-settings) true init-settings)
             ;; R: replay the exact level you died on (same seed + same
             ;; level number reproduces identical geometry + enemies).
-            (= kind :same)  (recur died-on max-lives 0 0 empty-run-stats new-seed 0 #{:pistol} nil nil (restart-show-map? init-settings) true init-settings)
+            (= kind :same)  (recur died-on max-lives 0 0 empty-run-stats new-seed (:backpack-level kit) (:owned-weapons kit) (:weapon kit) nil (restart-show-map? init-settings) true init-settings)
             :else           nil))
 
         :else

--- a/src/core/level.phel
+++ b/src/core/level.phel
@@ -656,28 +656,52 @@
               (assoc-in grid [y door-x] target)
               (recur (php/+ y 1)))))))))
 
+(def weapon-debut-levels
+  "Level a weapon first appears on: L2 shotgun, L3 chaingun, L4 chainsaw,
+   L5 the rocket launcher (issue #123), L6 the incinerator (issue #122),
+   L7 the rare BFG (issue #58). The pistol is the fresh-run default and
+   never drops."
+  {:shotgun 2 :chaingun 3 :chainsaw 4 :rocket 5 :incinerator 6 :bfg 7})
+
+(def max-weapon-drops-per-level
+  "Cap on weapon pickups seeded into one level. A player arriving with an
+   empty rack (`--level=8`) is owed up to six weapons; handing all of them
+   over at once turns the level into an armoury. Two keeps a late level
+   winnable without erasing progression."
+  2)
+
+(defn- weapons-owed
+  "Weapons missing from `owned'` whose debut level has already passed,
+   most recent debut first, capped at `max-weapon-drops-per-level` (#453).
+
+   Before #453 this answered only the level's OWN debut weapon, so an L8+
+   start put the player in front of archviles with a pistol and nothing on
+   the floor, and kill loot only refills weapons already owned
+   (docs/combat.md). The level's own weapon is by definition the most
+   recent, so the cap can never drop it."
+  [level-num owned']
+  (let [owed (filterv (fn [kw]
+                        (and (php/<= (get weapon-debut-levels kw) level-num)
+                             (not (contains? owned' kw))))
+                      (keys weapon-debut-levels))]
+    (take max-weapon-drops-per-level
+          (sort-by (fn [kw] (php/- 0 (get weapon-debut-levels kw))) owed))))
+
 (defn- maybe-spawn-weapon-pickups
-  "Per-level weapon drops. L2 always seeds a shotgun, L3 a chaingun,
-   L4 the chainsaw, L5 the rocket launcher (issue #123), L6 the
-   incinerator (issue #122), L7 the rare BFG (issue #58). Each skipped
-   if the player already owns the weapon so a re-played level doesn't
-   spam duplicate pickups. Returns a
-   vector of `{:x :y :weapon kw}` items."
+  "Weapon drops for `level-num`: one per weapon the player is owed (see
+   `weapons-owed`), each at its own open cell. Already-owned weapons are
+   skipped so a re-played level doesn't spam duplicate pickups.
+
+   Cells come from `spawn-unique-pickups`, which drops a colliding draw
+   rather than stacking two pickups on one cell (stepping on the shared
+   cell would silently consume one of them). A weapon left without a cell
+   by that bail-out is dropped with it. Returns a vector of
+   `{:x :y :weapon kw}` items."
   [grid level-num owned]
-  (let [owned'     (or owned #{:pistol})
-        candidates
-        (cond
-          (php/=== level-num 2) (if (contains? owned' :shotgun)       [] [:shotgun])
-          (php/=== level-num 3) (if (contains? owned' :chaingun)      [] [:chaingun])
-          (php/=== level-num 4) (if (contains? owned' :chainsaw)      [] [:chainsaw])
-          (php/=== level-num 5) (if (contains? owned' :rocket)        [] [:rocket])
-          (php/=== level-num 6) (if (contains? owned' :incinerator)   [] [:incinerator])
-          (php/=== level-num 7) (if (contains? owned' :bfg)           [] [:bfg])
-          :else                 [])]
-    (mapv (fn [kw]
-            (let [[wx wy] (random-spawn grid)]
-              {:x wx :y wy :weapon kw}))
-          candidates)))
+  (let [kws   (weapons-owed level-num (or owned #{:pistol}))
+        cells (spawn-unique-pickups grid (count kws))]
+    (mapv (fn [[cell kw]] (assoc cell :weapon kw))
+          (map vector cells kws))))
 
 (defn- maybe-spawn-keycard
   "Drop one keycard at a random open cell when the level is locked

--- a/tests/commands/play-test.phel
+++ b/tests/commands/play-test.phel
@@ -7,7 +7,7 @@
   (:require phel-doom.commands.play  :refer [tick-world resumed-pause? step-pause-menu
                                              apply-mouse-look clamp-frame-ms adopt-loaded-world
                                              poll-size? resize-poll-frames restart-show-map?
-                                             rearm-mouse? rearm-mouse-frames]))
+                                             rearm-mouse? rearm-mouse-frames retry-loadout]))
 
 (def open-grid
   (apply vector
@@ -453,3 +453,34 @@
       "an absent :minimap setting coerces to a strict false")
   (is (= false (restart-show-map? {:minimap nil}))
       "a nil :minimap setting coerces to a strict false"))
+
+;; retry-loadout (#453): pressing r / R on the death screen used to recur
+;; with #{:pistol} and backpack 0, so dying on L7 restarted L7 with the
+;; pistol against archviles - a progression wall, since kill loot only
+;; feeds weapons you already own. The rack carries; the ammo does not
+;; (mags come back fresh from build-world).
+
+(deftest test-retry-loadout-keeps-the-guns-and-the-backpack
+  (let [l (retry-loadout #{:pistol :shotgun :chaingun :rocket} 2 :rocket)]
+    (is (= #{:pistol :shotgun :chaingun :rocket} (:owned-weapons l)))
+    (is (= 2 (:backpack-level l)))
+    (is (= :rocket (:weapon l)) "you retry holding the gun you entered with")))
+
+(deftest test-retry-loadout-defaults-when-the-run-carries-nothing
+  (let [l (retry-loadout nil nil nil)]
+    (is (= #{:pistol} (:owned-weapons l)))
+    (is (= 0 (:backpack-level l)))
+    (is (= :pistol (:weapon l)))))
+
+;; The retry is fed the ENTRY rack, never the death rack. build-world
+;; seeds weapon pickups from the owned set and draws their cells before
+;; the ammo boxes, so retrying with one weapon more would draw one cell
+;; fewer and shift every later spawn - and `R` promises an identical
+;; replay. Entering L5 with 4 weapons, grabbing the rocket and dying must
+;; still rebuild from the 4.
+(deftest test-retry-loadout-ignores-what-was-grabbed-during-the-attempt
+  (let [entry #{:pistol :shotgun :chaingun :chainsaw}
+        l     (retry-loadout entry 0 :chaingun)]
+    (is (= entry (:owned-weapons l)))
+    (is (= false (contains? (:owned-weapons l) :rocket))
+        "the rocket picked up on the fatal attempt is back on the floor")))

--- a/tests/core/level-test.phel
+++ b/tests/core/level-test.phel
@@ -3,7 +3,8 @@
   (:require phel-doom.core.level :refer [ammo-box-count armor-shard-count config-for heart-count num-levels build-world place-secret-reward secret-trophies])
   (:require phel-doom.core.map :refer [door? cell-floor cell-wall cell-door-boss find-door-cell passable?])
   (:require phel-doom.core.rng :as rng)
-  (:require phel-doom.core.combat :as combat))
+  (:require phel-doom.core.combat :as combat)
+  (:require phel-doom.core.weapons :as weapons))
 
 ;; ---------------------------------------------------------------------
 ;; Seeded determinism (issue #64): same rng seed => identical level.
@@ -132,6 +133,59 @@
   (let [saws (filter (fn [p] (= :chainsaw (:weapon p)))
                      (:weapon-pickups (build-world 4 5 0 :normal #{:pistol :chainsaw})))]
     (is (= 0 (count saws)))))
+
+;; #453: a level seeds the weapons the player MISSED, not only its own
+;; debut drop. Before the fix an L8+ start (a death retry, or `-l N`)
+;; carried the pistol into archviles with no weapon on the floor at all,
+;; because the spawn table only answered levels 2..7.
+(deftest test-build-world-seeds-missed-weapons-on-a-late-level
+  (let [ws (:weapon-pickups (build-world 8 5 0 :normal #{:pistol}))]
+    (is (= 2 (count ws)) "pistol-only on L8 -> the two most recent unowned")
+    (is (= #{:incinerator :bfg} (set (map (fn [p] (:weapon p)) ws)))
+        "most recent first: bfg (7) + incinerator (6)")))
+
+(deftest test-build-world-still-seeds-the-levels-own-debut-weapon
+  ;; The level's own weapon is by definition the most recent, so the
+  ;; two-slot cap can never drop it.
+  (let [ws (:weapon-pickups (build-world 5 5 0 :normal #{:pistol}))]
+    (is (contains? (set (map (fn [p] (:weapon p)) ws)) :rocket))))
+
+(deftest test-build-world-seeds-no-weapon-when-all-are-owned
+  (let [owned (set weapons/weapon-order)]
+    (is (= 0 (count (:weapon-pickups (build-world 8 5 0 :normal owned)))))))
+
+(deftest test-build-world-owed-list-is-most-recent-missing-not-most-recent
+  ;; Owning the BFG (the newest weapon) must not stop the older gaps from
+  ;; being filled: the cap picks the two most recent MISSING weapons.
+  (let [ws (:weapon-pickups (build-world 8 5 0 :normal #{:pistol :bfg}))]
+    (is (= #{:incinerator :rocket} (set (map (fn [p] (:weapon p)) ws))))))
+
+;; Why a death retry must rebuild from the rack the player ENTERED with
+;; (#453, play/retry-loadout): weapon-pickup cells are drawn from the run
+;; PRNG BEFORE the ammo boxes, so changing the owed count changes every
+;; later draw. Same seed + same owned set is the only thing that
+;; reproduces a level, which is what `R` promises.
+(deftest test-build-world-owned-set-shifts-every-later-spawn
+  (rng/seed! 4242)
+  (let [a (build-world 5 5 0 :normal #{:pistol :shotgun :chaingun :chainsaw})]
+    (rng/seed! 4242)
+    (let [same (build-world 5 5 0 :normal #{:pistol :shotgun :chaingun :chainsaw})]
+      (is (= (map (fn [b] [(:x b) (:y b)]) (:ammo-boxes a))
+             (map (fn [b] [(:x b) (:y b)]) (:ammo-boxes same)))
+          "same seed + same rack -> identical ammo boxes"))
+    (rng/seed! 4242)
+    (let [richer (build-world 5 5 0 :normal #{:pistol :shotgun :chaingun :chainsaw :rocket})]
+      (is (= 0 (count (:weapon-pickups richer))) "nothing owed -> no draw")
+      (is (not (= (map (fn [b] [(:x b) (:y b)]) (:ammo-boxes a))
+                  (map (fn [b] [(:x b) (:y b)]) (:ammo-boxes richer))))
+          "one weapon more owned -> one draw fewer -> later spawns shift"))))
+
+(deftest test-build-world-weapon-pickups-never-share-a-cell
+  ;; Two pickups on one cell = one silently consumed (the same trap
+  ;; `spawn-ammo-boxes` retries around).
+  (let [ws    (:weapon-pickups (build-world 8 5 0 :normal #{:pistol}))
+        cells (set (map (fn [p] [(:x p) (:y p)]) ws))]
+    (is (= (count ws) (count cells)))))
 
 ;; ---------------------------------------------------------------------
 ;; Slim-entry refactor regression: each level's `:enemy` kw is stamped


### PR DESCRIPTION
## 📚 Description

Dying on L7 and pressing `r` / `R` restarted L7 with the pistol and backpack 0: both retry branches recurred with `#{:pistol}`. Kill loot only refills weapons you already own, and a level seeded only its own debut weapon, so L8-L10 had nothing on the floor at all - an unwinnable retry, and the same wall for `--level=N`. A retry now re-enters with the rack the level was built with, and levels seed the weapons the player is owed.

## 🔖 Changes

- `retry-loadout` (pure, unit-tested) feeds both death branches from the run loop's own bindings: owned weapons, backpack stack, active gun. Ammo still resets (nil weapon-state -> fresh mags), as do kills, time and lives.
- Entry rack, not death rack, on purpose: weapon-pickup cells are drawn from the run PRNG **before** the ammo boxes, so rebuilding with a weapon grabbed during the fatal attempt would draw one cell fewer and shift every later spawn, breaking the identical replay `R` promises. A new level test pins that coupling.
- `weapons-owed`: a level seeds every weapon whose debut has passed and the player does not own, most recent debut first, two at most. The level's own debut weapon is by definition the most recent, so the cap never drops it and the normal progression path draws exactly as many cells as before.
- Weapon cells now come from the existing `spawn-unique-pickups` (drops a colliding draw instead of stacking two pickups on one cell).
- Docs: `docs/game-loop.md` restart modes, `docs/level-system.md` drop table, CHANGELOG.

Review: a Fable `clean-code-reviewer` pass caught the `R`-replay determinism drift in the first draft (death rack shifting the ammo-box stream); this PR is the corrected design, plus its suggested test for "two most recent MISSING" and the `spawn-unique-pickups` reuse.

Closes #453