### PR TITLE
fix: revive a dead enemy out of the player's sight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 
 ### Fixed
 
+- Enemies stop respawning in plain sight (#455). A revived enemy only had to be 3 units from the player, which is a few cells of open floor and well inside the view, so a monster could pop into existence mid-room while you watched. The respawn now also requires the cell to be out of your line of sight, keeping a far-enough cell as a fallback so an open arena with nowhere to hide still brings its dead back.
 - Dying no longer strips your arsenal (#453). Both death-screen retries (`r` fresh map, `R` same seed) restarted the level you died on with the pistol and backpack 0, so an L7 retry met archviles with a starting weapon and no way back up: kill loot only refills weapons you already own, and a level seeded only its own debut weapon, so L8-L10 had nothing on the floor at all. A retry now re-enters with the rack you ENTERED that level carrying - weapons, backpack stack and the gun in hand - while kills, time, lives and ammo still reset. Entry rather than death rack on purpose: weapon-pickup cells are drawn from the run PRNG before the ammo boxes, so rebuilding with a weapon the player grabbed during the fatal attempt would shift every later spawn and break the identical replay `R` promises. Levels also seed the weapons you are owed rather than only their own debut drop - most recent debut first, two at most - so `--level=N` starts with a usable rack too.
 
 ## [0.17.0] - 2026-08-16

--- a/docs/monsters.md
+++ b/docs/monsters.md
@@ -130,7 +130,7 @@ Player ducks around corner:
 
 Killed enemy stays in vector with `:alive false` + `:respawn-after` timer (uniform 3-6s; nightmare: 1-2s).
 
-`tick-one` decays timer; on expiry, spawn at random cell ≥ 3.0 units away. No slot found: bump timer to 0.5s + retry next frame (no ambush spawn).
+`tick-one` decays timer; on expiry, spawn at random cell >= 3.0 units away AND out of the player's line of sight (issue #455) - distance alone is a few cells, which is well inside the frustum, so monsters used to pop into existence mid-room in plain view. Up to 8 candidates are drawn; the first unseen one wins, and a merely-far-enough candidate is kept as a fallback so an open arena with nowhere to hide still revives its dead. No slot found at all: bump timer to 0.5s + retry next frame (no ambush spawn).
 
 Optional `:max-concurrent` cap (per-type) enforces max-alive count. Revival checks live count; respawn delayed until a sibling dies. `:type` preserved across respawn.
 

--- a/src/core/enemy.phel
+++ b/src/core/enemy.phel
@@ -4,7 +4,7 @@
   (:require phel-doom.core.enemies    :refer [resists? default-lives-for])
   (:require phel-doom.core.engine     :refer [proj-dist])
   (:require phel-doom.core.projection :refer [sprite-half-rows wall-px])
-  (:require phel-doom.core.enemy-ai   :refer [apply-pain maybe-start-attack moves? observe start-wander target-pos tick-attack tick-pain tick-wander]))
+  (:require phel-doom.core.enemy-ai   :refer [apply-pain maybe-start-attack moves? observe sees-player? start-wander target-pos tick-attack tick-pain tick-wander]))
 
 ;; ---------------------------------------------------------------------
 ;; Enemy BODY: state, lifecycle, and physics. This module owns spawning
@@ -475,20 +475,35 @@
       enemies)))
 
 (defn- random-spawn-far-from
-  "Random open cell at least min-dist from (px, py). Falls back to nil
-   after a few attempts so the caller can keep the enemy dead another
-   frame instead of forcing an ambush spawn."
-  [grid min-dist px py]
-  (loop [attempts 8]
+  "Random open cell at least min-dist from (px, py), preferring one the
+   player cannot SEE (#455). Falls back to nil after a few attempts so
+   the caller can keep the enemy dead another frame instead of forcing
+   an ambush spawn.
+
+   Distance alone let a monster pop into existence mid-room in plain
+   view: `respawn-min-dist` is a few cells, and a few cells of open
+   floor is well inside the frustum. Every candidate that clears the
+   distance test is now also checked against `sees-player?`, and the
+   first unseen one wins. A candidate that is merely far enough is kept
+   as a fallback, so a room with nowhere to hide (an open arena) still
+   revives its dead rather than suspending them forever.
+
+   `pgrid` nil (test callers on the 7-arity `advance`) skips the sight
+   test and behaves exactly as before."
+  [grid pgrid min-dist px py]
+  (loop [attempts 8
+         far      nil]
     (if (php/<= attempts 0)
-      nil
+      far
       (let [[ex ey] (random-spawn grid)
             dx      (php/- ex px)
             dy      (php/- ey py)]
         (if (php/< (php/+ (php/* dx dx) (php/* dy dy))
                    (php/* min-dist min-dist))
-          (recur (php/- attempts 1))
-          [ex ey])))))
+          (recur (php/- attempts 1) far)
+          (if (or (nil? pgrid) (not (sees-player? pgrid ex ey px py)))
+            [ex ey]
+            (recur (php/- attempts 1) (or far [ex ey]))))))))
 
 (defn- alive-count-of-type
   "How many enemies in `enemies` are currently alive AND carry `:type`
@@ -587,7 +602,7 @@
               capped? (and cap (not (:nightmare? e))
                            (php/>= (alive-count-of-type all-enemies type-kw) cap))
               pos     (when (not capped?)
-                        (random-spawn-far-from grid respawn-min-dist player-x player-y))]
+                        (random-spawn-far-from grid pgrid respawn-min-dist player-x player-y))]
           (if pos
             ;; Carry :max-lives, :type, :max-concurrent, :nightmare?
             ;; across the respawn so a revived baron is still a baron,

--- a/tests/core/enemy-test.phel
+++ b/tests/core/enemy-test.phel
@@ -1,6 +1,7 @@
 (ns phel-doom-tests.core.enemy-test
   (:require phel.test :refer [deftest is])
   (:require phel-doom.core.rng :as rng)
+  (:require phel-doom.core.enemy-ai :refer [sees-player?])
   (:require phel-doom.core.enemy :refer [default-wander-fraction new-enemy promote-wanderers push-back-enemy spawn-enemies spawn-enemies-mixed shoot pierce spread-shoot splash beam-impact advance tick-scare rear-attacker? type-speed-mul]))
 
 (def open-grid
@@ -817,3 +818,45 @@
     (is (= 0 killed))
     (is (= nil hit-pos))
     (is (= 3 (:lives (get es' 0))) "off-cone enemy untouched")))
+
+;; ---------------------------------------------------------------------
+;; Respawn out of sight (#455). A dead enemy used to revive at any open
+;; cell >= respawn-min-dist away, so a monster could pop into existence
+;; mid-room in the player's view. The revive now prefers a cell the
+;; player cannot see, and falls back rather than refusing to spawn.
+;; ---------------------------------------------------------------------
+
+(def split-room-grid
+  ;; Vector twin of wall-between-pgrid: x=4 wall column splits the room.
+  [[1 1 1 1 1 1 1 1 1 1]
+   [1 0 0 0 1 0 0 0 0 1]
+   [1 0 0 0 1 0 0 0 0 1]
+   [1 0 0 0 1 0 0 0 0 1]
+   [1 0 0 0 1 0 0 0 0 1]
+   [1 0 0 0 1 0 0 0 0 1]
+   [1 0 0 0 1 0 0 0 0 1]
+   [1 0 0 0 1 0 0 0 0 1]
+   [1 0 0 0 1 0 0 0 0 1]
+   [1 1 1 1 1 1 1 1 1 1]])
+
+(deftest test-respawn-lands-out-of-the-players-sight
+  ;; Player stands on the right of the divider; every revive must land
+  ;; on the left of it, which is the only unseen half.
+  (let [seen? (fn [seed]
+                (rng/seed! seed)
+                (let [e (first (advance [{:x 2.5 :y 2.5 :alive false :respawn-after 0.0}]
+                                        split-room-grid wall-between-pgrid
+                                        7.5 5.5 0.5 0.75 true))]
+                  (and (:alive e) (sees-player? wall-between-pgrid (:x e) (:y e) 7.5 5.5))))]
+    (is (= false (seen? 1)))
+    (is (= false (seen? 2)))
+    (is (= false (seen? 3)))
+    (is (= false (seen? 12345)))))
+
+(deftest test-respawn-still-revives-when-nowhere-is-hidden
+  ;; An open arena has no unseen cell at all. The enemy must still come
+  ;; back (far away, as before) rather than stay dead forever.
+  (rng/seed! 99)
+  (let [e (first (advance [{:x 2.5 :y 2.5 :alive false :respawn-after 0.0}]
+                          open-grid open-pgrid 5.5 5.5 0.5 0.75 true))]
+    (is (= true (:alive e)))))


### PR DESCRIPTION
## 📚 Description

A revived enemy only had to be 3 units from the player. Three units of open floor is a few cells, well inside the view, so a monster could pop into existence mid-room while you watched it happen.

## 🔖 Changes

- `random-spawn-far-from` now also checks each candidate with `sees-player?` and takes the first cell the player cannot see.
- A merely-far-enough candidate is kept as a fallback, so an open arena with nowhere to hide still revives its dead rather than suspending them forever. Same 8-candidate budget, no new rng draws in the common case.
- `pgrid` nil (the 7-arity `advance` used by tests) skips the sight test and behaves exactly as before.
- Tests: four seeds in a split room must all land unseen; an open arena must still revive. Docs: monsters.md respawn section.

Closes #455