### PR TITLE
feat: a message line naming what just happened

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 
 ## [Unreleased]
 
+### Added
+
+- A Doom-style message line names what just happened (#456): `Picked up a heart.`, `Picked up the BLUE keycard.`, `You got the SHOTGUN!`, `A secret is revealed!`, and the weapon plus its ammo when you switch slots. Every pickup used to be the same door tink and the item vanishing, so a first-timer could not tell an armor shard from an ammo box, know the keycard was now held, or see that a pickup had auto-switched their weapon. One steady row for 2 seconds, no blink, clipped to the viewport and hidden on very short ones; the frame is byte-identical when there is nothing to say.
+
 ### Changed
 
 - Quitting and restarting ask before they act, and the game pauses when you alt-tab away (#454). `q` sits one key from `w` and used to end a run on the spot; in game it now opens the pause menu with the cursor on Quit, so the confirmation is the second `q` (or Enter on that row). From the pause page `q` still quits and still persists settings, and the start menu and end screens are unchanged. Restart on the pause menu asks the same way: the first select arms it (`Restart?  enter again`), moving the cursor disarms it. And the terminal now reports focus (`\e[?1004h`), so losing the window pauses a live run and drops the held movement instead of leaving the player standing in front of an enemy. Inside tmux the pane needs `focus-events on`.

--- a/docs/rendering.md
+++ b/docs/rendering.md
@@ -230,6 +230,12 @@ When the game-loop's startup calibration finds full detail too slow for a smooth
 
 H/ESC info menu width-adaptive: max 44 chars, min 36. Drops CONTROLS section first, then COMPASS HINT on squeeze.
 
+## Message line (issue #456)
+
+One left-aligned row at row 3 naming what just happened: `Picked up a heart.`, `Picked up the BLUE keycard.`, `You got the SHOTGUN!`, `A secret is revealed!`, or the weapon and its ammo on a slot switch. Before it, every pickup was the same door tink plus the item vanishing, so a first-timer could not tell a shard from an ammo box or know a keycard was now held.
+
+The model is two flat world fields, `:msg-text` and `:msg-secs` (`state/push-msg`, 2.0s), decayed with every other feel timer in `combat/decay-timers`. `paint-message` gates on `message-visible?`: text present, timer running, `vh >= 8`. Held steady for its whole ttl with no blink (calm 3D view), clipped with `mb_substr` to the viewport width so a long name cannot wrap into the scene, and byte-identical to the old frame when there is nothing to say. Quick-saves drop both fields - a save must not load mid-message.
+
 ## Why so many overlay passes
 
 Walls/sky/floor/enemies go into one string via the row loop. HUD, minimap, crosshair use absolute cursor positioning escapes (`\e[r;cH`) to paint anywhere. Alternate screen buffer + cursor-home redraw overwrites in place: no flicker, no scroll, no full clear.

--- a/docs/state.md
+++ b/docs/state.md
@@ -57,6 +57,8 @@ Pure data shapes that every other module operates on. `src/core/state.phel`.
  :fire-anim  <float seconds>  ; muzzle flash visibility
  :intro-secs <float seconds>  ; level intro splash countdown
  :flash-secs <float seconds>  ; 1-frame white impact flash
+ :msg-text   <string|nil>     ; message line: what was just picked up / revealed / switched to
+ :msg-secs   <float seconds>  ; how long that line stays up
  :fx         <vector of blood splatters>
  :blood-drops <vector>        ; screen-edge drips during i-frames
  :game-time  <float seconds>  ; pause-aware clock for render pulses
@@ -160,6 +162,7 @@ Float-seconds countdowns on the world, decayed by `decay-timers` in `core/combat
 | `:flash-secs` | `take-damage` (0.05s) | 1-frame all-white impact |
 | `:fire-anim` | `fire-shot` (0.09s) | Muzzle flash visibility |
 | `:intro-secs` | `build-world` (1.5s) | "LEVEL N · NAME" splash overlay |
+| `:msg-secs` | `push-msg` (2.0s) | Message line naming the pickup / secret / weapon (#456) |
 
 `:fx` is a vector of blood splatters with their own `:ttl` ticked by `decay-fx`.
 

--- a/src/commands/play.phel
+++ b/src/commands/play.phel
@@ -1,7 +1,7 @@
 (ns phel-doom.commands.play
   (:require phel.cli :as cli)
   (:require phel.string :as str)
-  (:require phel-doom.core.state :refer [advance-game-time backpack-level clamp-pitch decay-soul-overcap empty-moves max-lives max-stamina turn-player rebuild-pgrid reset-reticle toggle-debug toggle-map toggle-pause toggle-sound])
+  (:require phel-doom.core.state :refer [advance-game-time backpack-level clamp-pitch decay-soul-overcap empty-moves max-lives max-stamina push-msg turn-player rebuild-pgrid reset-reticle toggle-debug toggle-map toggle-pause toggle-sound])
   (:require phel-doom.core.map      :refer [door? reveal-secret secret? switch? toggle-switch])
   (:require phel-doom.glue.controls :refer [refresh-from-keys key-states rising-edges
                                             initial-key-snapshot nav-deltas mouse-aim])
@@ -368,13 +368,15 @@
     (let [[cx cy] (cell-ahead world)]
       (if (secret? (:grid world) cx cy)
         (let [idx (or (:secrets-found world) 0)]
-          (push-sfx
-           (-> world
-               (assoc :grid (reveal-secret (:grid world) cx cy))
-               (rebuild-pgrid)
-               (place-secret-reward cx cy idx)
-               (update :secrets-found (fn [n] (php/+ (or n 0) 1))))
-           :door 1.0))
+          (push-msg
+           (push-sfx
+            (-> world
+                (assoc :grid (reveal-secret (:grid world) cx cy))
+                (rebuild-pgrid)
+                (place-secret-reward cx cy idx)
+                (update :secrets-found (fn [n] (php/+ (or n 0) 1))))
+            :door 1.0)
+           "A secret is revealed!"))
         world))))
 
 (defn- try-toggle-switch
@@ -446,6 +448,15 @@
                    (:select-weapon6 edges) (switch-weapon w1 (get weapon-order 5))
                    (:select-weapon7 edges) (switch-weapon w1 (get weapon-order 6))
                    :else                   w1)
+            ;; Name the weapon on the message line when the swap actually
+            ;; took (#456), so a slot press never needs a glance at the
+            ;; top-left HUD. A refused swap - unowned slot, mid-reload -
+            ;; returns the same weapon and says nothing.
+            w1am (if (= (:weapon w1a) (:weapon w1))
+                   w1a
+                   (push-msg w1a (str (php/strtoupper (name (:weapon w1a)))
+                                      " " (or (:mag w1a) 0)
+                                      "/" (or (:ammo-reserve w1a) 0))))
             ;; tick-stamina runs BEFORE apply-physics so that, on the
             ;; frame the player's pool empties, the `:sprint-blocked?`
             ;; latch fires before physics samples it — apply-physics
@@ -453,7 +464,7 @@
             ;; 1.6x frame "for free". Drain reads the just-refreshed
             ;; :moves slots (refresh-from-keys above), so the player
             ;; pays for the intent the same frame they signal it.
-            w1b  (try-reveal-secret w1a (:action edges))
+            w1b  (try-reveal-secret w1am (:action edges))
             ;; Switch (issue #62): flip the cell glyph + every target
             ;; on the world's :switches metadata. Chained AFTER
             ;; reveal-secret so the F-press never double-fires.
@@ -587,6 +598,10 @@
    :enemy                (or (:enemy world) :imp)
    :save-flash-secs      (or (:save-flash-secs world) 0.0)
    :save-flash-msg       (:save-flash-msg world)
+   ;; Doom-style message line (#456): what was just picked up / revealed /
+   ;; switched to. Render gates on the timer, so the text can stay put.
+   :msg-text             (:msg-text world)
+   :msg-secs             (or (:msg-secs world) 0.0)
    :reload-ready-secs    (or (:reload-ready-secs world) 0.0)
    ;; Settings page (issue #107): the pause overlay paints the box from
    ;; these. The page IS the pause screen, so the render layer keys off

--- a/src/core/combat.phel
+++ b/src/core/combat.phel
@@ -380,6 +380,9 @@
            :shake-secs            (decay-timer world :shake-secs dt)
            :fire-anim             (decay-timer world :fire-anim dt)
            :intro-secs            (decay-timer world :intro-secs dt)
+           ;; The message TEXT is left in place; render gates on the timer,
+           ;; so there is no per-frame string write here (#456).
+           :msg-secs              (decay-timer world :msg-secs dt)
            :flash-secs            (decay-timer world :flash-secs dt)
            :streak-secs           streak-secs'
            :fire-cooldown         (decay-timer world :fire-cooldown dt)

--- a/src/core/pickups.phel
+++ b/src/core/pickups.phel
@@ -1,5 +1,5 @@
 (ns phel-doom.core.pickups
-  (:require phel-doom.core.state   :refer [at-backpack-cap? backpack-level gain-armor-shard gain-backpack gain-life gain-soulsphere max-armor])
+  (:require phel-doom.core.state   :refer [at-backpack-cap? backpack-level gain-armor-shard gain-backpack gain-life gain-soulsphere max-armor push-msg])
   (:require phel-doom.core.combat  :refer [ammo-per-box arm-berserk invuln-seconds push-sfx])
   (:require phel-doom.core.weapons :refer [give-weapon weapon-spec weapons]))
 
@@ -20,20 +20,21 @@
 (defn- consume-at
   "Shared step-on skeleton: when the player's integer cell holds an
    entity in `(slot world)`, drop that entity, apply `transform` to the
-   consumed world, and enqueue `sfx`. Returns `world` unchanged when the
-   player is not standing on one."
-  [world slot transform sfx]
+   consumed world, enqueue `sfx`, and stamp `msg` on the HUD message line
+   (#456 - the tink alone never said WHAT was picked up). Returns `world`
+   unchanged when the player is not standing on one."
+  [world slot transform sfx msg]
   (let [kept (entities-not-at (slot world)
                               (php/intval (:x (:player world)))
                               (php/intval (:y (:player world))))]
     (if (= (count kept) (count (or (slot world) [])))
       world
-      (push-sfx (transform (assoc world slot kept)) sfx 1.0))))
+      (push-msg (push-sfx (transform (assoc world slot kept)) sfx 1.0) msg))))
 
 (defn pickup-hearts
   "If the player stands on a heart cell, consume it and gain a life."
   [world]
-  (consume-at world :hearts gain-life :berserk))
+  (consume-at world :hearts gain-life :berserk "Picked up a heart."))
 
 (defn pickup-armors
   "Step-on triggers an armor pickup: bumps :armor by 1, capped at
@@ -44,7 +45,7 @@
   [world]
   (consume-at world :armors
               (fn [w] (update w :armor (fn [a] (php/min max-armor (php/+ (or a 0) 1)))))
-              :door))
+              :door "Picked up armor."))
 
 (defn- entity-at
   "Pick the first entity in `coll` at cell (px, py) so the caller can
@@ -93,11 +94,13 @@
             cur'      (php/min cap (php/+ cur per-box))
             stash'    (assoc-in stash [target :reserve] cur')
             refilled  (assoc world :ammo-boxes kept :weapon-state stash')]
-        (push-sfx
-         (if (= target (or (:weapon world) :pistol))
-           (assoc refilled :ammo-reserve cur')
-           refilled)
-         :door 1.0)))))
+        (push-msg
+         (push-sfx
+          (if (= target (or (:weapon world) :pistol))
+            (assoc refilled :ammo-reserve cur')
+            refilled)
+          :door 1.0)
+         "Picked up ammo.")))))
 
 (defn pickup-berserks
   "Step-on consumes the berserk sphere + arms `:berserk-secs` for the
@@ -106,7 +109,7 @@
    rather than adding to it. Distinct `:berserk` sfx so the pickup is
    audibly different from a generic door/key tink."
   [world]
-  (consume-at world :berserks arm-berserk :berserk))
+  (consume-at world :berserks arm-berserk :berserk "Berserk!"))
 
 (defn pickup-invulns
   "Step-on consumes the invulnerability sphere + arms
@@ -114,14 +117,14 @@
   [world]
   (consume-at world :invulns
               (fn [w] (assoc w :invuln-secs invuln-seconds))
-              :door))
+              :door "Invulnerability!"))
 
 (defn pickup-soulspheres
   "Step-on consumes a soulsphere + bumps `:lives` toward
    `soulsphere-cap` via `gain-soulsphere`. Over-cap lives decay back
    to `max-lives` over time (see `decay-soul-overcap`)."
   [world]
-  (consume-at world :soulspheres gain-soulsphere :berserk))
+  (consume-at world :soulspheres gain-soulsphere :berserk "Supercharge!"))
 
 (defn pickup-armor-shards
   "Step-on consumes an armor shard + adds +1 armor via
@@ -130,7 +133,7 @@
    pattern). Common pickup so the door tink reads as routine
    loot rather than a special-event sfx."
   [world]
-  (consume-at world :armor-shards gain-armor-shard :door))
+  (consume-at world :armor-shards gain-armor-shard :door "Picked up an armor shard."))
 
 (defn pickup-backpacks
   "Stacking pickup (#68 part 3): each step-on bumps `:backpack-level`
@@ -143,7 +146,7 @@
   [world]
   (consume-at world :backpacks
               (fn [w] (if (at-backpack-cap? w) w (gain-backpack w)))
-              :door))
+              :door "Picked up a backpack."))
 
 (defn pickup-weapon-pickups
   "Step-on consumes a weapon pickup, adds it to :owned-weapons, and
@@ -156,9 +159,11 @@
     (if (nil? on-pick)
       world
       (let [kept (entities-not-at (:weapon-pickups world) px py)]
-        (push-sfx
-         (give-weapon (assoc world :weapon-pickups kept) (:weapon on-pick))
-         :door 1.0)))))
+        (push-msg
+         (push-sfx
+          (give-weapon (assoc world :weapon-pickups kept) (:weapon on-pick))
+          :door 1.0)
+         (str "You got the " (php/strtoupper (name (:weapon on-pick))) "!"))))))
 
 (defn pickup-keycards
   "Step-on consumes the keycard + adds its colour to `:held-keys`.
@@ -170,8 +175,10 @@
     (if (nil? on-card)
       world
       (let [kept (entities-not-at (:keycards world) px py)]
-        (push-sfx
-         (assoc world
-                :keycards  kept
-                :held-keys (conj (or (:held-keys world) #{}) (:colour on-card)))
-         :door 1.0)))))
+        (push-msg
+         (push-sfx
+          (assoc world
+                 :keycards  kept
+                 :held-keys (conj (or (:held-keys world) #{}) (:colour on-card)))
+          :door 1.0)
+         (str "Picked up the " (php/strtoupper (name (:colour on-card))) " keycard."))))))

--- a/src/core/state.phel
+++ b/src/core/state.phel
@@ -176,6 +176,8 @@
     :fire-anim   0.0
     :intro-secs  0.0
     :flash-secs  0.0
+    :msg-text    nil
+    :msg-secs    0.0
     :fire-cooldown 0.0
     :reload-cooldown 0.0
     :empty-click-secs 0.0
@@ -244,6 +246,24 @@
     :sprint-cooldown-secs     0.0
     :sprint-blocked?          false
     :moves      empty-moves}))
+
+(def message-secs
+  "How long a message line stays up (seconds). Long enough to read
+   mid-fight without becoming a second HUD element."
+  2.0)
+
+(defn push-msg
+  "Stamp the one-line message the HUD shows for `message-secs` (#456).
+
+   Every pickup used to be the same door tink plus the item vanishing, so
+   a first-timer could not tell a shard from an ammo box, or know a
+   keycard was now held. The text names what just happened; the timer is
+   decayed in `combat/decay-timers` like every other feel timer.
+
+   Last writer wins: two pickups in one frame show the second, which is
+   also the one the player stepped on last."
+  [world text]
+  (assoc world :msg-text text :msg-secs message-secs))
 
 (defn gain-life
   "Heal one full heart (2 HP), capped at max-lives. Heart pickups grant

--- a/src/io/render/main.phel
+++ b/src/io/render/main.phel
@@ -7,7 +7,7 @@
   (:require phel-doom.io.render.wall-texture-data :refer [wall-tex])
   (:require phel-doom.io.render.enemy-sprite :refer [sprite-for-type-lod sprite-fade sprite-fade-index sprite-col-x sprite-subcol-x enemy-sprite-cell enemy-sprite-quad])
   (:require phel-doom.io.render.hud :refer [minimap-door-pulse minimap-rows minimap-frame hud-debug-line hud-line-str help-menu-string settings-menu-string pause-menu-string])
-  (:require phel-doom.io.render.paint :refer [paint-face-overlay paint-crosshair paint-intro-splash paint-locked-bump paint-blood-drops paint-rear-warning paint-low-ammo paint-reload-reminder paint-save-flash paint-reload-ready paint-game-info paint-berserk-badge paint-invuln-badge paint-empty-click paint-heartbeat-vignette paint-hit-vignette paint-berserk-tint paint-heat-bar paint-kill-streak paint-compass paint-enemy-hp-flashes paint-hearts-hud paint-weapon-hud])
+  (:require phel-doom.io.render.paint :refer [paint-face-overlay paint-crosshair paint-intro-splash paint-locked-bump paint-blood-drops paint-rear-warning paint-low-ammo paint-reload-reminder paint-message paint-save-flash paint-reload-ready paint-game-info paint-berserk-badge paint-invuln-badge paint-empty-click paint-heartbeat-vignette paint-hit-vignette paint-berserk-tint paint-heat-bar paint-kill-streak paint-compass paint-enemy-hp-flashes paint-hearts-hud paint-weapon-hud])
   (:require phel-doom.io.render.sprites :refer [paint-blood-fx-into paint-pickups-into paint-projectiles-into paint-tracers-into build-blood-cols sprites-enabled?])
   (:require phel-doom.core.engine :refer [cast-frame max-depth proj-dist])
   (:require phel-doom.core.map :refer [cell-door cell-door-blue cell-door-red cell-door-boss cell-door-yellow])
@@ -2288,7 +2288,14 @@
             ;; Shared enemy-projs: both are projected at the full `vw`, so
             ;; this is a pure filter over already-computed data.
             p19c        (paint-enemy-hp-flashes   p19b enemy-projs vw vh pr-full)
-            p20         (paint-save-flash         p19c stats vw vh)
+            ;; Clipped at the minimap's left margin: the panel's content
+            ;; starts on row 3 too, and this pass paints after it.
+            p19d        (paint-message           p19c stats
+                                                 (if (php/> visible-mh 0)
+                                                   (php/max 1 (php/- map-col 2))
+                                                   vw)
+                                                 vh)
+            p20         (paint-save-flash         p19d stats vw vh)
             p20b        (paint-reload-ready       p20 stats vw vh)]
         ;; Pause (P) IS the settings page: freezing the game and the
         ;; options live in one overlay so there's only one layer to

--- a/src/io/render/paint.phel
+++ b/src/io/render/paint.phel
@@ -381,6 +381,39 @@
                                       " press R to RELOAD ")))))
   parts)
 
+(defn message-visible?
+  {:doc "True when the message line has something to say this frame
+         (#456): text present, its timer still running, and the viewport
+         tall enough that the line is not stealing scene rows. Pure so
+         the rule is testable without the ANSI paint."
+   :see-also ["paint-message"]
+   :example "(message-visible? \"Picked up a heart.\" 1.2 24) ; => true"}
+  [text ^float secs ^int vh]
+  (and (php/> secs 0.0)
+       (not (nil? text))
+       (not (php/=== text ""))
+       (php/>= vh 8)))
+
+(defn paint-message
+  "Doom-style message line: one left-aligned row under the HUD strip
+   naming what just happened (#456 - a pickup used to be a tink and the
+   item vanishing, which never said WHAT). Held steady for its ttl, no
+   blink, so it reads as information rather than an alarm.
+
+   `right-edge` is the first column the line may NOT touch: the minimap
+   panel starts its content on this same row 3, and this overlay paints
+   after it, so an unclipped line would erase the panel's left edge.
+   Callers pass the minimap's left margin when the map is shown and the
+   viewport width when it is not."
+  [parts stats ^int right-edge ^int vh]
+  (let [text (get stats :msg-text)
+        secs (or (get stats :msg-secs) 0.0)]
+    (when (message-visible? text secs vh)
+      (buf-push parts (str "\e[3;1H\e[40;1;97m"
+                           (php/mb_substr text 0 (php/max 1 right-edge))
+                           "\e[0m"))))
+  parts)
+
 (defn paint-save-flash
   "Brief centred SAVED / LOADED cue near the top after F5 / F9 quick
    save / load (issue #63). Green chip so it's distinct from the amber

--- a/src/io/savegame.phel
+++ b/src/io/savegame.phel
@@ -91,9 +91,11 @@
    into a later load), and `:moves` (transient input hold counters - a
    mid-walk save must load standing still, see savestring->world), and
    `:pause-confirm` (a menu row waiting for its second Enter, #454 - a
-   question belongs to the session that asked it)."
+   question belongs to the session that asked it), and `:msg-text` /
+   `:msg-secs` (the transient message line, #456 - a save must not load
+   showing 'Picked up a heart.')."
   [world]
-  (let [clean (dissoc world :pgrid :light-grid :visited :settings :settings-cursor :moves :pause-confirm)
+  (let [clean (dissoc world :pgrid :light-grid :visited :settings :settings-cursor :moves :pause-confirm :msg-text :msg-secs)
         o     (php/array)]
     (php/aset o "version" save-version)
     (php/aset o "world"   (encode clean))

--- a/tests/commands/play-test.phel
+++ b/tests/commands/play-test.phel
@@ -131,6 +131,7 @@
         w'          (tick-world (new-world secret-grid (new-player 1.5 1.5 0.0))
                                 "" 0.016 (assoc no-edges :action true))]
     (is (= 1 (:secrets-found w')) "secret revealed + counted")
+    (is (= "A secret is revealed!" (:msg-text w')) "and the message line says so (#456)")
     (is (>= (count (:ammo-boxes w')) 1) "ammo dropped")
     (is (>= (count (:armor-shards w')) 1) "shard dropped")
     (is (= 1 (count (:soulspheres w'))) "idx-0 trophy is a soulsphere")
@@ -599,3 +600,29 @@
     (is (= true (:paused w)))
     (is (= :settings (:pause-screen w)) "does not yank the player off a sub-page")
     (is (= 2 (:pause-cursor w)))))
+
+;; The weapon-slot message (#456): a swap that took names the weapon and
+;; its ammo, a refused one says nothing.
+
+(deftest test-weapon-switch-names-the-weapon
+  (let [w0 (assoc (new-world open-grid (new-player 5.0 5.0 0.0))
+                  :owned-weapons #{:pistol :shotgun}
+                  :weapon :pistol
+                  :weapon-state {:shotgun {:mag 4 :reserve 12}})
+        w  (tick-world w0 "" 0.016 (assoc no-edges :select-weapon2 true))]
+    (is (= :shotgun (:weapon w)))
+    (is (= "SHOTGUN 4/12" (:msg-text w)))))
+
+(deftest test-refused-weapon-switch-says-nothing
+  ;; Slot 5 is the BFG and the player does not own it: switch-weapon is a
+  ;; no-op, so the message line must stay quiet.
+  (let [w0 (assoc (new-world open-grid (new-player 5.0 5.0 0.0))
+                  :owned-weapons #{:pistol} :weapon :pistol)
+        w  (tick-world w0 "" 0.016 (assoc no-edges :select-weapon5 true))]
+    (is (= :pistol (:weapon w)))
+    (is (= nil (:msg-text w))))
+  ;; Pressing the slot already held is not an event either.
+  (let [w0 (assoc (new-world open-grid (new-player 5.0 5.0 0.0))
+                  :owned-weapons #{:pistol} :weapon :pistol)
+        w  (tick-world w0 "" 0.016 (assoc no-edges :select-weapon1 true))]
+    (is (= nil (:msg-text w)))))

--- a/tests/core/pickups-test.phel
+++ b/tests/core/pickups-test.phel
@@ -118,3 +118,58 @@
                                     {:backpacks [{:x 5.0 :y 5.0}] :backpack-level 0}))]
     (is (= 0 (count (:backpacks w'))) "backpack consumed")
     (is (= 1 (:backpack-level w')) "first backpack lifts the level to 1")))
+
+;; ---------------------------------------------------------------------
+;; Message line (#456). Every pickup was the same door tink plus the item
+;; vanishing, so a first-timer could not tell a shard from an ammo box or
+;; know a keycard was now held. Each pickup names itself.
+;; ---------------------------------------------------------------------
+
+(defn- msg-of [world] (:msg-text world))
+
+(deftest test-pickups-name-themselves
+  (is (= "Picked up a heart."
+         (msg-of (pickup-hearts (merge (player-at 5.0 5.0)
+                                       {:hearts [{:x 5.0 :y 5.0}] :lives 4})))))
+  (is (= "Picked up armor."
+         (msg-of (pickup-armors (merge (player-at 5.0 5.0)
+                                       {:armors [{:x 5.0 :y 5.0}]})))))
+  (is (= "Picked up an armor shard."
+         (msg-of (pickup-armor-shards (merge (player-at 5.0 5.0)
+                                             {:armor-shards [{:x 5.0 :y 5.0}]})))))
+  (is (= "Berserk!"
+         (msg-of (pickup-berserks (merge (player-at 5.0 5.0)
+                                         {:berserks [{:x 5.0 :y 5.0}]})))))
+  (is (= "Invulnerability!"
+         (msg-of (pickup-invulns (merge (player-at 5.0 5.0)
+                                        {:invulns [{:x 5.0 :y 5.0}]})))))
+  (is (= "Supercharge!"
+         (msg-of (pickup-soulspheres (merge (player-at 5.0 5.0)
+                                            {:soulspheres [{:x 5.0 :y 5.0}] :lives 4})))))
+  (is (= "Picked up a backpack."
+         (msg-of (pickup-backpacks (merge (player-at 5.0 5.0)
+                                          {:backpacks [{:x 5.0 :y 5.0}]}))))))
+
+(deftest test-weapon-pickup-names-the-weapon
+  (is (= "You got the SHOTGUN!"
+         (msg-of (pickup-weapon-pickups
+                  (merge (player-at 5.0 5.0)
+                         {:weapon-pickups [{:x 5.0 :y 5.0 :weapon :shotgun}]}))))))
+
+(deftest test-keycard-pickup-names-the-colour
+  ;; The card only showed as a small chip in the HUD strip, which is the
+  ;; one pickup that gates progress.
+  (is (= "Picked up the BLUE keycard."
+         (msg-of (pickup-keycards
+                  (merge (player-at 5.0 5.0)
+                         {:keycards [{:x 5.0 :y 5.0 :colour :blue}]}))))))
+
+(deftest test-ammo-pickup-names-itself
+  (is (= "Picked up ammo."
+         (msg-of (pickup-ammos (merge (player-at 5.0 5.0)
+                                      {:ammo-boxes [{:x 5.0 :y 5.0}]
+                                       :weapon :pistol}))))))
+
+(deftest test-a-missed-pickup-says-nothing
+  (is (= nil (msg-of (pickup-hearts (merge (player-at 5.0 5.0)
+                                           {:hearts [{:x 7.0 :y 7.0}] :lives 4}))))))

--- a/tests/io/paint-test.phel
+++ b/tests/io/paint-test.phel
@@ -1,7 +1,8 @@
 (ns phel-doom-tests.io.paint-test
   (:require phel.test :refer [deftest is])
+  (:require phel.string :as str)
   (:require phel-doom.io.render.buffer :refer [buf-mk])
-  (:require phel-doom.io.render.paint :refer [paint-crosshair paint-game-info paint-compass paint-hearts-hud paint-hit-vignette paint-intro-splash paint-reload-ready]))
+  (:require phel-doom.io.render.paint :refer [paint-crosshair paint-game-info paint-compass paint-hearts-hud paint-hit-vignette paint-intro-splash paint-reload-ready paint-message message-visible?]))
 
 ;; ---------------------------------------------------------------------
 ;; Crosshair legibility. The reticle must be a SOLID glyph, never the old
@@ -204,3 +205,38 @@
 (deftest test-reload-ready-flash-hidden-on-tiny-viewport
   (is (= "" (reload-ready-str {:reload-ready-secs 0.30} 8))
       "suppressed under 9 rows"))
+
+;; ---------------------------------------------------------------------
+;; Message line (#456). Steady for its ttl (no blink - calm 3D view),
+;; suppressed on short viewports, clipped to the viewport width.
+;; ---------------------------------------------------------------------
+
+(deftest test-message-visible-only-while-it-has-something-to-say
+  (is (= true  (message-visible? "Picked up a heart." 1.2 24)))
+  (is (= false (message-visible? "Picked up a heart." 0.0 24)) "expired")
+  (is (= false (message-visible? nil 1.2 24)) "no text")
+  (is (= false (message-visible? "" 1.2 24)) "empty text")
+  (is (= false (message-visible? "Picked up a heart." 1.2 7)) "short viewport")
+  (is (= true  (message-visible? "Picked up a heart." 1.2 8)) "vh 8 is the boundary"))
+
+(deftest test-paint-message-writes-one-steady-row
+  (let [parts (paint-message (buf-mk) {:msg-text "Berserk!" :msg-secs 1.0} 80 24)
+        out   (php/implode "" parts)]
+    (is (str/contains? out "Berserk!"))
+    (is (str/contains? out "\e[3;1H") "row 3, left aligned")
+    (is (not (str/contains? out "\e[5")) "no terminal blink attribute")))
+
+(deftest test-paint-message-clips-at-its-right-edge
+  ;; The minimap panel's content starts on row 3 as well and this pass
+  ;; paints after it, so the line must stop at the panel's left margin.
+  (let [long-text (php/str_repeat "x" 200)
+        out       (php/implode "" (paint-message (buf-mk)
+                                                 {:msg-text long-text :msg-secs 1.0}
+                                                 40 24))]
+    (is (str/contains? out (php/str_repeat "x" 40)))
+    (is (not (str/contains? out (php/str_repeat "x" 41)))
+        "never past the edge the caller reserved")))
+
+(deftest test-paint-message-is-byte-identical-when-silent
+  (is (= "" (php/implode "" (paint-message (buf-mk) {:msg-secs 0.0} 80 24))))
+  (is (= "" (php/implode "" (paint-message (buf-mk) {} 80 24)))))

--- a/tests/io/savegame-test.phel
+++ b/tests/io/savegame-test.phel
@@ -53,7 +53,11 @@
     (is (= (:grid w) (:grid back)) "grid preserved")
     (is (= 1.5 (:x (:player back))))
     (is (some? (:pgrid back)) "pgrid rebuilt on load")
-    (is (php/is_array (:light-grid back)) "light-grid rebuilt as a php array on load")))
+    (is (php/is_array (:light-grid back)) "light-grid rebuilt as a php array on load")
+    ;; #456: the message line is transient - a save must not load still
+    ;; announcing the pickup that happened before it.
+    (is (= nil (:msg-text back)) "message text is not persisted")
+    (is (= nil (:msg-secs back)) "nor its timer")))
 
 (deftest test-savestring-drops-and-rederives-light-grid
   ;; #418: :light-grid is derived from :grid (like :pgrid) - it must NOT be


### PR DESCRIPTION
## 📚 Description

Every pickup was the same door tink plus the item vanishing, so a first-timer could not tell an armor shard from an ammo box, know the keycard was now held, or see that a pickup had auto-switched their weapon. Secret reveals said nothing at all.

## 🔖 Changes

- `state/push-msg` stamps `:msg-text` + `:msg-secs` (2.0s), decayed with the other feel timers in `combat/decay-timers`.
- Every pickup names itself through the shared `consume-at` skeleton (`Picked up a heart.`, `Picked up the BLUE keycard.`, `You got the SHOTGUN!`, ...); the secret reveal and the weapon-slot switch (`SHOTGUN 4/12`) stamp their own. A refused swap - unowned slot, mid-reload, slot already held - says nothing.
- `paint-message` paints one left-aligned row at row 3, steady for its ttl (no blink), hidden below `vh` 8, clipped at the caller's right edge: the minimap panel's content starts on row 3 too and this pass paints after it. Verified against a live 80x24 frame with the map on - longest message 29 columns against a clip at 52.
- Byte-identical when there is nothing to say. Quick-saves drop both fields.
- Docs: rendering.md (new section), state.md (world fields + timers table).

Review: a Fable `clean-code-reviewer` pass flagged the missing docs/state.md sync and four untested paths (secret message, weapon-switch took/refused/same-slot, savegame drop, the `vh` 8 boundary); all added here. The minimap clip was found first by rendering a real frame with an over-long message.

Closes #456