### PR TITLE
feat: show an enemy's attack wind-up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 
 ### Added
 
-- Enemies show their wind-up (#457): an enemy in the frozen moment before a swing or a fireball now carries a steady `!` above its head, in its own colour. The wind-up is 0.3-0.8s and dodging it is meant to be the skill, but in sprite mode there was nothing to read - the billboard is one baked frame and the face overlay is skipped, so a far cacodemon about to fire looked exactly like a dormant one. No pulse, and it costs one pass over enemies the frame had already projected.
+- Enemies show their wind-up (#457): an enemy in the frozen moment before a swing or a fireball now carries a steady `!` above its head, in its own colour. The wind-up is 0.3-0.8s and dodging it is meant to be the skill, but in sprite mode there was nothing to read - the billboard is one baked frame and the face overlay is skipped, so a far cacodemon about to fire looked exactly like a dormant one. No pulse, and at full detail it costs one pass over enemies the frame had already projected.
 - A Doom-style message line names what just happened (#456): `Picked up a heart.`, `Picked up the BLUE keycard.`, `You got the SHOTGUN!`, `A secret is revealed!`, and the weapon plus its ammo when you switch slots. Every pickup used to be the same door tink and the item vanishing, so a first-timer could not tell an armor shard from an ammo box, know the keycard was now held, or see that a pickup had auto-switched their weapon. One steady row for 2 seconds, no blink, clipped to the viewport and hidden on very short ones; the frame is byte-identical when there is nothing to say.
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 
 ### Added
 
+- Enemies show their wind-up (#457): an enemy in the frozen moment before a swing or a fireball now carries a steady `!` above its head, in its own colour. The wind-up is 0.3-0.8s and dodging it is meant to be the skill, but in sprite mode there was nothing to read - the billboard is one baked frame and the face overlay is skipped, so a far cacodemon about to fire looked exactly like a dormant one. No pulse, and it costs one pass over enemies the frame had already projected.
 - A Doom-style message line names what just happened (#456): `Picked up a heart.`, `Picked up the BLUE keycard.`, `You got the SHOTGUN!`, `A secret is revealed!`, and the weapon plus its ammo when you switch slots. Every pickup used to be the same door tink and the item vanishing, so a first-timer could not tell an armor shard from an ammo box, know the keycard was now held, or see that a pickup had auto-switched their weapon. One steady row for 2 seconds, no blink, clipped to the viewport and hidden on very short ones; the frame is byte-identical when there is nothing to say.
 
 ### Changed

--- a/docs/monsters.md
+++ b/docs/monsters.md
@@ -126,6 +126,10 @@ Player ducks around corner:
 3. Hunter walks to frozen `:lkp` while player runs.
 4. Hunter reaches `:lkp` with no LOS → `:dormant`. Escape.
 
+## Attack telegraph
+
+An enemy in `:attacking` (the frozen windup before a swing or a bolt) carries a steady `!` above its head, in its own head colour. See [rendering.md](rendering.md#attack-telegraph-issue-457) - without it the windup was invisible in sprite mode, and dodging depends on reading it.
+
 ## Respawn
 
 Killed enemy stays in vector with `:alive false` + `:respawn-after` timer (uniform 3-6s; nightmare: 1-2s).

--- a/docs/rendering.md
+++ b/docs/rendering.md
@@ -230,6 +230,14 @@ When the game-loop's startup calibration finds full detail too slow for a smooth
 
 H/ESC info menu width-adaptive: max 44 chars, min 36. Drops CONTROLS section first, then COMPASS HINT on squeeze.
 
+## Attack telegraph (issue #457)
+
+A steady `!` one row above the head of any enemy in the `:attacking` state, in the type's head colour on a dark BG. Casters freeze for a 0.6-0.8s windup before the bolt launches and melee monsters for 0.3-0.8s before the swing, which is what makes dodging a skill - but in sprite mode there was nothing to read: the billboard is one baked frame and `paint-face-overlay` is skipped, so a far cacodemon about to fire looked exactly like a dormant one.
+
+`paint-attack-telegraphs` filters the same already-projected enemy bundle the face glyph uses (`project-enemy-pd` carries `:state` at no extra cost), so it is one pass over a list the frame already built. Held for the whole windup with no pulse, tracking the pitch shear.
+
+Depth-gated by `enemy-front-visible-at?` like the face glyph, and for the same reason: `collect-enemy-projs` projects every alive enemy in the frustum with no occlusion test, so an ungated mark would float over the wall an enemy is winding up behind - a free wallhack pointing at the next ambush. Scene-space contract as well: `vw` / `vh` / `dists` / `edists` / `pr` are scene cells and `sc` scales the emitted terminal coordinates, so pixel-doubled mode re-projects at `svw` exactly like the face overlay.
+
 ## Message line (issue #456)
 
 One left-aligned row at row 3 naming what just happened: `Picked up a heart.`, `Picked up the BLUE keycard.`, `You got the SHOTGUN!`, `A secret is revealed!`, or the weapon and its ammo on a slot switch. Before it, every pickup was the same door tink plus the item vanishing, so a first-timer could not tell a shard from an ammo box or know a keycard was now held.

--- a/docs/rendering.md
+++ b/docs/rendering.md
@@ -234,9 +234,13 @@ H/ESC info menu width-adaptive: max 44 chars, min 36. Drops CONTROLS section fir
 
 A steady `!` one row above the head of any enemy in the `:attacking` state, in the type's head colour on a dark BG. Casters freeze for a 0.6-0.8s windup before the bolt launches and melee monsters for 0.3-0.8s before the swing, which is what makes dodging a skill - but in sprite mode there was nothing to read: the billboard is one baked frame and `paint-face-overlay` is skipped, so a far cacodemon about to fire looked exactly like a dormant one.
 
-`paint-attack-telegraphs` filters the same already-projected enemy bundle the face glyph uses (`project-enemy-pd` carries `:state` at no extra cost), so it is one pass over a list the frame already built. Held for the whole windup with no pulse, tracking the pitch shear.
+`paint-attack-telegraphs` filters the enemy bundle the zone pass already built (`project-enemy-pd` carries `:state` at no extra cost), so at full detail it is one pass over an existing list. Pixel-doubled mode re-projects at `svw` because the scene casts with a halved numerator - see below. Held for the whole windup with no pulse, tracking the pitch shear, and scaled by the sprite's own `:scale` so the boss's mark sits above its 2x head rather than on its chest.
 
-Depth-gated by `enemy-front-visible-at?` like the face glyph, and for the same reason: `collect-enemy-projs` projects every alive enemy in the frustum with no occlusion test, so an ungated mark would float over the wall an enemy is winding up behind - a free wallhack pointing at the next ambush. Scene-space contract as well: `vw` / `vh` / `dists` / `edists` / `pr` are scene cells and `sc` scales the emitted terminal coordinates, so pixel-doubled mode re-projects at `svw` exactly like the face overlay.
+Depth-gated by `enemy-front-visible-at?` like the face glyph, and for the same reason: `collect-enemy-projs` projects every alive enemy in the frustum with no occlusion test, so an ungated mark would float over the wall an enemy is winding up behind - a free wallhack pointing at the next ambush. Scene-space contract as well: `vw` / `vh` / `dists` / `edists` / `pr` are scene cells and `sc` scales the emitted terminal coordinates.
+
+Pixel-doubled mode needs the SCENE projection numerator, not the full one: the px2 scene casts and places sprite bodies with `scene-pd = 0.5 * proj-dist`, so a bundle projected at `svw` with the full numerator puts an off-centre enemy at roughly twice its real horizontal offset - and the depth gate then samples `dists` / `edists` at that drifted column. `collect-enemy-projs-pd` takes the numerator for exactly this. The face overlay still builds its px2 bundle with the full numerator (same latent drift, but changing it moves golden hashes, so it is tracked separately).
+
+Two overlaps are deliberate. A wounded attacker's HP digit targets the same cell; the telegraph paints later, so the `!` wins during the windup and the digit resumes after - the windup is the more urgent read. And a point-blank attacker's mark can land on HUD row 1 or 2, which is better than hiding the cue on the enemy about to hit you.
 
 ## Message line (issue #456)
 

--- a/src/io/render/frame_math.phel
+++ b/src/io/render/frame_math.phel
@@ -716,7 +716,7 @@
    projection numerator `pd` (`proj-dist` at full detail, half of it in
    the pixel-doubled scene so columns/widths land in scene cells).
    Returns {:col :half-width :dist :scale :damage-ratio :type :lives
-   :max-lives :hit-flash-secs} or nil when behind / off-screen — see
+   :max-lives :hit-flash-secs :state} or nil when behind / off-screen — see
    `project-enemy` for the field contract. `:lives` / `:max-lives` /
    `:hit-flash-secs` ride along at zero extra cost (`lives`/`max-lives`
    are already computed locals for `:damage-ratio`; `:hit-flash-secs`
@@ -755,7 +755,11 @@
            :type         (:type enemy)
            :lives        lives
            :max-lives    max-lives
-           :hit-flash-secs (or (:hit-flash-secs enemy) 0.0)})))))
+           :hit-flash-secs (or (:hit-flash-secs enemy) 0.0)
+           ;; AI state rides along for the attack telegraph (#457): the
+           ;; overlay needs to know who is mid-windup, and the zone pass
+           ;; has already projected every alive enemy.
+           :state        (:state enemy)})))))
 
 (defn project-enemy
   "Project one enemy into screen space relative to the player. Returns

--- a/src/io/render/frame_math.phel
+++ b/src/io/render/frame_math.phel
@@ -772,6 +772,27 @@
   [enemy player ^int vw]
   (project-enemy-pd proj-dist enemy player vw))
 
+(defn collect-enemy-projs-pd
+  "`collect-enemy-projs` for an explicit projection numerator (#457).
+
+   The pixel-doubled scene casts and places sprites with `0.5 *
+   proj-dist` (main/scene-pd), so a bundle projected at `svw` with the
+   FULL numerator puts an off-centre enemy at roughly twice its real
+   horizontal offset. Overlays that read `dists` / `edists` at a
+   projected column need the same numerator the scene used, or they
+   sample the wrong column and can hide - or leak - a mark."
+  [pd enemies player vw]
+  (let [raw (loop [es enemies acc []]
+              (if (php/=== es nil)
+                acc
+                (let [e (first es)]
+                  (recur (next es)
+                         (if (and e (:alive e))
+                           (let [p (project-enemy-pd pd e player vw)]
+                             (if p (conj acc p) acc))
+                           acc)))))]
+    (sort-by (fn [x] (php/- 0.0 (:dist x))) raw)))
+
 (defn collect-enemy-projs
   "Project every alive enemy and return a vector sorted by distance
    descending — back-to-front so closer sprites overwrite farther ones

--- a/src/io/render/main.phel
+++ b/src/io/render/main.phel
@@ -7,7 +7,7 @@
   (:require phel-doom.io.render.wall-texture-data :refer [wall-tex])
   (:require phel-doom.io.render.enemy-sprite :refer [sprite-for-type-lod sprite-fade sprite-fade-index sprite-col-x sprite-subcol-x enemy-sprite-cell enemy-sprite-quad])
   (:require phel-doom.io.render.hud :refer [minimap-door-pulse minimap-rows minimap-frame hud-debug-line hud-line-str help-menu-string settings-menu-string pause-menu-string])
-  (:require phel-doom.io.render.paint :refer [paint-face-overlay paint-crosshair paint-intro-splash paint-locked-bump paint-blood-drops paint-rear-warning paint-low-ammo paint-reload-reminder paint-message paint-save-flash paint-reload-ready paint-game-info paint-berserk-badge paint-invuln-badge paint-empty-click paint-heartbeat-vignette paint-hit-vignette paint-berserk-tint paint-heat-bar paint-kill-streak paint-compass paint-enemy-hp-flashes paint-hearts-hud paint-weapon-hud])
+  (:require phel-doom.io.render.paint :refer [paint-face-overlay paint-crosshair paint-intro-splash paint-locked-bump paint-blood-drops paint-rear-warning paint-low-ammo paint-reload-reminder paint-message paint-attack-telegraphs paint-save-flash paint-reload-ready paint-game-info paint-berserk-badge paint-invuln-badge paint-empty-click paint-heartbeat-vignette paint-hit-vignette paint-berserk-tint paint-heat-bar paint-kill-streak paint-compass paint-enemy-hp-flashes paint-hearts-hud paint-weapon-hud])
   (:require phel-doom.io.render.sprites :refer [paint-blood-fx-into paint-pickups-into paint-projectiles-into paint-tracers-into build-blood-cols sprites-enabled?])
   (:require phel-doom.core.engine :refer [cast-frame max-depth proj-dist])
   (:require phel-doom.core.map :refer [cell-door cell-door-blue cell-door-red cell-door-boss cell-door-yellow])
@@ -2288,9 +2288,17 @@
             ;; Shared enemy-projs: both are projected at the full `vw`, so
             ;; this is a pure filter over already-computed data.
             p19c        (paint-enemy-hp-flashes   p19b enemy-projs vw vh pr-full)
+            ;; Same scene-space contract as the face overlay: depth-gated
+            ;; by dists/edists so a windup behind a wall stays hidden, and
+            ;; px2 re-projects at svw like the face glyph does.
+            p19c2       (paint-attack-telegraphs  p19c
+                                                  (if px2?
+                                                    (collect-enemy-projs (:enemies world) (:player world) svw)
+                                                    enemy-projs)
+                                                  stats svw svh dists edists px-sc pr)
             ;; Clipped at the minimap's left margin: the panel's content
             ;; starts on row 3 too, and this pass paints after it.
-            p19d        (paint-message           p19c stats
+            p19d        (paint-message           p19c2 stats
                                                  (if (php/> visible-mh 0)
                                                    (php/max 1 (php/- map-col 2))
                                                    vw)

--- a/src/io/render/main.phel
+++ b/src/io/render/main.phel
@@ -3,7 +3,7 @@
 (ns phel-doom.io.render.main
   (:require phel-doom.io.render.buffer :refer [buf-mk buf-set buf-get buf-push])
   (:require phel-doom.io.render.palette :refer [enemy-head enemy-body sprite-shadow heart-shade heart-shade-bright heart-glyph heart-glyph-bright armor-shade armor-shade-bright armor-glyph armor-glyph-bright armor-shard-shade armor-shard-shade-bright armor-shard-glyph armor-shard-glyph-bright ammo-shade ammo-shade-bright ammo-glyph ammo-glyph-bright berserk-shade berserk-shade-bright berserk-glyph berserk-glyph-bright invuln-shade invuln-shade-bright invuln-glyph invuln-glyph-bright soulsphere-shade soulsphere-shade-bright soulsphere-glyph soulsphere-glyph-bright backpack-shade backpack-shade-bright backpack-glyph backpack-glyph-bright shotgun-pickup-shade shotgun-pickup-bright shotgun-pickup-glyph shotgun-pickup-glyph-bright chaingun-pickup-shade chaingun-pickup-bright chaingun-pickup-glyph chaingun-pickup-glyph-bright bfg-pickup-shade bfg-pickup-bright bfg-pickup-glyph bfg-pickup-glyph-bright incinerator-pickup-shade incinerator-pickup-bright incinerator-pickup-glyph incinerator-pickup-glyph-bright rocket-pickup-shade rocket-pickup-bright rocket-pickup-glyph rocket-pickup-glyph-bright keycard-blue-shade keycard-blue-bright keycard-blue-glyph keycard-blue-glyph-bright keycard-red-shade keycard-red-bright keycard-red-glyph keycard-red-glyph-bright keycard-yellow-shade keycard-yellow-bright keycard-yellow-glyph keycard-yellow-glyph-bright shade-table shade-code-table shade-table-blood shade-code-table-blood theme-floor-code])
-  (:require phel-doom.io.render.frame-math :refer [enemy-shade-string enemy-textured-shade-string boss-col-paint aggro-distance enemy-aggro-head-string build-horizon-gradient build-themed-gradient build-themed-gradient-codes tex-fade-table tex-fade-tc bg-cell-cache halfblock halfblock-tc paint-bg quadblock build-sky-halfblock build-sky-codes-sub seam-darken-16 seam-darken-8 seam-darken-5 seam-shade! collect-enemy-projs layout pulse visuals-for-type enemy-front-visible-at?])
+  (:require phel-doom.io.render.frame-math :refer [enemy-shade-string enemy-textured-shade-string boss-col-paint aggro-distance enemy-aggro-head-string build-horizon-gradient build-themed-gradient build-themed-gradient-codes tex-fade-table tex-fade-tc bg-cell-cache halfblock halfblock-tc paint-bg quadblock build-sky-halfblock build-sky-codes-sub seam-darken-16 seam-darken-8 seam-darken-5 seam-shade! collect-enemy-projs collect-enemy-projs-pd layout pulse visuals-for-type enemy-front-visible-at?])
   (:require phel-doom.io.render.wall-texture-data :refer [wall-tex])
   (:require phel-doom.io.render.enemy-sprite :refer [sprite-for-type-lod sprite-fade sprite-fade-index sprite-col-x sprite-subcol-x enemy-sprite-cell enemy-sprite-quad])
   (:require phel-doom.io.render.hud :refer [minimap-door-pulse minimap-rows minimap-frame hud-debug-line hud-line-str help-menu-string settings-menu-string pause-menu-string])
@@ -2291,9 +2291,15 @@
             ;; Same scene-space contract as the face overlay: depth-gated
             ;; by dists/edists so a windup behind a wall stays hidden, and
             ;; px2 re-projects at svw like the face glyph does.
+            ;; px2 projects with the SCENE numerator, not the full one:
+            ;; the scene casts at scene-pd, so a full-pd bundle at svw
+            ;; would drift an off-centre mark (and sample dists/edists at
+            ;; the drifted column). The face overlay above still uses the
+            ;; full-pd bundle - same latent drift, but fixing it moves
+            ;; golden hashes, so it is filed separately.
             p19c2       (paint-attack-telegraphs  p19c
                                                   (if px2?
-                                                    (collect-enemy-projs (:enemies world) (:player world) svw)
+                                                    (collect-enemy-projs-pd scene-pd (:enemies world) (:player world) svw)
                                                     enemy-projs)
                                                   stats svw svh dists edists px-sc pr)
             ;; Clipped at the minimap's left margin: the panel's content

--- a/src/io/render/paint.phel
+++ b/src/io/render/paint.phel
@@ -904,6 +904,50 @@
                            (:lives proj) "\e[0m")))))))
   parts)
 
+(defn paint-attack-telegraphs
+  "Steady `!` one row above the head of every enemy mid-windup (#457).
+
+   A caster freezes for its 0.6-0.8s `:attacking` window before the bolt
+   launches, and a melee monster for 0.3-0.8s before the swing - the
+   whole point being that the player can read it and strafe. In sprite
+   mode there was nothing to read: the billboard is one baked frame and
+   `paint-face-overlay` is skipped, so a far cacodemon about to fire
+   looked exactly like a dormant one.
+
+   Held for the whole windup with no pulse (calm 3D view), in the type's
+   head colour on a dark BG so it reads against any sprite behind it.
+
+   Depth-gated by `enemy-front-visible-at?` exactly like the face glyph:
+   `collect-enemy-projs` projects every alive enemy in the frustum with
+   no occlusion test, so without the gate an enemy winding up BEHIND a
+   wall would float an `!` over that wall - a free wallhack pointing at
+   the next ambush.
+
+   Scene-space contract matches `paint-face-overlay`: `vw` / `vh` /
+   `dists` / `edists` / `pr` are scene cells and `sc` is the render pixel
+   scale applied to the emitted terminal coordinates, so the caller
+   passes a bundle projected at the same `vw`."
+  [parts enemy-projs stats ^int vw ^int vh dists edists ^int sc & [pr-arg]]
+  (let [pr (or pr-arg 0)]
+    (doseq [proj enemy-projs]
+      (when (and (= :attacking (:state proj))
+                 (php/> (or (:lives proj) 0) 0))
+        (let [col (:col proj)
+              d   (:dist proj)]
+          (when (and (php/>= col 0)
+                     (php/< col vw)
+                     (enemy-front-visible-at? d col dists edists))
+            (let [h        (sprite-h vh d 1.0)
+                  feet-row (php/+ (php/intval (php/round (php/+ (php// vh 2.0) (php/* 0.5 (wall-px proj-dist d))))) pr)
+                  row      (php/- (php/- feet-row h) 1)]
+              (when (and (php/>= row 1) (php/<= row vh))
+                (buf-push parts
+                          (str "\e[" (php/* sc row) ";" (php/+ (php/* sc col) 1)
+                               "H\e[40;1;38;5;"
+                               (or (:head-code (visuals-for-type (:type proj) stats)) 196)
+                               "m!\e[0m")))))))))
+  parts)
+
 (defn paint-hearts-hud
   "Top-left lives + armor count. Hearts are held steady bright (calmer 3D
    view): the old dim/bright pulse while bloody read as a strobe, and the

--- a/src/io/render/paint.phel
+++ b/src/io/render/paint.phel
@@ -926,7 +926,15 @@
    Scene-space contract matches `paint-face-overlay`: `vw` / `vh` /
    `dists` / `edists` / `pr` are scene cells and `sc` is the render pixel
    scale applied to the emitted terminal coordinates, so the caller
-   passes a bundle projected at the same `vw`."
+   passes a bundle projected at the same `vw` AND the same projection
+   numerator the scene cast with (`collect-enemy-projs-pd`).
+
+   Two overlaps are deliberate. A wounded attacker's HP digit targets the
+   same cell; this pass paints later, so the `!` wins for the windup and
+   the digit resumes after it - the wind-up is the more urgent read. And
+   a point-blank attacker's mark can land on HUD row 1 or 2: hiding the
+   cue on the enemy about to hit you would be worse than one transient
+   cell of compass."
   [parts enemy-projs stats ^int vw ^int vh dists edists ^int sc & [pr-arg]]
   (let [pr (or pr-arg 0)]
     (doseq [proj enemy-projs]
@@ -937,7 +945,11 @@
           (when (and (php/>= col 0)
                      (php/< col vw)
                      (enemy-front-visible-at? d col dists edists))
-            (let [h        (sprite-h vh d 1.0)
+            ;; `:scale` matters here where it does not for the face glyph:
+            ;; the cyberdemon's billboard is 2x tall, so a 1.0 height would
+            ;; put the mark on its chest in the one fight where reading the
+            ;; windup matters most.
+            (let [h        (sprite-h vh d (or (:scale proj) 1.0))
                   feet-row (php/+ (php/intval (php/round (php/+ (php// vh 2.0) (php/* 0.5 (wall-px proj-dist d))))) pr)
                   row      (php/- (php/- feet-row h) 1)]
               (when (and (php/>= row 1) (php/<= row vh))

--- a/tests/io/paint-test.phel
+++ b/tests/io/paint-test.phel
@@ -2,7 +2,7 @@
   (:require phel.test :refer [deftest is])
   (:require phel.string :as str)
   (:require phel-doom.io.render.buffer :refer [buf-mk])
-  (:require phel-doom.io.render.paint :refer [paint-crosshair paint-game-info paint-compass paint-hearts-hud paint-hit-vignette paint-intro-splash paint-reload-ready paint-message message-visible?]))
+  (:require phel-doom.io.render.paint :refer [paint-crosshair paint-game-info paint-compass paint-hearts-hud paint-hit-vignette paint-intro-splash paint-reload-ready paint-message message-visible? paint-attack-telegraphs]))
 
 ;; ---------------------------------------------------------------------
 ;; Crosshair legibility. The reticle must be a SOLID glyph, never the old
@@ -240,3 +240,75 @@
 (deftest test-paint-message-is-byte-identical-when-silent
   (is (= "" (php/implode "" (paint-message (buf-mk) {:msg-secs 0.0} 80 24))))
   (is (= "" (php/implode "" (paint-message (buf-mk) {} 80 24)))))
+
+;; ---------------------------------------------------------------------
+;; Attack telegraph (#457). A caster freezes for its 0.6-0.8s windup
+;; before launching, but the sprite is one static frame and the face
+;; overlay is skipped in sprite mode, so a far cacodemon about to fire
+;; looked exactly like a dormant one. A steady `!` over the head is the
+;; tell, held for the whole windup (no pulse - calm 3D view).
+;; ---------------------------------------------------------------------
+
+(def- clear-dists
+  ;; Every column's wall is far away, and no nearer enemy anywhere: the
+  ;; depth gate lets everything through.
+  (let [a (php/array)] (dotimes [i 81] (php/aset a i 99.0)) a))
+
+(def- no-enemy-depths
+  (let [a (php/array)] (dotimes [i 81] (php/aset a i nil)) a))
+
+(defn- telegraph-out [projs]
+  (php/implode "" (paint-attack-telegraphs (buf-mk) projs {} 80 24
+                                           clear-dists no-enemy-depths 1 0)))
+
+(def- winding-up
+  {:col 40 :dist 6.0 :type :caco :state :attacking :lives 3 :max-lives 3})
+
+(deftest test-telegraph-marks-an-enemy-winding-up
+  (is (str/contains? (telegraph-out [winding-up]) "!")))
+
+(deftest test-telegraph-ignores-every-other-state
+  (is (= "" (telegraph-out [(assoc winding-up :state :aware)])))
+  (is (= "" (telegraph-out [(assoc winding-up :state :dormant)])))
+  (is (= "" (telegraph-out [(assoc winding-up :state :hunting)])))
+  (is (= "" (telegraph-out [(dissoc winding-up :state)]))
+      "a projection without a state says nothing"))
+
+(deftest test-telegraph-skips-the-dead
+  (is (= "" (telegraph-out [(assoc winding-up :lives 0)]))))
+
+(deftest test-telegraph-skips-off-screen-columns
+  (is (= "" (telegraph-out [(assoc winding-up :col -1)])))
+  (is (= "" (telegraph-out [(assoc winding-up :col 80)]))))
+
+(deftest test-telegraph-does-not-shine-through-a-wall
+  ;; collect-enemy-projs has no occlusion test, so without the depth gate
+  ;; an enemy winding up behind a wall would float an `!` over it - a free
+  ;; wallhack pointing at the next ambush.
+  (let [near-wall (let [a (php/array)] (dotimes [i 81] (php/aset a i 2.0)) a)
+        out       (php/implode "" (paint-attack-telegraphs
+                                   (buf-mk) [winding-up] {} 80 24
+                                   near-wall no-enemy-depths 1 0))]
+    (is (= "" out) "enemy at depth 6 behind a wall at depth 2 paints nothing")))
+
+(deftest test-telegraph-hides-behind-a-nearer-sprite
+  (let [nearer (let [a (php/array)] (dotimes [i 81] (php/aset a i 3.0)) a)]
+    (is (= "" (php/implode "" (paint-attack-telegraphs
+                               (buf-mk) [winding-up] {} 80 24
+                               clear-dists nearer 1 0))))))
+
+(deftest test-telegraph-scales-into-terminal-cells-when-pixel-doubled
+  ;; Scene-space contract: sc multiplies the emitted coordinates, so the
+  ;; px2 mark lands on the doubled terminal cell, not the scene cell.
+  (let [out (php/implode "" (paint-attack-telegraphs
+                             (buf-mk) [(assoc winding-up :col 20)] {} 40 12
+                             clear-dists no-enemy-depths 2 0))]
+    (is (str/contains? out "!"))
+    (is (str/contains? out ";41H") "scene col 20 -> terminal col 2*20+1")))
+
+(deftest test-telegraph-does-not-blink
+  ;; Calm 3D view: no terminal blink attribute, and the same projection
+  ;; paints the same bytes on every frame.
+  (let [out (telegraph-out [winding-up])]
+    (is (not (str/contains? out "\e[5")))
+    (is (= out (telegraph-out [winding-up])))))

--- a/tests/io/paint-test.phel
+++ b/tests/io/paint-test.phel
@@ -310,5 +310,5 @@
   ;; Calm 3D view: no terminal blink attribute, and the same projection
   ;; paints the same bytes on every frame.
   (let [out (telegraph-out [winding-up])]
-    (is (not (str/contains? out "\e[5")))
+    (is (not (str/contains? out "\e[5m")) "no terminal blink attribute")
     (is (= out (telegraph-out [winding-up])))))

--- a/tests/io/render-cache-test.phel
+++ b/tests/io/render-cache-test.phel
@@ -1,5 +1,6 @@
 (ns phel-doom-tests.io.render-cache-test
   (:require phel.test :refer [deftest is])
+  (:require phel.string :as str)
   (:require phel-doom.core.level :refer [build-world])
   (:require phel-doom.core.engine :refer [mark-visible-cells])
   (:require phel-doom.core.rng :as rng)
@@ -418,3 +419,29 @@
     (is (not (php/str_contains locked minimap-door-pulse)) "locked: no orange door yet")
     (is (php/str_contains unlocked minimap-door-pulse)   "killed: door turns orange")
     (is (not (php/str_contains unlocked boss-door-marker)) "killed: red marker gone")))
+
+;; ---------------------------------------------------------------------
+;; Attack telegraph at frame level (#457). The unit tests call the
+;; painter directly; this pins the 9-arg wiring in frame->string, where a
+;; swapped dists/edists pair would otherwise pass everything.
+;; ---------------------------------------------------------------------
+
+(defn- world-with-attacker [state]
+  ;; One enemy dead ahead of the player, close enough to be unobstructed.
+  (let [p  (:player world)
+        px (:x p)
+        py (:y p)]
+    (assoc world :enemies
+           [{:x (php/+ px 1.5) :y py :alive true :lives 3 :max-lives 3
+             :type :imp :state state :hit-flash-secs 0.0}])))
+
+(deftest test-frame-marks-an-attacking-enemy
+  (is (str/contains? (frame->string (world-with-attacker :attacking) stats 120 30)
+                     "m!\e[0m")
+      "the windup mark reaches the emitted frame"))
+
+(deftest test-frame-shows-no-mark-without-a-windup
+  ;; Same enemy, same place, not winding up: nothing is painted, which is
+  ;; also what "costs nothing when nobody attacks" means.
+  (is (not (str/contains? (frame->string (world-with-attacker :aware) stats 120 30)
+                          "m!\e[0m"))))


### PR DESCRIPTION
## 📚 Description

A caster freezes for 0.6-0.8s before its bolt launches and a melee monster for 0.3-0.8s before the swing; reading that window is what makes dodging a skill. In sprite mode there was nothing to read - the billboard is one baked frame and the face overlay is skipped - so a far cacodemon about to fire looked exactly like a dormant one.

## 🔖 Changes

- `project-enemy-pd` carries `:state` (free: the zone pass already projects every alive enemy).
- `paint-attack-telegraphs` paints a steady `!` one row above the head of anything mid-windup, in the type's head colour on a dark BG. No pulse, and it tracks the pitch shear.
- Depth-gated by `enemy-front-visible-at?`, like the face glyph: `collect-enemy-projs` has no occlusion test, so an ungated mark would float over the wall an enemy is winding up behind - a wallhack pointing at the next ambush. Tests pin both the wall case and the nearer-sprite case.
- Same scene-space contract as the face overlay, so pixel-doubled mode re-projects at `svw` and the mark lands on the doubled terminal cell (tested).
- Docs: rendering.md (new section), monsters.md.

Closes #457