### PR TITLE
feat: the damage flash is dark red, not full-screen white

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ User-facing changes (`feat:`, `fix:`, `perf:`) belong under `## [Unreleased]` un
 
 ### Changed
 
+- The damage flash is dark red instead of full-screen white (#465). Doom's pain language is red; the white wash was the last full-screen strobe left in the calm 3D view, and at the rate an enemy can land hits it blanked the attacker for two frames at exactly the moment you needed to see where the damage came from. Same 0.05s duration.
+
 - Quitting and restarting ask before they act, and the game pauses when you alt-tab away (#454). `q` sits one key from `w` and used to end a run on the spot; in game it now opens the pause menu with the cursor on Quit, so the confirmation is the second `q` (or Enter on that row). From the pause page `q` still quits and still persists settings, and the start menu and end screens are unchanged. Restart on the pause menu asks the same way: the first select arms it (`Restart?  enter again`), moving the cursor disarms it. And the terminal now reports focus (`\e[?1004h`), so losing the window pauses a live run and drops the held movement instead of leaving the player standing in front of an enemy. Inside tmux the pane needs `focus-events on`.
 
 ### Fixed

--- a/docs/combat.md
+++ b/docs/combat.md
@@ -94,7 +94,7 @@ Weapons flagged `:pierce?` (the pistol) or `:spread?` (the shotgun) take a diffe
 On contact:
 - Armor absorbs the whole hit (drop one armor unit, no life lost regardless of damage size); otherwise lose `hit-damage-for (:type attacker)` HP.
 - Arm 1.0s i-frames (prevent double-drain).
-- 0.05s white flash (impact jolt).
+- 0.05s dark-red flash (impact jolt, issue #465 - Doom's pain language, and the white wash it replaced was the last full-screen strobe in the calm 3D view).
 - Knockback away from attacker (try 1.0 / 0.5 / 0.25 units on wall collision).
 - Stamp `:hurt-side` (`:front` / `:back` / `:left` / `:right`, via `attacker-side`) for the 4-way blood-drip edge columns. Front/back use ±30° wedges around facing; everything else routes to left/right.
 - Stamp `:hurt-dir` (octant 0..7, via `attacker-octant`) for the precise 8-way directional damage arc (issue #201): render paints a centred red bar on the matching edge for the four cardinals, or an L at the matching corner for the four diagonals, so the player reads the exact incoming-damage bearing while i-frames are active. Single-shot feedback, kept in the calm 3D view.

--- a/docs/rendering.md
+++ b/docs/rendering.md
@@ -24,7 +24,7 @@ Entry point: `render! [world stats cols rows]` - cursor home, pick impact flash 
 ```phel
 (print "\e[H")                      ; cursor home
 (if (php/> (get stats :flash-secs) 0.0)
-  (print (white-flash-frame ...))   ; hit flash overlay
+  (print (pain-flash-frame ...))    ; hit flash overlay (dark red, #465)
   (print (frame->string ...)))
 (php/flush)
 ```
@@ -188,7 +188,7 @@ Camera pitch (arrow keys or mouse, issue #243) is rendered as a pure **vertical 
 
 **Weapon bob (#412)** shares the same `:bob-phase` and View bob intensity, applied to the viewmodel anchor in `paint-weapon-sprite` instead of the horizon. Two terms fold into the sprite's existing `shift`/`c0`: `projection/weapon-bob-rows` = `round(intensity * weapon-bob-cap * vh * abs(sin(phase)))` (`weapon-bob-cap` = 0.04) drops the gun on each footfall (`abs(sin)` = a downward bowl, so the gun dips but never rises above rest, unlike the symmetric head-bob), and `projection/weapon-bob-cols` = `round(intensity * weapon-sway-cap * vw * sin(phase))` (`weapon-sway-cap` = 0.02) sways it left/right. The muzzle flash tracks both. `c0` is clamped so the sway never runs the sprite off-screen. Same byte-identical contract: `intensity = 0` or `phase = 0` yields 0 in both axes, so a resting / bob-off frame draws the gun exactly where the no-bob path did.
 
-**Weapon-fire extralight (#413)** briefly brightens the room the frame or two after a shot, the feasible stand-in for a dynamic muzzle point-light (epic #408). `frame->string` subtracts `combat/fire-extralight((:fire-anim stats), duration)` from the near-death `haze-shift`, so the net shift can go NEGATIVE and pull walls toward the bright end of the 24-step shade table. `fire-extralight` returns `muzzle-extralight-steps` (4) while `fire-anim` sits in the first `muzzle-flash-fraction` (0.25) of its animation and 0 otherwise, so the flash lasts ~1-2 frames rather than the whole recoil, and is 0 when idle (resting frame stays byte-identical). Because a negative shift can push a shade index above 23, `compute-wall-shades` clamps `idx` to `[0, 23]`; without the upper clamp the index runs past the shade table and the frame breaks. It cannot collide with the pain-flash: a damage frame short-circuits to `white-flash-frame` before `frame->string` runs. Sky and floor stay untouched, exactly as the near-death haze leaves them.
+**Weapon-fire extralight (#413)** briefly brightens the room the frame or two after a shot, the feasible stand-in for a dynamic muzzle point-light (epic #408). `frame->string` subtracts `combat/fire-extralight((:fire-anim stats), duration)` from the near-death `haze-shift`, so the net shift can go NEGATIVE and pull walls toward the bright end of the 24-step shade table. `fire-extralight` returns `muzzle-extralight-steps` (4) while `fire-anim` sits in the first `muzzle-flash-fraction` (0.25) of its animation and 0 otherwise, so the flash lasts ~1-2 frames rather than the whole recoil, and is 0 when idle (resting frame stays byte-identical). Because a negative shift can push a shade index above 23, `compute-wall-shades` clamps `idx` to `[0, 23]`; without the upper clamp the index runs past the shade table and the frame breaks. It cannot collide with the pain-flash: a damage frame short-circuits to `pain-flash-frame` before `frame->string` runs. Sky and floor stay untouched, exactly as the near-death haze leaves them.
 
 
 ## Half-block sub-pixel rendering (floor / walls / sky)

--- a/docs/state.md
+++ b/docs/state.md
@@ -56,7 +56,7 @@ Pure data shapes that every other module operates on. `src/core/state.phel`.
  :shake-secs <float seconds>  ; screen-shake kick (damage + heavy-weapon fire/blast)
  :fire-anim  <float seconds>  ; muzzle flash visibility
  :intro-secs <float seconds>  ; level intro splash countdown
- :flash-secs <float seconds>  ; 1-frame white impact flash
+ :flash-secs <float seconds>  ; 1-frame dark-red impact flash
  :msg-text   <string|nil>     ; message line: what was just picked up / revealed / switched to
  :msg-secs   <float seconds>  ; how long that line stays up
  :fx         <vector of blood splatters>
@@ -159,7 +159,7 @@ Float-seconds countdowns on the world, decayed by `decay-timers` in `core/combat
 |---|---|---|
 | `:iframes` | `take-damage` (1.0s) | Red palette flush + immunity window |
 | `:shake-secs` | `take-damage` (0.25s), heavy-weapon fire/blast (splash-radius-scaled) | Cursor-home offset screen-shake |
-| `:flash-secs` | `take-damage` (0.05s) | 1-frame all-white impact |
+| `:flash-secs` | `take-damage` (0.05s) | 1-frame all-red impact wash (#465) |
 | `:fire-anim` | `fire-shot` (0.09s) | Muzzle flash visibility |
 | `:intro-secs` | `build-world` (1.5s) | "LEVEL N · NAME" splash overlay |
 | `:msg-secs` | `push-msg` (2.0s) | Message line naming the pickup / secret / weapon (#456) |

--- a/src/io/render/main.phel
+++ b/src/io/render/main.phel
@@ -2346,12 +2346,18 @@
   []
   (print "\e[2J\e[H"))
 
-(defn- white-flash-frame
-  "Full-screen white wash, one frame. Painted on impact so the player
-   sees a brief jolt before the red i-frame palette swap kicks in."
+(defn- pain-flash-frame
+  "Full-screen dark-red wash, one frame. Painted on impact so the player
+   sees a brief jolt before the red i-frame palette swap kicks in.
+
+   Red, not white (#465). Doom's pain language is red, the white wash was
+   the last full-screen strobe left in the calm 3D view, and at the ~1Hz
+   an enemy can land hits it blanked the attacker for two frames at
+   exactly the moment the player needed to see where the damage came
+   from. Same duration; only the colour changed."
   [cols rows]
   (let [parts (buf-mk)
-        line  (str "\e[107m" (php/str_repeat " " cols))]
+        line  (str "\e[48;5;124m" (php/str_repeat " " cols))]
     (buf-push parts "\e[H")
     (loop [r 1]
       (when (php/<= r rows)
@@ -2418,7 +2424,7 @@
     (when (get stats :mouse) (print "\e[>3p"))
     (print (str "\e[1;" shake-x "H"))
     (if (php/> (or (get stats :flash-secs) 0.0) 0.0)
-      (print (white-flash-frame cols rows))
+      (print (pain-flash-frame cols rows))
       (if debug?
         (let [t-start  (php/microtime true)
               frame    (frame->string world stats cols rows)


### PR DESCRIPTION
## 📚 Description

`white-flash-frame` washed the whole viewport white for 0.05s on every hit, armor-absorbed included. Doom's pain language is red, this was the last full-screen strobe left in the calm 3D view, and at the rate an enemy can land hits it blanked the attacker for two frames at exactly the moment you needed to see where the damage came from.

## 🔖 Changes

- `\e[107m` -> `\e[48;5;124m`, renamed `pain-flash-frame`. Same duration, same trigger.
- Docs: rendering.md (pipeline snippet + the extralight interaction note), combat.md, state.md.

Confirmed as a design call before implementing.

Closes #465