### PR TITLE
test(render): pin the overlays together, not just one at a time

### DIFF
--- a/docs/rendering.md
+++ b/docs/rendering.md
@@ -276,6 +276,18 @@ Measured drift before the fix, at a 120-column terminal pixel-doubled: an enemy 
 
 Two overlaps are deliberate. A wounded attacker's HP digit targets the same cell; the telegraph paints later, so the `!` wins during the windup and the digit resumes after - the windup is the more urgent read. And a point-blank attacker's mark can land on HUD row 1 or 2, which is better than hiding the cue on the enemy about to hit you.
 
+## Overlay coverage
+
+`tests/io/render-cache-test.phel` pins the QUIET frame - nothing picked up, nothing attacking, no hints - so each overlay was covered only by its own unit test and nothing pinned them together, which is where the interactions live: paint order, the row-3 clip against the minimap panel, two overlays reaching for the same cell.
+
+`tests/io/overlay-golden-test.phel` pins a frame with all of them at once, and names each in its own assertion so a broken hash says WHICH one went missing rather than just "something moved". The scene mirrors `tools/shots/showcase.phel`, so when a hash does move you can look at the picture:
+
+```bash
+tools/frame-shot.sh tools/shots/showcase.phel /tmp/showcase.png
+```
+
+It was mutation-checked: disabling the telegraph, the message line or the hint strip each fails it.
+
 ## First-run key hints (issue #467)
 
 One dim, steady line along the bottom of the viewport for the first fifteen seconds of level 1: `WASD move   mouse / arrows look   SPACE fire   F use   TAB help`. A first-time player landed in L1 with no reminder of the controls at all - the help panel exists but has to be discovered, and the objective splash says what to do, never how.

--- a/tests/io/overlay-golden-test.phel
+++ b/tests/io/overlay-golden-test.phel
@@ -1,0 +1,78 @@
+(ns phel-doom-tests.io.overlay-golden-test
+  (:require phel.test :refer [deftest is])
+  (:require phel.string :as str)
+  (:require phel-doom-tests.io.render-fixtures :refer [world stats])
+  (:require phel-doom.core.enemy :refer [new-enemy])
+  (:require phel-doom.io.render.main :refer [frame->string]))
+
+;; ---------------------------------------------------------------------
+;; The OVERLAY frame: message line, first-run hints, an enemy mid-windup
+;; (attack pose + its `!`), a hostile reticle and the full HUD strip, all
+;; in one frame.
+;;
+;; render-cache-test pins the quiet default frame - no message, no hints,
+;; no attacking enemy - so every overlay shipped in this batch was covered
+;; only by its own unit test. Nothing pinned them TOGETHER, which is where
+;; the interactions live: paint order, the row-3 clip against the minimap,
+;; two overlays reaching for the same cell.
+;;
+;; The scene mirrors tools/shots/showcase.phel, which is the picture you
+;; look at when a hash below moves and you want to see what changed.
+;; ---------------------------------------------------------------------
+
+(def overlay-world
+  (assoc world
+         :show-map true
+         ;; Dead ahead of the fixture player (11.5, 13.5 facing 5.847 rad),
+         ;; so the enemy is in frame, unobstructed and under the centre
+         ;; reticle - which is what makes the telegraph and the hostile
+         ;; tint both fire.
+         :enemies [(assoc (new-enemy 14.67 12.02 3 :caco) :state :attacking)]))
+
+(def overlay-stats
+  (merge stats
+         {:msg-text "Picked up the BLUE keycard." :msg-secs 1.4
+          :hint-secs 9.0
+          :hostile? true
+          :held-keys #{:blue :red}
+          :backpack-level 2
+          :difficulty :nightmare
+          :run-timer? true
+          :stamina 55.0 :max-stamina 100.0}))
+
+(deftest test-overlay-frame-bytes-pinned
+  ;; Update DELIBERATELY, and look at the frame before you do:
+  ;;   tools/frame-shot.sh tools/shots/showcase.phel /tmp/showcase.png
+  (is (= "fe4c446d8f13ef61586800e729b82144"
+         (php/md5 (frame->string overlay-world overlay-stats 120 30))))
+  ;; Same inputs twice: a hash that drifts run to run is worse than none.
+  (is (= (php/md5 (frame->string overlay-world overlay-stats 120 30))
+         (php/md5 (frame->string overlay-world overlay-stats 120 30)))))
+
+(deftest test-every-overlay-is-actually-in-the-frame
+  ;; The hash says "something changed"; these say WHICH thing went missing.
+  (let [f (frame->string overlay-world overlay-stats 120 30)]
+    (is (str/contains? f "Picked up the BLUE keycard.") "message line (#456)")
+    (is (str/contains? f "WASD move") "first-run hints (#467)")
+    (is (str/contains? f "m!\e[0m") "attack telegraph (#457)")
+    (is (str/contains? f "\e[91;1m+") "hostile reticle (#458)")
+    (is (str/contains? f "+pack x2") "HUD strip chips (#466)")
+    (is (str/contains? f "MAP") "minimap panel")))
+
+(deftest test-the-overlays-stay-out-of-each-others-cells
+  ;; Row 3 carries the message line AND the minimap's first content row;
+  ;; #466 clips the HUD strip at the panel's left margin for the same
+  ;; reason. If either regresses, the panel border loses cells.
+  (let [f    (frame->string overlay-world overlay-stats 120 30)
+        rows (php/explode "\n" f)]
+    (is (php/> (php/count rows) 3))
+    ;; The message must not run into the panel: the minimap's left border
+    ;; glyph still has to appear on its own rows.
+    (is (str/contains? f "│") "minimap panel borders survive the overlays")))
+
+(deftest test-a-quiet-frame-is-untouched-by-all-of-this
+  ;; The same fixture with nothing happening still matches the default
+  ;; golden in render-cache-test, so none of these overlays costs a byte
+  ;; when there is nothing to say.
+  (is (= "453c4baf9062da97bed130cc89623807"
+         (php/md5 (frame->string world stats 120 30)))))


### PR DESCRIPTION
## 📚 Description

`render-cache-test` pins the **quiet** frame - nothing picked up, nothing attacking, no hints. Every overlay in this batch was covered by its own unit test, and nothing pinned them **together** - which is where the interactions live: paint order, the row-3 clip against the minimap panel, two overlays reaching for the same cell.

## 🔖 Changes

- `tests/io/overlay-golden-test.phel`: one frame carrying the message line, first-run hints, an enemy mid-windup (attack pose + `!`), the hostile reticle and the full HUD strip with keycards and difficulty.
- Each overlay gets its **own named assertion**, so a moved hash says which one went missing instead of just "something changed".
- Plus a determinism assertion (a hash that drifts run to run is worse than no hash) and a re-pin of the quiet frame, proving none of this costs a byte when idle.

## 🧪 Mutation-checked, not assumed

Disabling the telegraph, the message line, or the hint strip each fails the test - two assertions apiece. Tree restored and green afterwards.

## 🪤 What placing the enemy taught me

An arbitrary coordinate put it off the player's ray, where it rendered **no telegraph at all** - which read like a bug in the feature rather than in my test. It now sits deliberately on the ray from the fixture player (11.5, 13.5 at 5.847 rad), which is also what puts it under the centre reticle for the hostile tint. Noted in the test so the next person placing an enemy there does not repeat it.

The scene mirrors `tools/shots/showcase.phel`, so when a hash moves you can look at the picture instead of guessing.