### PR TITLE
perf: measure and document where the frame time actually goes

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -23,6 +23,7 @@ composer bench        # frame/cast benchmarks (tests/bench, phel bench)
 composer bench-store  # write .phel/bench-baseline.json (run on main)
 composer bench-ref    # compare against it, fail past +10% (same machine)
 tools/bench-ab.sh <ref> [pairs] [filter]  # interleaved A/B vs another ref (the reliable one)
+tools/bench-flags.sh [passes] [filter]    # where frame time goes, by render feature
 composer format       # auto-format hand-written .phel files
 composer format-check # dry-run, fails CI on drift
 composer format-all   # include the generated data files (rarely needed)

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -16,6 +16,29 @@ It alternates the two refs back to back, so each pair shares a thermal state, an
 
 Worked example: the twenty PRs between v0.17.0 and the release after it added eight per-frame overlays (message line, attack telegraph, hint strip, HUD glyph indirection, secret-wall texture offset, attack poses). Five interleaved pairs put the whole batch at **+0.5 to +0.7% frame time, two of three rows with mixed signs** - i.e. free, within the harness's resolution.
 
+## Where the frame time goes
+
+`tools/bench-flags.sh` answers this by benchmarking the frame with each render feature switched off, interleaving the configs so a warming laptop cannot fake a result:
+
+```sh
+tools/bench-flags.sh            # 2 passes, the frame-120 row
+tools/bench-flags.sh 3 frame-240
+```
+
+At 120x30 on the reference machine, with the cast at ~0.1 ms against a ~5.8 ms frame (so render is ~98% of it):
+
+| Feature removed | frame | share |
+|---|---|---|
+| baseline | 5.75 ms | - |
+| wall texture (`PHEL_DOOM_FLAT_WALLS=1`) | 3.39 ms | 41% |
+| floor cast (`PHEL_DOOM_FLAT_FLOOR=1`) | 4.79 ms | 17% |
+| sub-pixel sampling (`PHEL_DOOM_NO_SUBPIXEL=1`) | 4.87 ms | 15% |
+| texture filter ON (`PHEL_DOOM_TEXMIP=1`) | 5.80 ms | -1% |
+
+The shares overlap and do not sum: the floor flag is subsumed by the wall flag (there is no point casting a floor texture with textures off), and sub-pixel sampling is what makes texture sampling expensive in the first place. What the table is for is ranking: **the wall texture is the single biggest line in the frame**, so a 10% win there beats deleting the floor cast outright, and any optimisation aimed elsewhere is competing for a fifth of the budget at best.
+
+One trap the script exists to prevent. Setting the flags by hand with `env $vars cmd` is silently wrong in zsh, which does not word-split an unquoted variable: `env "A=1 B=1" cmd` sets ONE variable named `A` to the string `"1 B=1"`. Every flag here is checked with `=== "1"`, so both read as off, the run measures the DEFAULT frame, and the number looks entirely plausible. That produced a phantom "disabling two features is 68% slower than disabling one" - which reads like a branch-selection bug in the renderer and is nothing of the sort. The script passes each config as a real assignment prefix and refuses to run if a self-check shows the shell mangling it.
+
 ## The bench harness itself
 
 `tests/bench/frame-bench.phel` is the tracked harness: `defbench` rows (phel

--- a/tools/README.md
+++ b/tools/README.md
@@ -38,6 +38,10 @@ composer test   # data files load + game logic still green
 
 Then smoke-test visually with the `/play` skill.
 
+## Benchmarking
+
+`bench-ab.sh` compares two git refs; `bench-flags.sh` compares render features within one ref, by measuring the frame with each switched off. Both interleave their configs, because a single reading drifts more than most changes are worth. See [performance.md](../docs/performance.md) for the current split - the wall texture is ~40% of the frame.
+
 ## Build guards
 
 Each is a `composer` script wired into `composer ci`, and each ships its own fixtures (`*-test.sh`) because a guard that is quietly wrong is worse than no guard.

--- a/tools/bench-flags.sh
+++ b/tools/bench-flags.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+# Attribute frame cost to the render features, by benchmarking the frame with
+# each one switched off.
+#
+# "Render is the bottleneck" has been true here for a long time; WHICH PART of
+# render was never written down, and every attempt to find out re-derived the
+# same shell juggling. It is worth knowing: the wall texture is ~40% of the
+# frame, so a 10% win there is worth more than eliminating the floor entirely.
+#
+# Two things this gets right that the obvious one-liner does not:
+#
+#   1. Interleaving. Absolute ms drifts badly as the laptop warms - the same
+#      commit read 5.9 ms and 7.5 ms an hour apart in one session. Shares are
+#      computed WITHIN a pass, where every config shares a thermal state, and
+#      then averaged.
+#
+#   2. Environment. `env $vars cmd` looks obvious and is silently wrong in zsh,
+#      which does not word-split an unquoted variable: `env "A=1 B=1" cmd` sets
+#      ONE variable named A to the string "1 B=1". Every flag check here is
+#      `=== "1"`, so both flags read as off, the run measures the DEFAULT frame,
+#      and the number looks plausible. That produced a phantom "disabling two
+#      features is 68% slower than disabling one" before this script existed.
+#      Flags are passed as an explicit prefix per config, and the self-check
+#      below proves both arrive.
+#
+# Usage:
+#   tools/bench-flags.sh [passes] [filter]
+#   tools/bench-flags.sh            # 2 passes, frame-120x30
+#   tools/bench-flags.sh 3 frame-240
+set -uo pipefail
+
+cd "$(cd "$(dirname "$0")/.." && pwd)" || exit 2
+
+passes="${1:-2}"
+filter="${2:-frame-120}"
+
+# name|VAR=1 ... : the baseline must come first, everything is relative to it.
+configs=(
+  "baseline|"
+  "flat walls (no wall texture)|PHEL_DOOM_FLAT_WALLS=1"
+  "flat floor (no floor cast)|PHEL_DOOM_FLAT_FLOOR=1"
+  "no sub-pixel (one colour per cell)|PHEL_DOOM_NO_SUBPIXEL=1"
+  "texture filter on (mips)|PHEL_DOOM_TEXMIP=1"
+)
+
+# Self-check: prove a two-variable prefix really arrives as two variables. If
+# this shell mangles it, every number below would be measuring the default
+# frame while claiming otherwise.
+probe="$(PHEL_DOOM_FLAT_WALLS=1 PHEL_DOOM_FLAT_FLOOR=1 \
+  php -r 'echo getenv("PHEL_DOOM_FLAT_WALLS"), ",", getenv("PHEL_DOOM_FLAT_FLOOR");')"
+if [ "$probe" != "1,1" ]; then
+  echo "bench-flags: this shell mangles the env prefix (got '$probe', want '1,1')."
+  echo "Every measurement would silently be the default frame. Refusing to run."
+  exit 2
+fi
+
+bench_us() { # -> microseconds, or empty when the filter matched nothing
+  PHEL_DOOM_SILENT=1 vendor/bin/phel bench --filter="$filter" 2>/dev/null |
+    awk 'NR>1 && NF>=4 {print $4; exit}' |
+    python3 -c '
+import re,sys
+v=sys.stdin.read().strip()
+m=re.match(r"([\d.]+)\s*(ms|μs|us|ns)", v)
+if not m: raise SystemExit
+n=float(m.group(1)); u=m.group(2)
+print(n*1000 if u=="ms" else n/1000 if u=="ns" else n)
+'
+}
+
+echo "bench-flags: $passes interleaved passes, filter '$filter'"
+
+results=""
+for p in $(seq 1 "$passes"); do
+  for cfg in "${configs[@]}"; do
+    name="${cfg%%|*}"
+    vars="${cfg#*|}"
+    if [ -z "$vars" ]; then
+      us="$(bench_us)"
+    else
+      # One prefix, expanded by the shell as assignments - never through `env`
+      # with an interpolated string. `set -- $vars` splits on IFS in bash AND
+      # zsh, unlike a bare `$vars` expansion.
+      # shellcheck disable=SC2086
+      us="$(set -- $vars; export "$@"; bench_us)"
+    fi
+    [ -z "$us" ] && { echo "bench-flags: filter '$filter' matched no benchmark."; exit 2; }
+    results="${results}${p}|${name}|${us}"$'\n'
+  done
+  echo "  pass $p done"
+done
+
+printf '%s' "$results" | python3 -c '
+import sys, collections
+rows = [l.split("|") for l in sys.stdin.read().splitlines() if l.strip()]
+per_pass = collections.defaultdict(dict)
+order = []
+for p, name, us in rows:
+    per_pass[p][name] = float(us)
+    if name not in order:
+        order.append(name)
+base_name = order[0]
+
+print()
+print("%-38s%10s%14s%17s" % ("config", "mean", "vs baseline", "share of frame"))
+for name in order:
+    vals = [per_pass[p][name] for p in per_pass if name in per_pass[p]]
+    mean = sum(vals) / len(vals)
+    if name == base_name:
+        print("%-38s%9.3fms%14s%17s" % (name, mean / 1000, "-", "-"))
+        continue
+    # Share is computed per pass, then averaged: a pass shares a thermal state,
+    # the run as a whole does not.
+    shares = [(per_pass[p][base_name] - per_pass[p][name]) / per_pass[p][base_name] * 100
+              for p in per_pass if name in per_pass[p]]
+    share = sum(shares) / len(shares)
+    delta = [(per_pass[p][name] - per_pass[p][base_name]) / 1000 for p in per_pass if name in per_pass[p]]
+    print(f"{name:<38}{mean/1000:>9.3f}ms{sum(delta)/len(delta):>+13.3f}ms{share:>16.1f}%")
+print()
+print("Share = how much of the frame that feature costs, measured by removing it.")
+print("They overlap and do not sum: the floor flag is subsumed by the wall flag")
+print("(no point casting a floor texture with textures off), and sub-pixel")
+print("sampling is what makes the texture sampling expensive in the first place.")
+print("A positive share is a cost removed; a negative one is a feature that pays")
+print("for itself (the texture filter samples smaller mips on far walls).")
+'


### PR DESCRIPTION
## 📚 Description

"Render is the bottleneck" has been true here for a long time; *which part* of render was never written down, so every attempt to find out re-derived the same shell juggling.

At 120x30 on the reference machine, cast is ~0.1 ms of a ~5.8 ms frame:

| Feature removed | frame | share |
|---|---|---|
| baseline | 5.75 ms | - |
| wall texture | 3.39 ms | 41% |
| floor cast | 4.79 ms | 17% |
| sub-pixel sampling | 4.87 ms | 15% |
| texture filter ON | 5.80 ms | -1% (free, as claimed) |

Shares overlap and do not sum, but the ranking is the point: the wall texture is the single biggest line in the frame, so a 10% win there beats deleting the floor cast outright.

## 🔖 Changes

- `tools/bench-flags.sh`: benchmarks the frame with each render feature switched off, interleaving configs so a warming laptop cannot fake a result (shares computed within a pass, then averaged).
- It refuses to run if a self-check shows the shell mangling its env prefix. `env $vars cmd` is silently wrong in zsh, which does not word-split an unquoted variable: `env "A=1 B=1" cmd` sets ONE variable named `A` to `"1 B=1"`. Every flag is checked with `=== "1"`, so both read as off and the run measures the default frame. That produced a phantom "disabling two features is 68% slower than disabling one" - which reads like a branch-selection bug in the renderer and is nothing of the sort.
- `docs/performance.md` gains a "Where the frame time goes" section with the table and the trap; `docs/contributing.md` and `tools/README.md` list the script.