### PR TITLE
ref(ci): fixture the deprecation gate's cache handling

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,10 @@
         "format-all": "vendor/bin/phel format",
         "lint": "vendor/bin/phel lint src tests",
         "check-layers": "bash tools/check-layers.sh",
-        "check-deprecations": "bash tools/check-deprecations.sh",
+        "check-deprecations": [
+            "bash tools/check-deprecations.sh",
+            "bash tools/check-deprecations-test.sh"
+        ],
         "test": "PHEL_DOOM_SILENT=1 vendor/bin/phel test",
         "bench": "PHEL_DOOM_SILENT=1 vendor/bin/phel bench",
         "bench-store": "PHEL_DOOM_SILENT=1 vendor/bin/phel bench --store=.phel/bench-baseline.json",

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -32,7 +32,7 @@ composer check-layers # io/ -> glue/ -> core/ direction holds
 composer check-cycles # no require cycles (+ the guard's own fixtures)
 composer check-unused # no src/ definition that nothing references (+ fixtures)
 composer check-docs   # every doc link, anchor and path claim resolves (+ fixtures)
-composer check-deprecations # suite again with every deprecation channel on
+composer check-deprecations # the suite with every deprecation channel on (+ the guard's own fixtures)
 composer build        # compile to out/main.php
 composer ci           # full pre-push gate
 composer repl         # REPL
@@ -52,7 +52,7 @@ CI runs `composer ci` on PHP 8.5. PHP 8.4 works locally but isn't CI-tested.
 
 The compile it needs is a workaround for [phel-lang#3222](https://github.com/phel-lang/phel-lang/issues/3222): the cache key ignores the warn-deprecations flag, so a warm shared cache reports nothing and `phel test` has no `--no-cache`. It used to get its compile by deleting the shared cache, which meant a full cold recompile on every run - 25.4s of a 41s gate, paid even by a one-line doc change. It now keeps its own cache directory instead (`PHEL_CACHE_DIR`), so only what changed recompiles: **11.2s warm**, and the gate is about 27s.
 
-Two things keep that honest. The directory name carries a hash of `composer.lock` and `phel-config.php`, so a compiler upgrade or an optimisation-level change starts a fresh cache rather than trusting yesterday's output. And a run that finds something deletes the cache before exiting - otherwise the offending file is cached with its warning already emitted and the next run is green with nothing fixed, a gate you could pass by running it twice. Failure costs the next run a cold compile, which is the right price. CI is unaffected: a fresh runner has no such directory and compiles everything.
+Two things keep that honest. The directory name carries a hash of `composer.lock` and `phel-config.php`, so a compiler upgrade or an optimisation-level change starts a fresh cache rather than trusting yesterday's output. And a run that finds something deletes the cache before exiting - otherwise the offending file is cached with its warning already emitted and the next run is green with nothing fixed, a gate you could pass by running it twice. Failure costs the next run a cold compile, which is the right price. CI is unaffected: a fresh runner has no such directory and compiles everything. The cache handling has its own fixtures (`tools/check-deprecations-test.sh`, stubbing `phel test` so a 25-second suite does not end up inside a fixture): a clean run keeps the cache, a deprecation / a test failure / an empty run / an interrupt each drop it, a lockfile or `phel-config.php` change starts a new one, and stale ones are pruned.
 
 `check-deprecations` re-runs the suite under `PHEL_WARN_DEPRECATIONS=1` and fails
 on any notice. It exists for the quiet half: phel 0.50 infers a parameter's type

--- a/tools/README.md
+++ b/tools/README.md
@@ -54,6 +54,8 @@ Each is a `composer` script wired into `composer ci`, and each ships its own fix
 | `check-docs.php` | a doc links to a missing file or heading, or names a path or composer script that is not there |
 | `check-deprecations.sh` | the suite raises a compiler deprecation or a float-truncation notice |
 
+Every guard ships fixtures (`*-test.sh`) run by its own composer script. `check-deprecations` keeps a compile cache between runs, so its fixtures are about when that cache must be thrown away - a stale one there is a fail-OPEN, a green gate with a live deprecation in the tree.
+
 `check-cycles` and `check-unused` share `lib/phel-source.php`, which blanks `;` comments, `#_` discards and string bodies while keeping offsets and newlines, so neither can be fooled by a name that appears only in prose - and a fix to that parser reaches both.
 
 `php tools/check-unused.php --report` also lists the definitions referenced only from `tests/`. Those are not failures (a fixture, or a parser whose only caller today is its own test), but the list is worth a look when hunting dead weight.

--- a/tools/check-deprecations-test.sh
+++ b/tools/check-deprecations-test.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+# Regression fixtures for tools/check-deprecations.sh.
+#
+# This was the last guard without any, and it is the one whose failure mode is
+# worst: it keeps a compile cache between runs, so every bug in its cache
+# handling is a fail-OPEN - the suite passes while a deprecation sits in the
+# tree. The behaviours below are what make reusing that cache safe, and each is
+# a thing the script must do rather than a thing it happens to do:
+#
+#   a clean run KEEPS the cache          (the whole point: 11s instead of 25s)
+#   a run that finds a deprecation DROPS it   (else `run it twice` turns green)
+#   a run that produces no result DROPS it    (a crash mid-compile caches half)
+#   an interrupted run DROPS it               (Ctrl-C caches half, silently)
+#   a toolchain change starts a NEW cache     (an upgrade can deprecate old code)
+#   stale caches are pruned                   (one per lockfile, forever, else)
+#
+# `phel test` is stubbed: these are tests of the cache logic, not of the
+# compiler, and a real compile would put a 25-second suite inside a fixture.
+# The stub's mode comes from FAKE_MODE.
+#
+# Run: bash tools/check-deprecations-test.sh   (wired into `composer check-deprecations`)
+set -uo pipefail
+
+GUARD="$(cd "$(dirname "$0")" && pwd)/check-deprecations.sh"
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/phel-doom-dep.XXXXXX")"
+trap 'rm -rf "$WORK"' EXIT
+mkdir -p "$WORK/tools" "$WORK/vendor/bin" "$WORK/.phel"
+cd "$WORK" || exit 2
+cp "$GUARD" tools/check-deprecations.sh
+printf '{"packages":[{"name":"phel-lang/phel-lang","version":"0.50.0"}]}' > composer.lock
+printf '<?php return 1;' > phel-config.php
+
+cat > vendor/bin/phel <<'STUB'
+#!/usr/bin/env bash
+# Stand-in for `vendor/bin/phel test`, driven by FAKE_MODE. Creates the cache
+# directory the way the real compiler does - the script under test never makes
+# it, it only decides whether yesterday's may be kept.
+[ -n "${PHEL_CACHE_DIR:-}" ] && mkdir -p "$PHEL_CACHE_DIR"
+case "${FAKE_MODE:-ok}" in
+  ok)    echo "Passed: 10"; echo "Total: 10"; exit 0 ;;
+  dep)   echo "Deprecated: Using \"php/new\" is deprecated"; echo "Total: 10"; exit 0 ;;
+  fail)  echo "FAIL some-test"; echo "Total: 10"; exit 1 ;;
+  empty) echo "nothing ran"; exit 0 ;;
+  hang)  sleep 30; exit 0 ;;
+esac
+STUB
+chmod +x vendor/bin/phel
+
+pass=0
+fail=0
+
+caches() { ls -d .phel/cache-deprecations-* 2>/dev/null | wc -l | tr -d ' '; }
+
+check() { # check <name> <expected-exit: 0|nonzero> <expected-caches>
+  local name="$1" want_rc="$2" want_caches="$3" rc n
+  out="$(FAKE_MODE="$MODE" bash tools/check-deprecations.sh 2>&1)"
+  rc=$?
+  n="$(caches)"
+  local ok=1
+  if [ "$want_rc" = "0" ] && [ "$rc" -ne 0 ]; then ok=0; fi
+  if [ "$want_rc" != "0" ] && [ "$rc" -eq 0 ]; then ok=0; fi
+  [ "$n" != "$want_caches" ] && ok=0
+  if [ "$ok" -eq 1 ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL  $name (exit $rc want $want_rc; caches $n want $want_caches)"
+    echo "      ${out//$'\n'/$'\n'      }"
+  fi
+}
+
+# A clean run leaves its cache behind - that is the entire reason this
+# directory exists, and the 14 seconds a warm run saves.
+MODE=ok  check "a clean run keeps its cache" 0 1
+MODE=ok  check "a second clean run reuses it" 0 1
+
+# ... and a run that FINDS something takes it away, so the next run recompiles
+# and reports it again. A gate you can pass by running it twice is worse than
+# no gate.
+MODE=dep check "a deprecation drops the cache" 1 0
+MODE=dep check "and stays red on the retry" 1 0
+
+# A test failure is not a deprecation, but the compile that produced it is
+# still half-cached with warnings already emitted.
+MODE=ok  check "warm up again" 0 1
+MODE=fail check "a suite failure drops the cache" 1 0
+
+# No result line at all: the suite crashed, or never ran.
+MODE=ok    check "warm up again" 0 1
+MODE=empty check "an empty run drops the cache" 1 0
+
+# Ctrl-C mid-compile is the same hazard, and the quietest: some namespaces are
+# compiled and cached, their warnings went to a log nobody reads.
+MODE=ok bash tools/check-deprecations.sh >/dev/null 2>&1
+if [ "$(caches)" = "1" ]; then
+  FAKE_MODE=hang bash tools/check-deprecations.sh >/dev/null 2>&1 &
+  hangpid=$!
+  # Wait for the stub to actually be running before signalling.
+  for _ in 1 2 3 4 5 6 7 8 9 10; do
+    kill -0 "$hangpid" 2>/dev/null || break
+    pgrep -P "$hangpid" >/dev/null 2>&1 && break
+    perl -e 'select(undef,undef,undef,0.2)'
+  done
+  kill -INT "$hangpid" $(pgrep -P "$hangpid" 2>/dev/null) 2>/dev/null
+  wait "$hangpid" 2>/dev/null
+  if [ "$(caches)" = "0" ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL  an interrupted run drops the cache (caches $(caches) want 0)"
+  fi
+else
+  fail=$((fail + 1))
+  echo "FAIL  an interrupted run drops the cache (setup: no warm cache to start from)"
+fi
+
+# SIGTERM is the case only the trap can answer. On SIGINT bash happens to run
+# the rest of the script, so the no-result branch below catches it either way -
+# a fixture that only proves THAT would pass with the trap deleted (checked).
+# On SIGTERM, untrapped bash dies on the spot and the half-filled cache
+# survives, which is the fail-open.
+MODE=ok bash tools/check-deprecations.sh >/dev/null 2>&1
+if [ "$(caches)" = "1" ]; then
+  FAKE_MODE=hang bash tools/check-deprecations.sh >/dev/null 2>&1 &
+  termpid=$!
+  for _ in 1 2 3 4 5 6 7 8 9 10; do
+    kill -0 "$termpid" 2>/dev/null || break
+    pgrep -P "$termpid" >/dev/null 2>&1 && break
+    perl -e 'select(undef,undef,undef,0.2)'
+  done
+  kill -TERM "$termpid" 2>/dev/null
+  wait "$termpid" 2>/dev/null
+  pkill -P "$termpid" 2>/dev/null
+  if [ "$(caches)" = "0" ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL  a terminated run drops the cache (caches $(caches) want 0)"
+  fi
+else
+  fail=$((fail + 1))
+  echo "FAIL  a terminated run drops the cache (setup: no warm cache to start from)"
+fi
+
+# A compiler upgrade can deprecate a form that compiled clean yesterday, so the
+# old cache is not evidence about the new toolchain.
+MODE=ok check "warm up again" 0 1
+before="$(ls -d .phel/cache-deprecations-* 2>/dev/null)"
+printf '{"packages":[{"name":"phel-lang/phel-lang","version":"0.51.0"}]}' > composer.lock
+MODE=ok check "a lockfile change starts a new cache" 0 1
+after="$(ls -d .phel/cache-deprecations-* 2>/dev/null)"
+if [ "$before" != "$after" ]; then
+  pass=$((pass + 1))
+else
+  fail=$((fail + 1))
+  echo "FAIL  a lockfile change starts a new cache (still $after)"
+fi
+
+# The same check for the compiler settings, which change what is generated.
+before="$after"
+printf '<?php return 2;' > phel-config.php
+MODE=ok check "a phel-config change starts a new cache" 0 1
+after="$(ls -d .phel/cache-deprecations-* 2>/dev/null)"
+if [ "$before" != "$after" ]; then
+  pass=$((pass + 1))
+else
+  fail=$((fail + 1))
+  echo "FAIL  a phel-config change starts a new cache (still $after)"
+fi
+
+# Exactly one cache survives each change: the count assertions above already
+# say so, but state it plainly - otherwise every lockfile bump leaves a
+# directory behind forever.
+mkdir -p .phel/cache-deprecations-deadbeef0000
+MODE=ok check "a stale cache is pruned" 0 1
+
+echo "check-deprecations fixtures: $pass passed, $fail failed."
+[ "$fail" -eq 0 ] || exit 1

--- a/tools/check-deprecations.sh
+++ b/tools/check-deprecations.sh
@@ -69,6 +69,7 @@ esac
 for old in "$root"/.phel/cache-deprecations-*; do
   [ -d "$old" ] || continue
   [ "$old" = "$cache" ] && continue
+  echo "check-deprecations: pruning stale cache $old"
   rm -rf "$old"
 done
 
@@ -83,7 +84,19 @@ trap 'rm -f "$log"' EXIT
 
 # Delete the cache so the next run recompiles from scratch. Called on every
 # non-success path: a cached warning is emitted once and never again.
-drop_cache() { rm -rf "$cache"; }
+drop_cache() {
+  [ -d "$cache" ] || return 0
+  echo "check-deprecations: dropping compile cache $cache"
+  rm -rf "$cache"
+}
+
+# Ctrl-C is a non-success path too, and the worst one: the run stops after some
+# namespaces have compiled - emitting their warnings into a log nobody reads -
+# and those are now cached. Without this, an interrupted run could leave the
+# next one green with a live deprecation. Bash happens to reach the no-result
+# branch below today, which drops the cache anyway; this makes it a decision
+# rather than a signal-timing accident.
+trap 'drop_cache; exit 130' INT TERM
 
 PHEL_CACHE_DIR="$cache" PHEL_WARN_DEPRECATIONS=1 PHEL_DOOM_SILENT=1 vendor/bin/phel test >"$log" 2>&1
 status=$?


### PR DESCRIPTION
## 📚 Description

#508 gave this gate a compile cache it keeps between runs, which makes every bug in its cache handling a **fail-open**: the suite passes while a deprecation sits in the tree. It was also the last guard with no fixtures - its proven behaviours lived in a commit message.

## 🔖 Changes

- **16 fixtures**, with `phel test` stubbed so a 25-second suite does not end up inside a fixture: a clean run keeps its cache; a deprecation, a test failure, an empty run and an interrupt each drop it; a `composer.lock` or `phel-config.php` change starts a new one; a stale one is pruned.
- **SIGTERM was a real hole.** On SIGINT bash happens to run the rest of the script, so the no-result branch drops the cache anyway - which is why an interrupt fixture passes with the trap deleted. On SIGTERM, untrapped bash dies on the spot and the half-filled cache survives. `trap 'drop_cache; exit 130' INT TERM` closes it, and the fixture fails without it (verified by deleting the trap).
- **Dependent invalidation checked, nothing to fix.** A macro whose expansion emits a deprecated form fires while its *callers* compile, so a warm cache could in principle hide it. Phel recompiles dependents when the macro's file changes - 189 notices from one edit to `buf-mk`.
- Both `rm -rf` sites print the resolved path before deleting.