### PR TITLE
test(bench): measure the loop's step phase, which nothing ever had

### DIFF
--- a/docs/performance.md
+++ b/docs/performance.md
@@ -16,6 +16,21 @@ It alternates the two refs back to back, so each pair shares a thermal state, an
 
 Worked example: the twenty PRs between v0.17.0 and the release after it added eight per-frame overlays (message line, attack telegraph, hint strip, HUD glyph indirection, secret-wall texture offset, attack poses). Five interleaved pairs put the whole batch at **+0.5 to +0.7% frame time, two of three rows with mixed signs** - i.e. free, within the harness's resolution.
 
+## The loop's three phases
+
+`input -> step -> cast -> render`. Cast and render have had rows in the bench for a long time; the step - `commands/play` `tick-world`, the pure state transition - had none, so every performance claim in this project was about the two ends of a three-part loop. At 120x30 on the reference machine:
+
+| phase | cost | share |
+|---|---|---|
+| cast (`cast-frame`) | 0.083 ms | 2% |
+| step, quiet frame (`tick-world`) | 0.75 ms | 15% |
+| step, firing frame | 1.49 ms | 26% |
+| render (`frame->string`) | 4.28 ms | 83% / 74% |
+
+Render still dominates, but the step is not the rounding error it was assumed to be: a frame in which the player is shooting spends a quarter of its budget before the renderer starts. Roughly half of that is the shot resolution itself - with no enemies in the world at all, firing still costs ~0.9 ms, which is the wall hitscan.
+
+There are deliberately **two** step rows. Every bench rev starts from the same world, so a row that passes `:fire true` re-resolves a shot on every rev - the weapon cooldown never advances - and reports the firing cost as though it were a normal frame; a row that never fires misses the most expensive thing the step does. Quoting either one alone is how a 2x difference gets written down as a fact.
+
 ## Where the frame time goes
 
 `tools/bench-flags.sh` answers this by benchmarking the frame with each render feature switched off, interleaving the configs so a warming laptop cannot fake a result:

--- a/tests/bench/frame-bench.phel
+++ b/tests/bench/frame-bench.phel
@@ -20,6 +20,7 @@
 ;; deftest here - the suite discovers zero tests and moves on.
 (ns phel-doom-tests.bench.frame-bench
   (:require phel.bench :refer [defbench])
+  (:require phel-doom.commands.play :refer [tick-world])
   (:require phel-doom.core.rng :as rng)
   (:require phel-doom.core.level :refer [build-world])
   (:require phel-doom.core.enemy :refer [new-enemy])
@@ -87,6 +88,31 @@
 (defbench cast-240
   {:revs 100}
   (cast-frame (:world @scene) 240 1))
+
+;; --- one pure state transition (commands/play tick-world) ---
+;; The loop is input -> step -> cast -> render, and the middle phase had
+;; no row here at all: every perf claim in this project was about the two
+;; ends of it. It is not small - a quiet frame is ~1.1 ms against a
+;; ~4.2 ms render at 120x30.
+;;
+;; TWO rows, because one would mislead either way. Every call starts from
+;; the same world, so a bench that passes `:fire true` re-resolves a shot
+;; on every single rev - the cooldown never advances - and reports 2.4 ms
+;; as if that were a normal frame. A bench that never fires misses the
+;; most expensive thing the step does. Walking is in both: physics,
+;; pickups, enemy AI and the timers all run either way.
+
+(defbench step-120
+  {:revs 200}
+  (tick-world (:world @scene) "w" 0.016
+              {:fire false :toggle-map false :toggle-pause false
+               :toggle-sound false :about-face false}))
+
+(defbench step-fire-120
+  {:revs 200}
+  (tick-world (:world @scene) "w" 0.016
+              {:fire true :toggle-map false :toggle-pause false
+               :toggle-sound false :about-face false}))
 
 ;; --- full frame: cast + render to the ANSI string, no terminal write ---
 ;; A frame is milliseconds, so a handful of revs already amortises the


### PR DESCRIPTION
## 📚 Description

The loop is `input -> step -> cast -> render`. Cast and render have had bench rows for a long time; `tick-world`, the pure state transition, had none - so every performance claim in this project was about the two ends of a three-part loop.

At 120x30 on the reference machine:

| phase | cost | share |
|---|---|---|
| cast (`cast-frame`) | 0.083 ms | 2% |
| step, quiet frame (`tick-world`) | 0.75 ms | 15% |
| step, firing frame | 1.49 ms | 26% |
| render (`frame->string`) | 4.28 ms | 83% / 74% |

Render still dominates, but the step is not the rounding error it was assumed to be: a frame where the player is shooting spends a quarter of its budget before the renderer starts. About half of that is the shot itself - with no enemies in the world at all, firing still costs ~0.9 ms, which is the wall hitscan.

## 🔖 Changes

- Two step rows, and the reason is the point: every rev starts from the same world, so a row passing `:fire true` re-resolves a shot on **every** rev - the cooldown never advances - and reports 1.49 ms as if it were a normal frame. A row that never fires misses the most expensive thing the step does. The first version of this had only the firing row, and 1.49 ms was about to be written down as "the step phase".
- `docs/performance.md` gains the phase table and that caveat.

No optimisation here on purpose: the row comes first, then the work.