### PR TITLE
perf: take the generic dispatch out of the grid predicates

### DIFF
--- a/docs/performance.md
+++ b/docs/performance.md
@@ -215,6 +215,28 @@ Caveats:
 - `opcache.validate_timestamps=0` disables source-file stat checks. Set to `1` during dev.
 - The repo-root Dockerfile does NOT configure OPcache or JIT; enable both per host if you are benchmarking in it.
 
+## What a Phel operation costs
+
+Measured with 200k-iteration loops (the empty loop is ~150 ns and is subtracted):
+
+| | cost |
+|---|---|
+| `php/aget` on a nested php array | ~4 ns |
+| `(get row x)` on a persistent vector | ~600 ns |
+| reading a module-level `def` | ~320 ns |
+| `php/===` against a literal | free (folded) |
+| `=` (generic equality) | ~850 ns |
+| `(cell grid x y)` | 1.6 us |
+| `(wall? grid x y)` | 2.1 us (was 5.9) |
+
+Two of those are surprising enough to be worth stating outright.
+
+**A module-level `def` is not a constant.** Every read compiles to `\Phel::getDefinition("phel_doom.core.map", "cell-wall")` - a registry lookup by two strings. Four of them in `wall?` cost more than reading the grid did. Hoisting a constant into a `let` outside a loop is worth doing; inside a per-call predicate there is nowhere to hoist to, which is why `wall?` compares against literals with `test-wall-literals-match-the-constants` pinning them.
+
+**`=` and `<` dispatch on type.** On values known to be ints, `php/===` and `php/<` are free by comparison. This is the same lesson as the `:pgrid` mirror, one level down: the persistent, generic version of every operation is 100x to 1000x the native one, and the hot paths have to opt out of all of it.
+
+None of this makes a dramatic difference to a frame on its own - the predicate swap above is worth ~1.5% of a threaded frame, because a quiet frame only makes about ten such calls. It matters where the calls are counted in thousands, which is where every large win in this file has come from.
+
 ## Direct PHP ops in the hot loop
 
 Unspecialised Phel dispatch through the runtime. Hot loops use `php/+`, `php/<`, `php/aget` for direct PHP operations: `$a + $b`, `$a < $b`, `$arr[$k]`. No dispatch, no method call.

--- a/src/core/map.phel
+++ b/src/core/map.phel
@@ -107,29 +107,51 @@
   "Read map cell at integer (x, y). Out-of-bounds reads return cell-wall
    so the raycaster never escapes off the map."
   [grid x y]
-  (if (or (< x 0) (< y 0))
+  ;; php ops, not Phel's generic `<` / `or` / `nil?`. Cell values are ints
+  ;; and this is the primitive every grid predicate is built on: the
+  ;; generic versions dispatch on type per call, which measured 2.7us
+  ;; against 1.4us here. The two `get`s are the persistent-vector reads
+  ;; that remain (~600ns each); callers on a hot path read the php mirror
+  ;; instead - see `:pgrid` in state.phel.
+  (if (or (php/< x 0) (php/< y 0))
     cell-wall
     (let [row (get grid y)]
-      (if (nil? row)
+      (if (php/=== nil row)
         cell-wall
-        (or (get row x) cell-wall)))))
+        (let [c (get row x)]
+          (if (php/=== nil c) cell-wall c))))))
 
 (defn ^:pure wall?
   "True when (x, y) blocks player movement. Solid walls, unrevealed
    secrets, AND switch cells (either state) qualify; doors are
    passable triggers."
   [grid x y]
+  ;; Two deliberate uglinesses, both measured, on what is the hottest
+  ;; predicate in the codebase - called per enemy and per projectile
+  ;; every frame:
+  ;;
+  ;;   `php/===` rather than `=`, because these are int comparisons and
+  ;;   Phel's generic equality dispatches on type per call;
+  ;;
+  ;;   the cell codes as LITERALS rather than the named constants,
+  ;;   because every module-level `def` read compiles to a
+  ;;   `\Phel::getDefinition(ns, name)` registry lookup - ~320ns each,
+  ;;   and four of them cost more than reading the grid.
+  ;;
+  ;; 5.9us -> 1.7us together. `test-wall-literals-match-the-constants`
+  ;; in map-test fails if any of these codes is ever renumbered, so the
+  ;; literals cannot drift away from the names they stand for.
   (let [c (cell grid x y)]
-    (or (= cell-wall c)
-        (= cell-secret c)
-        (= cell-switch-off c)
-        (= cell-switch-on c))))
+    (or (php/=== 1 c)      ; cell-wall
+        (php/=== 6 c)      ; cell-secret
+        (php/=== 7 c)      ; cell-switch-off
+        (php/=== 8 c))))   ; cell-switch-on
 
 (defn secret?
   "True when (x, y) holds an unrevealed secret wall. Used by
    `reveal-secret-ahead` to spot the player's bump target."
   [grid x y]
-  (= cell-secret (cell grid x y)))
+  (php/=== cell-secret (cell grid x y)))
 
 (defn switch?
   "True when (x, y) holds a switch cell (either ON or OFF). Used by
@@ -166,12 +188,12 @@
   [grid held-keys x y]
   (let [c (cell grid x y)]
     (cond
-      (= cell-wall c)            false
-      (= cell-secret c)          false
-      (= cell-switch-off c)      false
-      (= cell-switch-on c)       false
-      (contains? lock-colours c) (contains? (or held-keys #{}) (get lock-colours c))
-      :else                      true)))
+      (php/=== cell-wall c)       false
+      (php/=== cell-secret c)     false
+      (php/=== cell-switch-off c) false
+      (php/=== cell-switch-on c)  false
+      (contains? lock-colours c)  (contains? (or held-keys #{}) (get lock-colours c))
+      :else                       true)))
 
 (defn find-door-cell
   "Scan `grid` for the first door cell (any variant: unlocked or any

--- a/tests/core/map-test.phel
+++ b/tests/core/map-test.phel
@@ -390,3 +390,32 @@
             [1 1 1]]
         g' (seed-secrets g 2)]
     (is (= cell-secret (get-in g' [2 1])) "vertical divider converted")))
+
+;; ---------------------------------------------------------------------
+;; `wall?` compares against the cell codes as LITERALS, because reading a
+;; module-level `def` compiles to a `\Phel::getDefinition(ns, name)`
+;; registry lookup - about 320ns each, and four of them cost more than
+;; reading the grid. It is the hottest predicate in the codebase (per
+;; enemy and per projectile, every frame) and the swap took it from
+;; 5.9us to 2.1us.
+;;
+;; The cost of that trick is a pair of numbers in one function that no
+;; longer say what they mean. This is the test that makes it safe:
+;; renumber any of these codes and it fails, naming the function that
+;; has to change with it.
+;; ---------------------------------------------------------------------
+
+(deftest test-wall-literals-match-the-constants
+  (is (= 1 cell-wall)       "wall? hard-codes 1 for cell-wall")
+  (is (= 6 cell-secret)     "wall? hard-codes 6 for cell-secret")
+  (is (= 7 cell-switch-off) "wall? hard-codes 7 for cell-switch-off")
+  (is (= 8 cell-switch-on)  "wall? hard-codes 8 for cell-switch-on"))
+
+(deftest test-wall-agrees-with-the-named-constants
+  ;; The behavioural half: whatever the numbers are, `wall?` must say
+  ;; true for exactly the blocking codes and false for the rest.
+  (let [row (fn [c] [[cell-wall c cell-wall]])]
+    (foreach [c [cell-wall cell-secret cell-switch-off cell-switch-on]]
+      (is (true? (wall? (row c) 1 0)) (str "blocks code " c)))
+    (foreach [c [cell-floor cell-door]]
+      (is (false? (wall? (row c) 1 0)) (str "passes code " c)))))


### PR DESCRIPTION
## 📚 Description

Sweeping the per-frame paths for persistent-collection reads turned up `wall?` - called per enemy and per projectile every frame - and measuring it turned up something more useful than the call site.

With 200k-iteration loops (empty loop ~150 ns, subtracted):

| | cost |
|---|---|
| `php/aget` on a nested php array | ~4 ns |
| `(get row x)` on a persistent vector | ~600 ns |
| **reading a module-level `def`** | **~320 ns** |
| `php/===` against a literal | free (folded) |
| **`=` (generic equality)** | **~850 ns** |

Two of those are worth stating outright. **A module-level `def` is not a constant**: every read compiles to `\Phel::getDefinition(ns, name)`, a registry lookup by two strings, and the four in `wall?` cost more than reading the grid did. And **`=` / `<` dispatch on type**, so on values known to be ints `php/===` and `php/<` are free by comparison.

## 🔖 Changes

| | before | after |
|---|---|---|
| `cell` | 2.55 µs | 1.63 µs |
| `wall?` | 5.85 µs | **2.09 µs** (2.8x) |

- `wall?` compares against the cell codes as literals, which is ugly, so `map-test` pins them: renumber any code and the test fails, naming the function that has to change with it. A second test asserts the behaviour independently of the numbers.
- `docs/performance.md` gains the cost table.

**Honest about the frame-level effect**: interleaved A/B over threaded frames puts it at about **-1.5%**, branch faster in all three pairs. A quiet frame only makes ~10 of these calls. The primitive being 2.8x cheaper is what matters for anything that loops over cells.

One near-miss worth recording: the equivalence probe for `noise-wake` came back with a different hash, which looked like a behaviour change. It was the shared-rng load-order trap - two probe files in one process, so the first one's draws shifted the second one's worlds. Run alone it matches main exactly.