### PR TITLE
perf: chain the per-frame assocs instead of passing many keys at once

### DIFF
--- a/docs/performance.md
+++ b/docs/performance.md
@@ -228,10 +228,15 @@ Measured with 200k-iteration loops (the empty loop is ~150 ns and is subtracted)
 | `=` (generic equality) | ~850 ns |
 | `(cell grid x y)` | 1.6 us |
 | `(wall? grid x y)` | 2.1 us (was 5.9) |
+| `(assoc m :a 1)` on a 12-key map | ~0.9 us |
+| `(assoc m :a 1 :b 2)` on a 12-key map | ~5.0 us |
+| `(assoc (assoc m :a 1) :b 2)` | ~1.9 us |
 
 Two of those are surprising enough to be worth stating outright.
 
 **A module-level `def` is not a constant.** Every read compiles to `\Phel::getDefinition("phel_doom.core.map", "cell-wall")` - a registry lookup by two strings. Four of them in `wall?` cost more than reading the grid did. Hoisting a constant into a `let` outside a loop is worth doing; inside a per-call predicate there is nowhere to hoist to, which is why `wall?` compares against literals with `test-wall-literals-match-the-constants` pinning them.
+
+**A multi-key `assoc` is slower than chaining single-key ones.** Not slightly - on a 12-key map, two keys cost 5.0 us against 1.9 us chained, three keys 8.2 us against 2.9 us. The variadic path does something per extra pair that a plain write does not. Worth stating because the intuition runs the other way: `observe` in `enemy_ai.phel` carried a docstring explicitly claiming the single multi-key write was the cheap version. The per-frame call sites are chained now, worth ~1.5% of a frame with 16 enemies, measured interleaved.
 
 **`=` and `<` dispatch on type.** On values known to be ints, `php/===` and `php/<` are free by comparison. This is the same lesson as the `:pgrid` mirror, one level down: the persistent, generic version of every operation is 100x to 1000x the native one, and the hot paths have to opt out of all of it.
 

--- a/src/core/enemy_ai.phel
+++ b/src/core/enemy_ai.phel
@@ -241,10 +241,11 @@
    is what :hunting walks toward — that's how a player can break
    contact by ducking around a corner.
 
-   Pure: returns the updated enemy as a single multi-key assoc so the
-   per-frame allocation cost on big enemy vectors stays at one map
-   write instead of two. Caller threads the result back into the
-   enemies vector."
+   Pure: returns the updated enemy. The two writes are CHAINED rather
+   than a single multi-key `assoc`, which reads like the wasteful
+   version and is not: Phel's variadic assoc costs ~5.2us for two keys
+   against ~2.0us for two chained single-key writes, measured on a
+   12-key map. This docstring used to claim the opposite."
   [enemy pgrid ^float px ^float py]
   (let [sees?  (sees-player? pgrid (:x enemy) (:y enemy) px py)
         ;; Refresh lkp only while LOS is clear. Without LOS the
@@ -252,7 +253,7 @@
         ;; here' breadcrumb the hunter is following.
         lkp'   (if sees? {:x px :y py} (:lkp enemy))
         state' (next-state enemy sees?)]
-    (assoc enemy :state state' :lkp lkp')))
+    (assoc (assoc enemy :state state') :lkp lkp')))
 
 (defn apply-pain
   "Maybe stagger an enemy. Pre-rolled `roll` is a uniform 0..1 float
@@ -473,23 +474,26 @@
       (let [w  (:attack-windup-secs enemy)
             w' (php/- w dt)]
         (if (php/<= w' 0.0)
-          (assoc enemy
-                 :state                :aware
-                 :attack-windup-secs   0.0
-                 ;; Depth-scaled: deeper levels stamp a smaller
-                 ;; :aggression so the cooldown between strikes shrinks.
-                 ;; Windup (the telegraph) is left at the per-type value
-                 ;; so the warning stays honest.
-                 :attack-cooldown-secs (php/* (:cooldown (attack-spec-of enemy))
-                                              (or (:aggression enemy) 1.0))
-                 ;; Casters release a projectile on windup-expiry. The
-                 ;; spawn pass (core/projectile) harvests this flag,
-                 ;; aims a bolt at the player, then clears it. Melee
-                 ;; enemies leave it false — their hit already landed
-                 ;; via the contact test during the windup window.
-                 :fire-now             (caster? enemy))
-          (assoc enemy
-                 :attack-windup-secs   w'
+          ;; Chained single-key writes: Phel's variadic assoc is ~2.9x the
+          ;; cost of chaining for three keys, and worse as they multiply.
+          (assoc
+           (assoc
+            (assoc
+             (assoc enemy :state :aware)
+             :attack-windup-secs 0.0)
+             ;; Depth-scaled: deeper levels stamp a smaller
+             ;; :aggression so the cooldown between strikes shrinks.
+             ;; Windup (the telegraph) is left at the per-type value
+             ;; so the warning stays honest.
+            :attack-cooldown-secs (php/* (:cooldown (attack-spec-of enemy))
+                                         (or (:aggression enemy) 1.0)))
+           ;; Casters release a projectile on windup-expiry. The
+           ;; spawn pass (core/projectile) harvests this flag,
+           ;; aims a bolt at the player, then clears it. Melee
+           ;; enemies leave it false — their hit already landed
+           ;; via the contact test during the windup window.
+           :fire-now (caster? enemy))
+          (assoc (assoc enemy :attack-windup-secs w')
                  :attack-cooldown-secs cd')))
       (assoc enemy :attack-cooldown-secs cd'))))
 
@@ -551,8 +555,8 @@
    new information."
   [enemy ^float ox ^float oy]
   (case (state-of enemy)
-    :dormant (assoc enemy :state :hunting :lkp {:x ox :y oy})
-    :wander  (assoc enemy :state :hunting :lkp {:x ox :y oy})
+    :dormant (assoc (assoc enemy :state :hunting) :lkp {:x ox :y oy})
+    :wander  (assoc (assoc enemy :state :hunting) :lkp {:x ox :y oy})
     :hunting (assoc enemy :lkp {:x ox :y oy})
     enemy))
 

--- a/src/core/physics.phel
+++ b/src/core/physics.phel
@@ -374,7 +374,9 @@
   [world ^float dt]
   (let [interval (heartbeat-interval (:lives world))]
     (if (nil? interval)
-      (assoc world :heartbeat-phase 0.0 :heartbeat-tick? false)
+      ;; Chained: Phel's variadic assoc costs ~2.7x two chained
+      ;; single-key writes, and this runs every frame.
+      (assoc (assoc world :heartbeat-phase 0.0) :heartbeat-tick? false)
       (let [phase (php/+ (or (:heartbeat-phase world) 0.0)
                          (php// dt interval))
             wrap? (php/>= phase 1.0)]


### PR DESCRIPTION
## 📚 Description

Chasing what the per-enemy tick spends its 110 µs on turned up a primitive that behaves backwards from the intuition. On a 12-key map:

| | cost |
|---|---|
| `(assoc m :a 1)` | ~0.9 µs |
| `(assoc m :a 1 :b 2)` | ~5.0 µs |
| `(assoc (assoc m :a 1) :b 2)` | **~1.9 µs** |
| `(assoc m :a 1 :b 2 :c 3)` | ~8.2 µs |
| chained ×3 | **~2.9 µs** |

A multi-key `assoc` is **2.7× the cost** of writing the same keys one at a time, and it gets worse per pair.

`observe` in `enemy_ai.phel` carried a docstring stating the opposite outright - *"a single multi-key assoc so the per-frame allocation cost stays at one map write instead of two"* - so the code had been deliberately steered into the slow form. That docstring is corrected rather than deleted, since the claim is the kind that gets re-invented.

## 🔖 Changes

- Chained at the per-frame and per-shot call sites: `observe`, `tick-attack` (two branches, one of them five keys), `wake-by-noise`, the physics heartbeat.
- `docs/performance.md` gains the numbers.

**Honest number**: interleaved A/B over threaded frames, **-1.1% with 4 enemies and -1.5% with 16**, branch faster in both pairs at both counts. Small - the finding is worth more than the change, since anything writing several keys in a loop is paying 2-3× for it.

**Also tried and reverted**: skipping the cooldown and hit-flash writes when the value had not moved. It measured *slower* in both pairs, twice - the writes are not actually redundant in a live scene, and the extra comparison is not free. Recorded in the commit so it is not retried.